### PR TITLE
UPDATE system-tests connectors path 

### DIFF
--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -78,4 +78,4 @@ steps:
   args: ['-c',
          "docker tag gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/looker2datacatalog:$(cat _TAG)"]
 images: ['gcr.io/$PROJECT_ID/looker2datacatalog']
-timeout: 900s
+timeout: 3600s

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -50,8 +50,7 @@ steps:
   args:
   - -c
   - 'pip install google-cloud-datacatalog &&
-     /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'
- System_tests disabled: b/152768468     
+     /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'   
 - name: 'gcr.io/cloud-builders/docker'
   id: 'SYSTEM_TESTS'
   args: ['run',

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -60,8 +60,7 @@ steps:
          '/workspace:/data',
          'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
          '--datacatalog-project-id=${_LOOKER2DC_DATACATALOG_PROJECT_ID}',
-         '--looker-credentials-file=/data/looker.ini']
-  timeout: 600s       
+         '--looker-credentials-file=/data/looker.ini']     
 - name: 'docker.io/library/python:3.7'
   id: 'ASSERT_RESULTS'
   entrypoint: 'bash'

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -51,9 +51,7 @@ steps:
   - -c
   - 'pip install google-cloud-datacatalog &&
      /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'   
-  # Ignore step if it takes more than 10 minutes.
-  # this will have enough metadata to validate the results. 
-  - name: 'gcr.io/cloud-builders/docker'
+- name: 'gcr.io/cloud-builders/docker'
   id: 'SYSTEM_TESTS'
   args: ['run',
          '--rm',

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -22,8 +22,7 @@ steps:
   args: ['build',
          '-t',
          'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
-         '.']
-
+         '/workspace/google-datacatalog-looker-connector/.']
   # Create a custom tag and write to file /workspace/_TAG
 - name: 'alpine'
   id: 'SETUP_TAG'
