### PR TITLE
Looker - FIX/get query error

### DIFF
--- a/google-datacatalog-looker-connector/setup.py
+++ b/google-datacatalog-looker-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-looker-connector',
-    version='0.5.0',
+    version='0.5.1',
     author='Google LLC',
     description='Package for ingesting Looker metadata'
     ' into Google Cloud Data Catalog',

--- a/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
+++ b/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
@@ -321,17 +321,18 @@ class MetadataSynchronizer:
 
     def __scrape_query(self, query_id):
         query = self.__metadata_scraper.scrape_query(query_id)
-        generated_sql = \
-            self.__metadata_scraper.scrape_query_generated_sql(query_id)
 
         model_explore = None
         connection = None
+        generated_sql = None
 
         try:
             model_explore = self.__metadata_scraper\
                 .scrape_lookml_model_explore(query.model, query.view)
             connection = self.__metadata_scraper.scrape_connection(
                 model_explore.connection_name)
+            generated_sql = \
+                self.__metadata_scraper.scrape_query_generated_sql(query_id)
         except error.SDKError:
             pass
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Added logic to handle `error.SDKError` on `scrape_query_generated_sql`, some Looker instances may have queries not pointing to their generated_sql. So we need to handle the `error.SDKError`, if it does not exist, the generated_sql will be ignored.

**- How I did it**
Added `scrape_query_generated_sql ` to `error.SDKError` try/except handler.

**- How to verify it**
Run the connector on a Looker instance with inconsistent query information.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added logic to handle `error.SDKError` on `scrape_query_generated_sql`.

Fixes #17 