### PR TITLE
Use BaseEntryFactory's id and display name formatters

### DIFF
--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/constant.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/constant.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ENTRY_ID_LENGTH = 64
 ENTRY_ID_PREFIX = 't__'
+NO_PREFIX_ENTRY_ID_LENGTH = ENTRY_ID_LENGTH - len(ENTRY_ID_PREFIX)
 
 USER_SPECIFIED_TYPE_DASHBOARD = 'dashboard'
 USER_SPECIFIED_TYPE_SHEET = 'sheet'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -20,10 +20,12 @@ import logging
 from google.cloud import datacatalog
 from google.cloud.datacatalog import types
 
+from google.datacatalog_connectors.commons.prepare.base_entry_factory import \
+    BaseEntryFactory
 from . import constant
 
 
-class DataCatalogEntryFactory:
+class DataCatalogEntryFactory(BaseEntryFactory):
     # Datetime format with timezone information
     __DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
 
@@ -47,7 +49,7 @@ class DataCatalogEntryFactory:
         entry.user_specified_system = self.__user_specified_system
         entry.user_specified_type = constant.USER_SPECIFIED_TYPE_DASHBOARD
 
-        entry.display_name = self.__format_display_name(
+        entry.display_name = self._format_display_name(
             dashboard_metadata.get('name'))
 
         path = dashboard_metadata.get('path')
@@ -90,7 +92,7 @@ class DataCatalogEntryFactory:
         entry.user_specified_system = self.__user_specified_system
         entry.user_specified_type = constant.USER_SPECIFIED_TYPE_SHEET
 
-        entry.display_name = self.__format_display_name(
+        entry.display_name = self._format_display_name(
             sheet_metadata.get('name'))
 
         # A null path that means the sheet was hidden and included on a
@@ -131,7 +133,7 @@ class DataCatalogEntryFactory:
         entry.user_specified_system = self.__user_specified_system
         entry.user_specified_type = constant.USER_SPECIFIED_TYPE_WORKBOOK
 
-        entry.display_name = self.__format_display_name(
+        entry.display_name = self._format_display_name(
             workbook_metadata.get('name'))
         entry.description = workbook_metadata.get('description')
 
@@ -157,14 +159,11 @@ class DataCatalogEntryFactory:
 
     @classmethod
     def __format_id(cls, source_id):
-        return f'{constant.ENTRY_ID_PREFIX}{source_id}'.replace('-', '_')
-
-    @classmethod
-    def __format_display_name(cls, source_name):
-        formatted_name = source_name.replace('&', '_')
-        formatted_name = formatted_name.replace(':', '_')
-        formatted_name = formatted_name.replace('/', '_')
-        return formatted_name
+        no_prefix_fmt_id = cls._format_id(source_id)
+        if len(no_prefix_fmt_id) > constant.NO_PREFIX_ENTRY_ID_LENGTH:
+            no_prefix_fmt_id = \
+                no_prefix_fmt_id[:constant.NO_PREFIX_ENTRY_ID_LENGTH]
+        return f'{constant.ENTRY_ID_PREFIX}{no_prefix_fmt_id}'
 
     @classmethod
     def __format_site_content_url(cls, workbook_metadata):

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
@@ -174,3 +174,29 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                                              datetime_format)
         self.assertEqual(updated_datetime.timestamp(),
                          entry.source_system_timestamps.update_time.seconds)
+
+    def test_make_entry_long_luid_should_limit_result_id_length(self):
+        metadata = {
+            'luid': '12345678901234567890123456789012'
+                    '34567890123456789012345678901234',
+            'name': 'Test Name',
+            'path': 'test/sheet',
+            'createdAt': '2019-09-12T16:30:00Z',
+            'updatedAt': '2019-09-12T16:30:55Z'
+        }
+
+        workbook_metadata = {'site': {'name': 'test-site'}}
+
+        entry = self.__factory.make_entry_for_sheet(metadata,
+                                                    workbook_metadata)
+
+        self.assertEqual(
+            't__1234567890123456789012345678901234567890123456789012345678901',
+            entry[0])
+
+        entry = entry[1]
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            't__1234567890123456789012345678901234567890123456789012345678901',
+            entry.name)


### PR DESCRIPTION
Closes #19 

**- What I did**
Started using `BaseEntryFactory`'s id and display name formatters.

**- How I did it**
Changed the `DataCatalogEntryFactory` class in order to make it child of `google.datacatalog_connectors.commons.prepare.base_entry_factory.BaseEntryFactory`. Then, called the parent class `_format_id()` and `_format_display_name()` methods.

**- How to verify it**
Run the automated and maybe manual tests.

**- Description for the changelog**
Use BaseEntryFactory's id and display name formatters