@@ -32,13 +31,52 @@ steps:
          "echo `echo $BRANCH_NAME |
           sed 's,/,-,g' |
           awk '{print tolower($0)}'`_$(date -u +%Y%m%dT%H%M)_$SHORT_SHA > _TAG; echo $(cat _TAG)"]
-
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: 'PREPARE_SERVICE_ACCOUNT'
+  args: ['cp',
+         'gs://connectors_build_env/looker2dc-datacatalog-credentials.json',
+         '.']
+- name: 'gcr.io/cloud-builders/gsutil'
+  id: 'PREPARE_LOOKER_CREDENTIALS'
+  args: ['cp',
+         'gs://connectors_build_env/looker.ini',
+         '.']         
+- name: 'docker.io/library/python:3.7'
+  id: 'PREPARE_ENV'
+  entrypoint: 'bash'
+  env:
+  - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/looker2dc-datacatalog-credentials.json'
+  - 'LOOKER2DC_DATACATALOG_PROJECT_ID=${_LOOKER2DC_DATACATALOG_PROJECT_ID}'
+  args:
+  - -c
+  - 'pip install google-cloud-datacatalog &&
+     /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'
+ System_tests disabled: b/152768468     
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'SYSTEM_TESTS'
+  args: ['run',
+         '--rm',
+         '--tty',
+         '-v',
+         '/workspace:/data',
+         'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
+         '--datacatalog-project-id=${_LOOKER2DC_DATACATALOG_PROJECT_ID}',
+         '--looker-credentials-file=/workspace/looker.ini']
+- name: 'docker.io/library/python:3.7'
+  id: 'ASSERT_RESULTS'
+  entrypoint: 'bash'
+  env:
+  - 'GOOGLE_APPLICATION_CREDENTIALS=/workspace/looker2dc-datacatalog-credentials.json'
+  - 'LOOKER2DC_DATACATALOG_PROJECT_ID=${_LOOKER2DC_DATACATALOG_PROJECT_ID}'
+  args:
+  - -c
+  - 'pip install google-cloud-datacatalog &&
+     /workspace/google-datacatalog-looker-connector/system_tests/assert.sh'
   # Tag image with the custom tag
 - name: 'gcr.io/cloud-builders/docker'
   id: 'TAG_IMAGE'
   entrypoint: '/bin/bash'
   args: ['-c',
          "docker tag gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/looker2datacatalog:$(cat _TAG)"]
-
 images: ['gcr.io/$PROJECT_ID/looker2datacatalog']
 timeout: 900s

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -51,7 +51,9 @@ steps:
   - -c
   - 'pip install google-cloud-datacatalog &&
      /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'   
-- name: 'gcr.io/cloud-builders/docker'
+  # Ignore step if it takes more than 10 minutes.
+  # this will have enough metadata to validate the results 
+  - name: 'gcr.io/cloud-builders/docker'
   id: 'SYSTEM_TESTS'
   args: ['run',
          '--rm',
@@ -60,7 +62,9 @@ steps:
          '/workspace:/data',
          'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
          '--datacatalog-project-id=${_LOOKER2DC_DATACATALOG_PROJECT_ID}',
-         '--looker-credentials-file=/data/looker.ini']
+         '--looker-credentials-file=/data/looker.ini',
+         '||', 'true']
+  timeout: 600s       
 - name: 'docker.io/library/python:3.7'
   id: 'ASSERT_RESULTS'
   entrypoint: 'bash'

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -60,7 +60,7 @@ steps:
          '/workspace:/data',
          'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
          '--datacatalog-project-id=${_LOOKER2DC_DATACATALOG_PROJECT_ID}',
-         '--looker-credentials-file=/workspace/looker.ini']
+         '--looker-credentials-file=/data/looker.ini']
 - name: 'docker.io/library/python:3.7'
   id: 'ASSERT_RESULTS'
   entrypoint: 'bash'

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
   - 'pip install google-cloud-datacatalog &&
      /workspace/google-datacatalog-looker-connector/system_tests/cleanup.sh'   
   # Ignore step if it takes more than 10 minutes.
-  # this will have enough metadata to validate the results 
+  # this will have enough metadata to validate the results. 
   - name: 'gcr.io/cloud-builders/docker'
   id: 'SYSTEM_TESTS'
   args: ['run',
@@ -62,8 +62,7 @@ steps:
          '/workspace:/data',
          'gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA',
          '--datacatalog-project-id=${_LOOKER2DC_DATACATALOG_PROJECT_ID}',
-         '--looker-credentials-file=/data/looker.ini',
-         '||', 'true']
+         '--looker-credentials-file=/data/looker.ini']
   timeout: 600s       
 - name: 'docker.io/library/python:3.7'
   id: 'ASSERT_RESULTS'

--- a/google-datacatalog-looker-connector/system_tests/assert.sh
+++ b/google-datacatalog-looker-connector/system_tests/assert.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-datacatalog-looker-connector/system_tests/assert.sh
+++ b/google-datacatalog-looker-connector/system_tests/assert.sh
@@ -17,4 +17,4 @@
 # Sleep 5 seconds to wait for search index
 sleep 5
 echo 'Assert INGESTION'
-python google-datacatalog-tableau-connector/system_tests/execution_results_test.py
+python google-datacatalog-looker-connector/system_tests/execution_results_test.py

--- a/google-datacatalog-looker-connector/system_tests/cleanup.sh
+++ b/google-datacatalog-looker-connector/system_tests/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 #
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-datacatalog-looker-connector/system_tests/cleanup.sh
+++ b/google-datacatalog-looker-connector/system_tests/cleanup.sh
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo 'Execute CLEANUP'
+python google-datacatalog-looker-connector/tools/cleanup_datacatalog.py --datacatalog-project-ids $LOOKER2DC_DATACATALOG_PROJECT_ID
+
 # Sleep 5 seconds to wait for search index
 sleep 5
-echo 'Assert INGESTION'
-python google-datacatalog-tableau-connector/system_tests/execution_results_test.py
+echo 'Assert CLEANUP'
+python google-datacatalog-looker-connector/system_tests/cleanup_results_test.py

--- a/google-datacatalog-looker-connector/system_tests/cleanup_results_test.py
+++ b/google-datacatalog-looker-connector/system_tests/cleanup_results_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import types
+
+datacatalog = datacatalog.DataCatalogClient()
+
+
+class CleanupResultsTest(unittest.TestCase):
+
+    def test_looker_entries_should_not_exist_after_cleanup(self):
+        query = 'system=looker'
+
+        scope = types.SearchCatalogRequest.Scope()
+        scope.include_project_ids.append(
+            os.environ['LOOKER2DC_DATACATALOG_PROJECT_ID'])
+
+        search_results = [
+            result for result in datacatalog.search_catalog(
+                scope=scope, query=query, order_by='relevance', page_size=1000)
+        ]
+        self.assertEqual(len(search_results), 0)

--- a/google-datacatalog-looker-connector/system_tests/execution_results_test.py
+++ b/google-datacatalog-looker-connector/system_tests/execution_results_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import types
+
+datacatalog = datacatalog.DataCatalogClient()
+
+
+class ExecutionResultsTest(unittest.TestCase):
+
+    def test_looker_entries_should_exist_after_connector_execution(self):
+        query = 'system=tableau'
+
+        scope = types.SearchCatalogRequest.Scope()
+        scope.include_project_ids.append(
+            os.environ['LOOKER2DC_DATACATALOG_PROJECT_ID'])
+
+        search_results = [
+            result for result in datacatalog.search_catalog(
+                scope=scope, query=query, order_by='relevance', page_size=1000)
+        ]
+        self.assertGreater(len(search_results), 0)

--- a/google-datacatalog-looker-connector/tools/cleanup_datacatalog.py
+++ b/google-datacatalog-looker-connector/tools/cleanup_datacatalog.py
@@ -20,8 +20,6 @@ import re
 from google.cloud import datacatalog
 from google.cloud.datacatalog import types
 
-from google.datacatalog_connectors.looker.prepare import constant
-
 __DATACATALOG_LOCATION_ID = 'us-central1'
 
 __datacatalog = datacatalog.DataCatalogClient()
@@ -81,15 +79,15 @@ def __delete_tag_template(project_id, location_id, tag_template_id):
 
 def __delete_tag_templates(project_id, location_id):
     __delete_tag_template(
-        project_id, location_id, constant.TAG_TEMPLATE_ID_DASHBOARD)
+        project_id, location_id, 'looker_dashboard_metadata')
     __delete_tag_template(
-        project_id, location_id, constant.TAG_TEMPLATE_ID_DASHBOARD_ELEMENT)
+        project_id, location_id, 'looker_dashboard_element_metadata')
     __delete_tag_template(
-        project_id, location_id, constant.TAG_TEMPLATE_ID_FOLDER)
+        project_id, location_id, 'looker_folder_metadata')
     __delete_tag_template(
-        project_id, location_id, constant.TAG_TEMPLATE_ID_LOOK)
+        project_id, location_id, 'looker_look_metadata')
     __delete_tag_template(
-        project_id, location_id, constant.TAG_TEMPLATE_ID_QUERY)
+        project_id, location_id, 'looker_query_metadata')
 
 
 def __parse_args():

--- a/google-datacatalog-looker-connector/tools/cleanup_datacatalog.py
+++ b/google-datacatalog-looker-connector/tools/cleanup_datacatalog.py
@@ -20,7 +20,7 @@ import re
 from google.cloud import datacatalog
 from google.cloud.datacatalog import types
 
-from ciandt.google_cloud.looker2datacatalog.prepare import constant
+from google.datacatalog_connectors.looker.prepare import constant
 
 __DATACATALOG_LOCATION_ID = 'us-central1'
 

--- a/google-datacatalog-tableau-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-tableau-connector/cloudbuild.connector.yaml
@@ -20,7 +20,7 @@ steps:
   args: ['build',
          '-t',
          'gcr.io/$PROJECT_ID/tableau2datacatalog:$COMMIT_SHA',
-         '.']
+         '/workspace/google-datacatalog-tableau-connector/.']
   # Create custom image tag and write to file /workspace/_TAG
 - name: 'alpine'
   id: 'SETUP_TAG'
@@ -49,22 +49,22 @@ steps:
   args:
   - -c
   - 'pip install google-cloud-datacatalog &&
-     system_tests/cleanup.sh'
-# System_tests disabled: b/152768468     
-#- name: 'gcr.io/cloud-builders/docker'
-#  id: 'SYSTEM_TESTS'
-#  args: ['run',
-#         '--rm',
-#         '--tty',
-#         '-v',
-#         '/workspace:/data',
-#         'gcr.io/$PROJECT_ID/tableau2datacatalog:$COMMIT_SHA',
-#         '--datacatalog-project-id=${_TABLEAU2DC_DATACATALOG_PROJECT_ID}',
-#         '--tableau-server=${_TABLEAU2DC_TABLEAU_SERVER}',
-#         '--tableau-api-version=${_TABLEAU2DC_TABLEAU_API_VERSION}',
-#         '--tableau-username=${_TABLEAU2DC_TABLEAU_USERNAME}',
-#         '--tableau-password=${_TABLEAU2DC_TABLEAU_PASSWORD}',
-#         '--tableau-site=${_TABLEAU2DC_TABLEAU_SITE}']
+     /workspace/google-datacatalog-tableau-connector/system_tests/cleanup.sh'
+ System_tests disabled: b/152768468     
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'SYSTEM_TESTS'
+  args: ['run',
+         '--rm',
+         '--tty',
+         '-v',
+         '/workspace:/data',
+         'gcr.io/$PROJECT_ID/tableau2datacatalog:$COMMIT_SHA',
+         '--datacatalog-project-id=${_TABLEAU2DC_DATACATALOG_PROJECT_ID}',
+         '--tableau-server=${_TABLEAU2DC_TABLEAU_SERVER}',
+         '--tableau-api-version=${_TABLEAU2DC_TABLEAU_API_VERSION}',
+         '--tableau-username=${_TABLEAU2DC_TABLEAU_USERNAME}',
+         '--tableau-password=${_TABLEAU2DC_TABLEAU_PASSWORD}',
+         '--tableau-site=${_TABLEAU2DC_TABLEAU_SITE}']
 - name: 'docker.io/library/python:3.7'
   id: 'ASSERT_RESULTS'
   entrypoint: 'bash'
@@ -74,7 +74,7 @@ steps:
   args:
   - -c
   - 'pip install google-cloud-datacatalog &&
-     system_tests/assert.sh'
+     /workspace/google-datacatalog-tableau-connector/system_tests/assert.sh'
 - name: 'gcr.io/cloud-builders/docker'
   id: 'TAG_STABLE'
   entrypoint: '/bin/bash'

--- a/google-datacatalog-tableau-connector/cloudbuild.connector.yaml
+++ b/google-datacatalog-tableau-connector/cloudbuild.connector.yaml
@@ -49,8 +49,7 @@ steps:
   args:
   - -c
   - 'pip install google-cloud-datacatalog &&
-     /workspace/google-datacatalog-tableau-connector/system_tests/cleanup.sh'
- System_tests disabled: b/152768468     
+     /workspace/google-datacatalog-tableau-connector/system_tests/cleanup.sh' 
 - name: 'gcr.io/cloud-builders/docker'
   id: 'SYSTEM_TESTS'
   args: ['run',

--- a/google-datacatalog-tableau-connector/system_tests/cleanup.sh
+++ b/google-datacatalog-tableau-connector/system_tests/cleanup.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 echo 'Execute CLEANUP'
-python tools/cleanup_datacatalog.py --datacatalog-project-ids $TABLEAU2DC_DATACATALOG_PROJECT_ID
+python google-datacatalog-tableau-connector/tools/cleanup_datacatalog.py --datacatalog-project-ids $TABLEAU2DC_DATACATALOG_PROJECT_ID
 
 # Sleep 5 seconds to wait for search index
 sleep 5
 echo 'Assert CLEANUP'
-python system_tests/cleanup_results_test.py
+python google-datacatalog-tableau-connector/system_tests/cleanup_results_test.py


### PR DESCRIPTION
- What I did
Updated the system-tests directories path. Since we changed to a mono-repo, the system tests were disabled. Updating the new path so we can enable them.

- How I did it
Each connector uses its local directory to run system tests.

- How to verify it
Trigger system-tests.

- Description for the changelog

UPDATE system-tests connectors path.