### PR TITLE
Improve the Looker sync stage output

### DIFF
--- a/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
+++ b/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
@@ -416,10 +416,21 @@ class MetadataSynchronizer:
         metadata_ingestor = ingest.DataCatalogMetadataIngestor(
             self.__project_id, self.__location_id, self.__ENTRY_GROUP_ID)
 
-        for assembled_entries_data in assembled_entries_dict.values():
-            metadata_ingestor.ingest_metadata(assembled_entries_data,
-                                              tag_templates_dict)
-
         entries_count = sum(
             len(entries) for entries in assembled_entries_dict.values())
-        logging.info('==== %s entries synchronized!', entries_count)
+        logging.info('==== %d entries to be synchronized!', entries_count)
+
+        synced_entries_count = 0
+        for folder_id, assembled_entries in assembled_entries_dict.items():
+            folder_entries_count = len(assembled_entries)
+
+            logging.info('')
+            logging.info('==== The Folder identified by %s has %d entries.',
+                         folder_id, folder_entries_count)
+            metadata_ingestor.ingest_metadata(assembled_entries,
+                                              tag_templates_dict)
+            synced_entries_count = synced_entries_count + folder_entries_count
+
+        logging.info('')
+        logging.info('==== %d of %d entries successfully synchronized!',
+                     synced_entries_count, entries_count)


### PR DESCRIPTION
**- What I did**
Added logs to make the Looker metadata sync process clearer.

**- How I did it**
Added counters and `log.info()` statements to `datacatalog_connectors/looker/sync/metadata_synchronizer.py`.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added logs to make the Looker metadata sync process clearer.
