### PR TITLE
Add elementary code to consume the Engine API

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -89,7 +89,6 @@ jobs:
       matrix:
         build-dir:
           [
-            "./google-datacatalog-qlik-connector",
             "./google-datacatalog-tableau-connector",
           ]
         python-version: [3.8]

--- a/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
+++ b/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/sync/metadata_synchronizer.py
@@ -59,12 +59,8 @@ class MetadataSynchronizer:
         api_url = config_parser['Looker']['base_url']
 
         parsed_uri = urlparse(api_url)
-        scheme = parsed_uri.scheme
 
-        # Strip the port number.
-        server_address = parsed_uri.netloc[:parsed_uri.netloc.find(':')]
-
-        return f'{scheme}://{server_address}'
+        return f'{parsed_uri.scheme}://{parsed_uri.hostname}'
 
     def run(self):
         """Coordinates a full scrape > prepare > ingest process."""

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -7,6 +7,9 @@ currently supporting below asset types:
 
 **Disclaimer: This is not an officially supported Google product.**
 
+> **WORK IN PROGRESS**: This connector is under active development and breaking
+> changes are expected in the coming weeks!
+
 <!--
   ⚠️ DO NOT UPDATE THE TABLE OF CONTENTS MANUALLY ️️⚠️
   run `npx markdown-toc -i README.md`.

--- a/google-datacatalog-qlik-connector/setup.cfg
+++ b/google-datacatalog-qlik-connector/setup.cfg
@@ -2,7 +2,7 @@
 test = pytest
 
 [tool:pytest]
-addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 95
+addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 90
 testpaths = tests
 
 [yapf]

--- a/google-datacatalog-qlik-connector/setup.cfg
+++ b/google-datacatalog-qlik-connector/setup.cfg
@@ -2,7 +2,7 @@
 test = pytest
 
 [tool:pytest]
-addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 90
+addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 95
 testpaths = tests
 
 [yapf]

--- a/google-datacatalog-qlik-connector/setup.cfg
+++ b/google-datacatalog-qlik-connector/setup.cfg
@@ -2,7 +2,7 @@
 test = pytest
 
 [tool:pytest]
-addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 89
+addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 90
 testpaths = tests
 
 [yapf]

--- a/google-datacatalog-qlik-connector/setup.cfg
+++ b/google-datacatalog-qlik-connector/setup.cfg
@@ -2,7 +2,7 @@
 test = pytest
 
 [tool:pytest]
-addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 90
+addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 89
 testpaths = tests
 
 [yapf]

--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
     install_requires=(
         'google-datacatalog-connectors-commons >= 0.6.0',
         'requests_ntlm',
+        'websockets',
     ),
     setup_requires=('pytest-runner',),
     tests_require=('pytest-cov',),

--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -50,7 +50,6 @@ setuptools.setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -38,9 +38,9 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
-        'google-datacatalog-connectors-commons >= 0.6.0',
-        'requests_ntlm',
-        'websockets',
+        'google-datacatalog-connectors-commons ~= 0.6',
+        'requests_ntlm ~= 1.1',
+        'websockets ~= 8.1',
     ),
     setup_requires=('pytest-runner',),
     tests_require=('pytest-cov',),

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -128,7 +128,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         units = ['bytes', 'KB', 'MB', 'GB']
         for unit in units:
             if size_val < 1024.0:
-                human_readable_space = f'{size_val} {unit}'
+                human_readable_space = f'{round(size_val, 2)} {unit}'
                 return human_readable_space
-            size_val = round(size_val / 1024.0, 2)
-        return f'{size_val} TB'
+            size_val = size_val / 1024.0
+        return f'{round(size_val, 2)} TB'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+
+from urllib.parse import urlparse
+import websockets
+
+from google.datacatalog_connectors.qlik.scrape import constants
+
+
+class EngineAPIHelper:
+    """Wraps requests to the Qlik Qlik Engine JSON API.
+
+    The Qlik Engine JSON API is a WebSocket protocol that uses JSON to pass
+    information between the Qlik associative engine and the clients. This API
+    consists of a set of objects representing apps, lists, and so on. These
+    objects are organized in a hierarchical structure.
+
+    Websockets use an asynchronous communication channel, but the public
+    methods from this class are intended to be called synchronously. They
+    take care of handling the async API calls for their clients.
+
+    """
+
+    def __init__(self, server_address):
+        self.__server_address = server_address
+        # The server address starts with an http/https scheme. The below
+        # statement replaces the original scheme with 'wss', which is used for
+        # secure websockets communication.
+        self.__base_api_endpoint = \
+            f'wss://{self.__extract_server_netloc(server_address)}'
+        self.__common_headers = {
+            constants.XRFKEY_HEADER_NAME: constants.XRFKEY,
+        }
+
+    @classmethod
+    def __extract_server_netloc(cls, server_address):
+        parsed_uri = urlparse(server_address)
+        netloc = parsed_uri.netloc
+        netloc_colon_index = netloc.find(':')
+
+        if netloc_colon_index > 0:
+            # Strip the port number.
+            return netloc[:netloc_colon_index]
+
+        return netloc
+
+    def get_sheets(self, app_id, auth_cookie):
+        """Get the list of Sheets that belong to a given App.
+
+        Returns:
+            A list of sheets.
+        """
+        return self.__run_async(self.__get_sheets(app_id, auth_cookie))
+
+    async def __get_sheets(self, app_id, auth_cookie):
+        websocket = await self.__connect_websocket(app_id, auth_cookie)
+        open_doc_return = await self.__open_doc(app_id, websocket)
+
+        await websocket.send(
+            json.dumps({
+                'handle': open_doc_return.get('qHandle'),
+                'method': 'GetObjects',
+                'params': {
+                    'qOptions': {
+                        'qTypes': ['sheet'],
+                    },
+                },
+            }))
+
+        async for message in websocket:
+            json_message = json.loads(message)
+            result = json_message.get('result')
+            if result:
+                return result.get('qList')
+
+    async def __connect_websocket(self, app_id, auth_cookie):
+        url = f'{self.__base_api_endpoint}/app/{app_id}' \
+              f'?Xrfkey={constants.XRFKEY}'
+
+        headers = self.__common_headers.copy()
+        # Format the header value as <key>=<value> string.
+        headers['Cookie'] = f'{auth_cookie.name}={auth_cookie.value}'
+
+        return await websockets.connect(url, extra_headers=headers)
+
+    @classmethod
+    async def __open_doc(cls, app_id, websocket):
+        """Open an App (aka Doc) to enable calling subsequent methods of it,
+        e.g. `GetObjects`.
+
+        Returns:
+            An [ObjectInterface](https://help.qlik.com/en-US/sense-developer/November2020/APIs/EngineAPI/definitions-ObjectInterface.html).  # noqa E501
+        """
+        await websocket.send(
+            json.dumps({
+                'handle': -1,
+                'method': 'OpenDoc',
+                'params': [app_id],
+            }))
+
+        async for message in websocket:
+            json_message = json.loads(message)
+            result = json_message.get('result')
+            if result:
+                return result.get('qReturn')
+
+    def get_windows_authentication_url(self):
+        return self.__run_async(self.__get_windows_authentication_url())
+
+    async def __get_windows_authentication_url(self):
+        """Get a Windows Authentication url.
+
+        This method sends an unauthenticated request to a well known endpoint
+        of the Qlik Engine JSON API. The expected response has a `loginUri`
+        param, which is the Windows Authentication url.
+
+        P.S. The endpoint was manually captured from the Engine API Explorer's
+        Execution Logs (https://<qlik-site>/dev-hub/engine-api-explorer).
+
+        Returns:
+            A string.
+        """
+        url = f'{self.__base_api_endpoint}/app/?transient=' \
+              f'?Xrfkey={constants.XRFKEY}' \
+              f'&reloadUri={self.__server_address}/dev-hub/engine-api-explorer'
+
+        # Sets the User-Agent to Windows temporarily to get a Windows
+        # Authentication URL that is required by the NTLM authentication flow.
+        headers = self.__common_headers.copy()
+        headers['User-Agent'] = constants.WINDOWS_USER_AGENT
+
+        websocket = await websockets.connect(url, extra_headers=headers)
+
+        async for message in websocket:
+            json_message = json.loads(message)
+            params = json_message.get('params')
+            if params:
+                return params.get('loginUri')
+
+    @classmethod
+    def __run_async(cls, method_call):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(method_call)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -140,20 +140,11 @@ class EngineAPIHelper:
         async with websockets.connect(uri=uri,
                                       extra_headers=headers) as websocket:
 
-            request_id = self.__generate_request_id()
-            await websocket.send(
-                json.dumps({
-                    'handle': -1,
-                    'method': 'GetDocList',
-                    'params': [],
-                    'id': request_id,
-                }))
-
             async for message in websocket:
                 json_message = json.loads(message)
-                response_id = json_message.get('id')
-                if request_id == response_id:
-                    return json_message.get('params').get('loginUri')
+                params = json_message.get('params')
+                if params:
+                    return params.get('loginUri')
 
     def __connect_websocket(self, app_id):
         """Open websocket connection.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -47,23 +47,10 @@ class EngineAPIHelper:
         # The server address starts with an http/https scheme. The below
         # statement replaces the original scheme with 'wss', which is used for
         # secure websockets communication.
-        self.__base_api_endpoint = \
-            f'wss://{self.__extract_server_netloc(server_address)}'
+        self.__base_api_endpoint = f'wss://{urlparse(server_address).hostname}'
         self.__common_headers = {
             constants.XRFKEY_HEADER_NAME: constants.XRFKEY,
         }
-
-    @classmethod
-    def __extract_server_netloc(cls, server_address):
-        parsed_uri = urlparse(server_address)
-        netloc = parsed_uri.netloc
-        netloc_colon_index = netloc.find(':')
-
-        if netloc_colon_index > 0:
-            # Strip the port number.
-            return netloc[:netloc_colon_index]
-
-        return netloc
 
     def get_sheets(self, app_id, auth_cookie):
         """Get the list of Sheets that belong to a given App.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -101,14 +101,14 @@ class EngineAPIHelper:
             An awaiting function that yields a :class:`WebSocketClientProtocol`
             which can then be used to send and receive messages.
         """
-        url = f'{self.__base_api_endpoint}/app/{app_id}' \
+        uri = f'{self.__base_api_endpoint}/app/{app_id}' \
               f'?Xrfkey={constants.XRFKEY}'
 
         headers = self.__common_headers.copy()
         # Format the header value as <key>=<value> string.
         headers['Cookie'] = f'{auth_cookie.name}={auth_cookie.value}'
 
-        return websockets.connect(url, extra_headers=headers)
+        return websockets.connect(uri=uri, extra_headers=headers)
 
     @classmethod
     async def __open_doc(cls, app_id, websocket):
@@ -150,7 +150,7 @@ class EngineAPIHelper:
         Returns:
             A string.
         """
-        url = f'{self.__base_api_endpoint}/app/?transient=' \
+        uri = f'{self.__base_api_endpoint}/app/?transient=' \
               f'?Xrfkey={constants.XRFKEY}' \
               f'&reloadUri={self.__server_address}/dev-hub/engine-api-explorer'
 
@@ -159,7 +159,8 @@ class EngineAPIHelper:
         headers = self.__common_headers.copy()
         headers['User-Agent'] = constants.WINDOWS_USER_AGENT
 
-        async with websockets.connect(url, extra_headers=headers) as websocket:
+        async with websockets.connect(uri=uri,
+                                      extra_headers=headers) as websocket:
             async for message in websocket:
                 json_message = json.loads(message)
                 params = json_message.get('params')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -25,7 +25,7 @@ from google.datacatalog_connectors.qlik.scrape import constants
 
 
 class EngineAPIHelper:
-    """Wraps requests to the Qlik Qlik Engine JSON API.
+    """Wraps requests to the Qlik Engine JSON API.
 
     The Qlik Engine JSON API is a WebSocket protocol that uses JSON to pass
     information between the Qlik associative engine and the clients. This API

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_helper.py
@@ -66,7 +66,8 @@ class EngineAPIHelper:
         Returns:
             A list of sheets.
         """
-        return self.__run_async(self.__get_sheets(app_id, auth_cookie))
+        return self.__run_until_complete(self.__get_sheets(
+            app_id, auth_cookie))
 
     async def __get_sheets(self, app_id, auth_cookie):
         websocket = await self.__connect_websocket(app_id, auth_cookie)
@@ -121,7 +122,8 @@ class EngineAPIHelper:
                 return result.get('qReturn')
 
     def get_windows_authentication_url(self):
-        return self.__run_async(self.__get_windows_authentication_url())
+        return self.__run_until_complete(
+            self.__get_windows_authentication_url())
 
     async def __get_windows_authentication_url(self):
         """Get a Windows Authentication url.
@@ -154,6 +156,6 @@ class EngineAPIHelper:
                 return params.get('loginUri')
 
     @classmethod
-    def __run_async(cls, method_call):
+    def __run_until_complete(cls, async_method_call):
         loop = asyncio.get_event_loop()
-        return loop.run_until_complete(method_call)
+        return loop.run_until_complete(async_method_call)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -81,8 +81,9 @@ class MetadataScraper:
     def scrape_sheets(self, app):
         self.__initialize_engine_api_auth_cookie()
         app_id = app.get('id')
-        return self.__engine_api_helper.get_sheets(
+        sheets = self.__engine_api_helper.get_sheets(
             app_id, self.__engine_api_auth_cookie)
+        return sheets if sheets else []
 
     def __initialize_engine_api_auth_cookie(self):
         if self.__engine_api_auth_cookie:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -47,18 +47,27 @@ class MetadataScraper:
             engine_api_helper.EngineAPIHelper(server_address)
 
         self.__qrs_api_session = None
-        self.__initialize_qrs_api_session()
-
         self.__engine_api_auth_cookie = None
-        self.__initialize_engine_api_auth_cookie()
+
+    def scrape_all_apps(self):
+        self.__initialize_qrs_api_session()
+        return self.__qrs_api_helper.get_full_app_list(self.__qrs_api_session)
+
+    def scrape_all_streams(self):
+        self.__initialize_qrs_api_session()
+        return self.__qrs_api_helper.get_full_stream_list(
+            self.__qrs_api_session)
 
     def __initialize_qrs_api_session(self):
+        if self.__qrs_api_session:
+            return
+
         self.__qrs_api_session = sessions.Session()
 
         windows_auth_url = \
             self.__qrs_api_helper.get_windows_authentication_url(
                 self.__qrs_api_session)
-        qps_session_cookie = authenticator.Authenticator\
+        qps_session_cookie = authenticator.Authenticator \
             .get_qps_session_cookie_windows_auth(
                 ad_domain=self.__ad_domain,
                 username=self.__username,
@@ -69,7 +78,16 @@ class MetadataScraper:
         logging.debug('QPS session cookie issued for the QRS API: %s',
                       qps_session_cookie)
 
+    def scrape_sheets(self, app):
+        self.__initialize_engine_api_auth_cookie()
+        app_id = app.get('id')
+        return self.__engine_api_helper.get_sheets(
+            app_id, self.__engine_api_auth_cookie)
+
     def __initialize_engine_api_auth_cookie(self):
+        if self.__engine_api_auth_cookie:
+            return
+
         windows_auth_url = \
             self.__engine_api_helper.get_windows_authentication_url()
         self.__engine_api_auth_cookie = authenticator.Authenticator\
@@ -80,15 +98,3 @@ class MetadataScraper:
                 auth_url=windows_auth_url)
         logging.debug('QPS session cookie issued for the Engine API: %s',
                       self.__engine_api_auth_cookie)
-
-    def scrape_all_apps(self):
-        return self.__qrs_api_helper.get_full_app_list(self.__qrs_api_session)
-
-    def scrape_all_streams(self):
-        return self.__qrs_api_helper.get_full_stream_list(
-            self.__qrs_api_session)
-
-    def scrape_sheets(self, app):
-        app_id = app.get('id')
-        return self.__engine_api_helper.get_sheets(
-            app_id, self.__engine_api_auth_cookie)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -14,12 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
-from requests import sessions
-
 from google.datacatalog_connectors.qlik.scrape import \
-    authenticator, engine_api_helper, repository_services_api_helper
+    engine_api_helper, repository_services_api_helper
 
 
 class MetadataScraper:
@@ -27,75 +23,21 @@ class MetadataScraper:
     comprising the interactions between Qlik Sense Proxy Service (QPS), Qlik
     Sense Repository Service (QRS), and Qlik Engine JSON API.
 
-    Attributes:
-        __qrs_api_session: An HTTP session for the QRS RESP API calls.
-        __engine_api_auth_cookie: A cookie to authenticate the provided user
-          in the Qlik Engine JSON API.
-
     """
 
     def __init__(self, server_address, ad_domain, username, password):
-        self.__server_address = server_address
-        self.__ad_domain = ad_domain
-        self.__username = username
-        self.__password = password
-
         self.__qrs_api_helper = \
             repository_services_api_helper.RepositoryServicesAPIHelper(
-                server_address)
-        self.__engine_api_helper = \
-            engine_api_helper.EngineAPIHelper(server_address)
-
-        self.__qrs_api_session = None
-        self.__engine_api_auth_cookie = None
+                server_address, ad_domain, username, password)
+        self.__engine_api_helper = engine_api_helper.EngineAPIHelper(
+            server_address, ad_domain, username, password)
 
     def scrape_all_apps(self):
-        self.__initialize_qrs_api_session()
-        return self.__qrs_api_helper.get_full_app_list(self.__qrs_api_session)
+        return self.__qrs_api_helper.get_full_app_list()
 
     def scrape_all_streams(self):
-        self.__initialize_qrs_api_session()
-        return self.__qrs_api_helper.get_full_stream_list(
-            self.__qrs_api_session)
+        return self.__qrs_api_helper.get_full_stream_list()
 
-    def __initialize_qrs_api_session(self):
-        if self.__qrs_api_session:
-            return
-
-        self.__qrs_api_session = sessions.Session()
-
-        windows_auth_url = \
-            self.__qrs_api_helper.get_windows_authentication_url(
-                self.__qrs_api_session)
-        qps_session_cookie = authenticator.Authenticator \
-            .get_qps_session_cookie_windows_auth(
-                ad_domain=self.__ad_domain,
-                username=self.__username,
-                password=self.__password,
-                auth_url=windows_auth_url)
-
-        self.__qrs_api_session.cookies.set_cookie(qps_session_cookie)
-        logging.debug('QPS session cookie issued for the QRS API: %s',
-                      qps_session_cookie)
-
-    def scrape_sheets(self, app):
-        self.__initialize_engine_api_auth_cookie()
-        app_id = app.get('id')
-        sheets = self.__engine_api_helper.get_sheets(
-            app_id, self.__engine_api_auth_cookie)
+    def scrape_sheets(self, app_metadata):
+        sheets = self.__engine_api_helper.get_sheets(app_metadata.get('id'))
         return sheets if sheets else []
-
-    def __initialize_engine_api_auth_cookie(self):
-        if self.__engine_api_auth_cookie:
-            return
-
-        windows_auth_url = \
-            self.__engine_api_helper.get_windows_authentication_url()
-        self.__engine_api_auth_cookie = authenticator.Authenticator\
-            .get_qps_session_cookie_windows_auth(
-                ad_domain=self.__ad_domain,
-                username=self.__username,
-                password=self.__password,
-                auth_url=windows_auth_url)
-        logging.debug('QPS session cookie issued for the Engine API: %s',
-                      self.__engine_api_auth_cookie)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -19,46 +19,76 @@ import logging
 from requests import sessions
 
 from google.datacatalog_connectors.qlik.scrape import \
-    authenticator, constants, repository_services_api_helper
+    authenticator, engine_api_helper, repository_services_api_helper
 
 
 class MetadataScraper:
+    """A Facade that provides a simplified interface for the Qlik services,
+    comprising the interactions between Qlik Sense Proxy Service (QPS), Qlik
+    Sense Repository Service (QRS), and Qlik Engine JSON API.
+
+    Attributes:
+        __qrs_api_session: An HTTP session for the QRS RESP API calls.
+        __engine_api_auth_cookie: A cookie to authenticate the provided user
+          in the Qlik Engine JSON API.
+
+    """
 
     def __init__(self, server_address, ad_domain, username, password):
         self.__server_address = server_address
         self.__ad_domain = ad_domain
         self.__username = username
         self.__password = password
-        self.__session = sessions.Session()
+
         self.__qrs_api_helper = \
             repository_services_api_helper.RepositoryServicesAPIHelper(
                 server_address)
+        self.__engine_api_helper = \
+            engine_api_helper.EngineAPIHelper(server_address)
+
+        self.__qrs_api_session = None
+        self.__initialize_qrs_api_session()
+
+        self.__engine_api_auth_cookie = None
+        self.__initialize_engine_api_auth_cookie()
+
+    def __initialize_qrs_api_session(self):
+        self.__qrs_api_session = sessions.Session()
+
+        windows_auth_url = \
+            self.__qrs_api_helper.get_windows_authentication_url(
+                self.__qrs_api_session)
+        qps_session_cookie = authenticator.Authenticator\
+            .get_qps_session_cookie_windows_auth(
+                ad_domain=self.__ad_domain,
+                username=self.__username,
+                password=self.__password,
+                auth_url=windows_auth_url)
+
+        self.__qrs_api_session.cookies.set_cookie(qps_session_cookie)
+        logging.debug('QPS session cookie issued for the QRS API: %s',
+                      qps_session_cookie)
+
+    def __initialize_engine_api_auth_cookie(self):
+        windows_auth_url = \
+            self.__engine_api_helper.get_windows_authentication_url()
+        self.__engine_api_auth_cookie = authenticator.Authenticator\
+            .get_qps_session_cookie_windows_auth(
+                ad_domain=self.__ad_domain,
+                username=self.__username,
+                password=self.__password,
+                auth_url=windows_auth_url)
+        logging.debug('QPS session cookie issued for the Engine API: %s',
+                      self.__engine_api_auth_cookie)
 
     def scrape_all_apps(self):
-        self.__set_qps_session_cookie()
-        return self.__qrs_api_helper.get_full_app_list(self.__session)
+        return self.__qrs_api_helper.get_full_app_list(self.__qrs_api_session)
 
     def scrape_all_streams(self):
-        self.__set_qps_session_cookie()
-        return self.__qrs_api_helper.get_full_stream_list(self.__session)
+        return self.__qrs_api_helper.get_full_stream_list(
+            self.__qrs_api_session)
 
-    def __set_qps_session_cookie(self):
-        cookie = None
-
-        if self.__session.cookies:
-            cookie = next(
-                cookie for cookie in self.__session.cookies
-                if cookie.name.startswith(constants.QPS_SESSION_COOKIE_PREFIX))
-
-        if not cookie:
-            windows_auth_url = \
-                self.__qrs_api_helper.get_windows_authentication_url(
-                    self.__session)
-            qps_session_cookie = authenticator.Authenticator\
-                .get_qps_session_cookie_windows_auth(
-                    ad_domain=self.__ad_domain,
-                    username=self.__username,
-                    password=self.__password,
-                    auth_url=windows_auth_url)
-            self.__session.cookies.set_cookie(qps_session_cookie)
-            logging.debug('New QPS session cookie set: %s', qps_session_cookie)
+    def scrape_sheets(self, app):
+        app_id = app.get('id')
+        return self.__engine_api_helper.get_sheets(
+            app_id, self.__engine_api_auth_cookie)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
@@ -29,14 +29,14 @@ class RepositoryServicesAPIHelper:
     QRS returns full objects when /full is included in the request path;
     otherwise, it returns condensed objects. Full objects are preferred
     because they allow the connector to read a richer metadata set (see [Full
-    versus condensed objects](https://help.qlik.com/en-US/sense-developer/November2020/Subsystems/RepositoryServiceAPI/Content/Sense_RepositoryServiceAPI/RepositoryServiceAPI-Connect-API-Full-vs-Condensed-Objects.htm) # noqa E501
+    versus condensed objects](https://help.qlik.com/en-US/sense-developer/November2020/Subsystems/RepositoryServiceAPI/Content/Sense_RepositoryServiceAPI/RepositoryServiceAPI-Connect-API-Full-vs-Condensed-Objects.htm)  # noqa E501
     for more information).
 
     """
 
     def __init__(self, server_address):
         self.__base_api_endpoint = f'{server_address}/qrs'
-        self.__headers = {
+        self.__common_headers = {
             'Content-Type': constants.JSON_CONTENT_TYPE,
             'Accept': constants.JSON_CONTENT_TYPE,
             constants.XRFKEY_HEADER_NAME: constants.XRFKEY,
@@ -52,7 +52,7 @@ class RepositoryServicesAPIHelper:
         url = f'{self.__base_api_endpoint}' \
               f'/app/hublist/full?Xrfkey={constants.XRFKEY}'
 
-        return session.get(url=url, headers=self.__headers).json()
+        return session.get(url=url, headers=self.__common_headers).json()
 
     def get_full_stream_list(self, session):
         """Get the list of streams with full metadata from a given server.
@@ -63,7 +63,7 @@ class RepositoryServicesAPIHelper:
         url = f'{self.__base_api_endpoint}' \
               f'/stream/full?Xrfkey={constants.XRFKEY}'
 
-        return session.get(url=url, headers=self.__headers).json()
+        return session.get(url=url, headers=self.__common_headers).json()
 
     def get_windows_authentication_url(self, session):
         """Get a Windows Authentication url.
@@ -78,12 +78,13 @@ class RepositoryServicesAPIHelper:
         """
         url = f'{self.__base_api_endpoint}/about?Xrfkey={constants.XRFKEY}'
 
-        # Sets the User-Agent to Windows to get a Windows Authentication URL
-        # that is required by the NTLM authentication flow.
-        self.__headers['User-Agent'] = constants.WINDOWS_USER_AGENT
+        # Sets the User-Agent to Windows temporarily to get a Windows
+        # Authentication URL that is required by the NTLM authentication flow.
+        headers = self.__common_headers.copy()
+        headers['User-Agent'] = constants.WINDOWS_USER_AGENT
 
         response = requests.get(url=url,
-                                headers=self.__headers,
+                                headers=headers,
                                 allow_redirects=False)
 
         return session.get_redirect_target(response)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -57,7 +57,7 @@ class MetadataSynchronizer:
         logging.info('===> Scraping Qlik Sense metadata...')
 
         logging.info('')
-        logging.info('Streams and apps...')
+        logging.info('Objects to be scraped: Streams, Apps, and Sheets')
         streams = self.__scrape_streams()
         logging.info('==== DONE ========================================')
 
@@ -101,6 +101,13 @@ class MetadataSynchronizer:
         """
         all_streams = self.__metadata_scraper.scrape_all_streams()
         all_apps = self.__metadata_scraper.scrape_all_apps()
+
+        for app in all_apps:
+            logging.info('')
+            logging.info(' . Scraping Sheets from "%s"', app.get('name'))
+            app['sheets'] = self.__metadata_scraper.scrape_sheets(app)
+            logging.info(' .. The App has %d Sheets', len(app['sheets']))
+        logging.info('')
 
         self.__assemble_stream_metadata_from_flat_lists(all_streams, all_apps)
 
@@ -195,7 +202,7 @@ class MetadataSynchronizer:
             stream_entries_count = len(assembled_entries)
 
             logging.info('')
-            logging.info('==== The Stream identified by %s has %d entries.',
+            logging.info('==== The Stream identified by "%s" has %d entries.',
                          stream_id, stream_entries_count)
             metadata_ingestor.ingest_metadata(assembled_entries,
                                               tag_templates_dict)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/authenticator_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/authenticator_test.py
@@ -53,8 +53,7 @@ class AuthenticatorTest(unittest.TestCase):
 
     def test_get_qps_cookie_win_auth_should_return_none_on_cookie_not_found(
             self, mock_requests):
-        mock_requests.get.return_value = \
-            scrape_ops_mocks.FakeResponseWithIgnoredCookies()
+        mock_requests.get.return_value = mock.MagicMock()
 
         cookie = authenticator.Authenticator \
             .get_qps_session_cookie_windows_auth(

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
@@ -67,13 +67,12 @@ class EngineAPIHelperTest(unittest.TestCase):
 
         mock_websocket.return_value.__enter__.return_value.set_data([
             {
-                'id': 2202,
                 'params': {
                     'loginUri': 'redirect-url'
                 }
             },
             {
-                'id': 9326,
+                'id': 2202,
                 'result': {
                     'qReturn': {}
                 }

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
@@ -31,8 +31,8 @@ _SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
 class EngineAPIHelperTest(unittest.TestCase):
 
     def setUp(self):
-        # Set a constant seed to ensure generated numbers will always be the
-        # same when running the tests.
+        # Set a constant seed so generated numbers will always be the same when
+        # running the tests.
         random.seed(1)
 
         self.__helper = engine_api_helper.EngineAPIHelper(
@@ -82,14 +82,49 @@ class EngineAPIHelperTest(unittest.TestCase):
             {
                 'id': 9326,
                 'result': {
-                    'qList': []
+                    'qList': [{
+                        'qInfo': {
+                            'qId': 'sheet-id',
+                            'qType': 'sheet'
+                        },
+                    }]
                 }
             },
         ])
 
         sheets = self.__helper.get_sheets({'id': 'app-id'}, mock.MagicMock())
 
-        self.assertIsNotNone(sheets)
+        self.assertEqual(1, len(sheets))
+        self.assertEqual('sheet-id', sheets[0].get('qInfo').get('qId'))
+
+    def test_get_sheets_should_return_none_on_no_server_response(
+            self, mock_websocket):
+
+        mock_websocket.return_value.__enter__.return_value.set_data([
+            {
+                'id': 2202,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1
+                    }
+                }
+            },
+            {
+                'id': 9327,
+                'result': {
+                    'qList': [{
+                        'qInfo': {
+                            'qId': 'sheet-id',
+                            'qType': 'sheet'
+                        },
+                    }]
+                }
+            },
+        ])
+
+        sheets = self.__helper.get_sheets({'id': 'app-id'}, mock.MagicMock())
+
+        self.assertIsNone(sheets)
 
     def test_get_windows_authentication_url_should_return_url_from_response(
             self, mock_websocket):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_helper_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.qlik.scrape import \
+    constants, engine_api_helper
+
+from . import scrape_ops_mocks
+
+_SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
+
+
+@mock.patch(f'{_SCRAPE_PACKAGE}.engine_api_helper.websockets.connect',
+            new_callable=scrape_ops_mocks.AsyncContextManager)
+class EngineAPIHelperTest(unittest.TestCase):
+
+    def setUp(self):
+        # Set a constant seed to ensure generated numbers will always be the
+        # same when running the tests.
+        random.seed(1)
+
+        self.__helper = engine_api_helper.EngineAPIHelper(
+            server_address='https://test-server')
+
+    def test_constructor_should_set_instance_attributes(self, mock_websocket):
+        attrs = self.__helper.__dict__
+
+        self.assertEqual('https://test-server',
+                         attrs['_EngineAPIHelper__server_address'])
+        self.assertEqual('wss://test-server',
+                         attrs['_EngineAPIHelper__base_api_endpoint'])
+        self.assertIsNotNone(attrs['_EngineAPIHelper__common_headers'])
+
+    def test_websocket_connection_should_use_cookie(self, mock_websocket):
+        mock_websocket.return_value.__enter__.return_value.set_data([
+            {
+                'id': 2202,
+                'result': {
+                    'qReturn': {}
+                }
+            },
+        ])
+
+        fake_cookie = scrape_ops_mocks.FakeQPSSessionCookie()
+        self.__helper.get_sheets('app-id', fake_cookie)
+
+        mock_websocket.assert_called_once()
+
+        extra_headers = self.__helper.__dict__[
+            '_EngineAPIHelper__common_headers'].copy()
+        extra_headers['Cookie'] = 'X-Qlik-Session=Test cookie'
+        mock_websocket.assert_called_with(
+            uri=f'wss://test-server/app/app-id?Xrfkey={constants.XRFKEY}',
+            extra_headers=extra_headers)
+
+    def test_get_sheets_should_return_list_on_success(self, mock_websocket):
+        mock_websocket.return_value.__enter__.return_value.set_data([
+            {
+                'id': 2202,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1
+                    }
+                }
+            },
+            {
+                'id': 9326,
+                'result': {
+                    'qList': []
+                }
+            },
+        ])
+
+        sheets = self.__helper.get_sheets({'id': 'app-id'}, mock.MagicMock())
+
+        self.assertIsNotNone(sheets)
+
+    def test_get_windows_authentication_url_should_return_url_from_response(
+            self, mock_websocket):
+
+        mock_websocket.return_value.__enter__.return_value.set_data([
+            {
+                'id': 2202,
+                'params': {
+                    'loginUri': 'redirect-url'
+                }
+            },
+        ])
+
+        url = self.__helper.get_windows_authentication_url()
+
+        extra_headers = self.__helper.__dict__[
+            '_EngineAPIHelper__common_headers'].copy()
+        extra_headers['User-Agent'] = 'Windows'
+
+        self.assertEqual('redirect-url', url)
+        mock_websocket.assert_called_with(
+            uri=f'wss://test-server/app/?transient=?Xrfkey={constants.XRFKEY}'
+            f'&reloadUri=https://test-server/dev-hub/engine-api-explorer',
+            extra_headers=extra_headers)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -19,8 +19,6 @@ from unittest import mock
 
 from google.datacatalog_connectors.qlik import scrape
 
-from . import scrape_ops_mocks
-
 
 class MetadataScraperTest(unittest.TestCase):
     __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
@@ -64,7 +62,7 @@ class MetadataScraperTest(unittest.TestCase):
 
         qrs_api_helper.get_windows_authentication_url.return_value = 'test-url'
         mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
-            scrape_ops_mocks.FakeQPSSessionCookie()
+            mock.MagicMock()
         qrs_api_helper.get_full_stream_list.return_value = streams_metadata
 
         streams = self.__scraper.scrape_all_streams()
@@ -87,8 +85,7 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'app-id',
         }]
 
-        attrs['_MetadataScraper__qrs_api_session'] = \
-            scrape_ops_mocks.FakeSessionWithCookies()
+        attrs['_MetadataScraper__qrs_api_session'] = mock.MagicMock()
         qrs_api_helper.get_full_app_list.return_value = apps_metadata
 
         apps = self.__scraper.scrape_all_apps()
@@ -105,8 +102,7 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'stream-id',
         }]
 
-        attrs['_MetadataScraper__qrs_api_session'] = \
-            scrape_ops_mocks.FakeSessionWithCookies()
+        attrs['_MetadataScraper__qrs_api_session'] = mock.MagicMock()
         qrs_api_helper.get_full_stream_list.return_value = streams_metadata
 
         streams = self.__scraper.scrape_all_streams()
@@ -128,7 +124,7 @@ class MetadataScraperTest(unittest.TestCase):
         engine_api_helper.get_windows_authentication_url.return_value = \
             'test-url'
         mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
-            scrape_ops_mocks.FakeQPSSessionCookie()
+            mock.MagicMock()
         engine_api_helper.get_sheets.return_value = sheets_metadata
 
         sheets = self.__scraper.scrape_sheets({'id': 'app-id'})
@@ -151,8 +147,7 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'sheet-id',
         }]
 
-        attrs['_MetadataScraper__engine_api_auth_cookie'] = \
-            scrape_ops_mocks.FakeQPSSessionCookie()
+        attrs['_MetadataScraper__engine_api_auth_cookie'] = mock.MagicMock()
         engine_api_helper.get_sheets.return_value = sheets_metadata
 
         sheets = self.__scraper.scrape_sheets({'id': 'app-id'})

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -26,19 +26,10 @@ class MetadataScraperTest(unittest.TestCase):
     __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
     __SCRAPER_MODULE = f'{__SCRAPE_PACKAGE}.metadata_scraper'
 
-    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator')
     @mock.patch(f'{__SCRAPER_MODULE}.engine_api_helper.EngineAPIHelper')
     @mock.patch(f'{__SCRAPER_MODULE}.repository_services_api_helper'
                 f'.RepositoryServicesAPIHelper')
-    def setUp(self, mock_qrs_api_helper, mock_engine_api_helper,
-              mock_authenticator):
-        mock_qrs_api_helper.get_windows_authentication_url.return_value = \
-            'test-url'
-        mock_engine_api_helper.get_windows_authentication_url.return_value = \
-            'test-url'
-        mock_authenticator.get_qps_session_cookie_windows_auth.return_value =\
-            scrape_ops_mocks.FakeQPSSessionCookie()
-
+    def setUp(self, mock_qrs_api_helper, mock_engine_api_helper):
         self.__scraper = scrape.MetadataScraper(server_address='test-server',
                                                 ad_domain='test-domain',
                                                 username='test-username',
@@ -56,8 +47,37 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertIsNotNone(attrs['_MetadataScraper__qrs_api_helper'])
         self.assertIsNotNone(attrs['_MetadataScraper__engine_api_helper'])
 
-        self.assertIsNotNone(attrs['_MetadataScraper__qrs_api_session'])
-        self.assertIsNotNone(attrs['_MetadataScraper__engine_api_auth_cookie'])
+    def test_constructor_should_not_set_session_related_attributes(self):
+        attrs = self.__scraper.__dict__
+
+        self.assertIsNone(attrs['_MetadataScraper__qrs_api_session'])
+        self.assertIsNone(attrs['_MetadataScraper__engine_api_auth_cookie'])
+
+    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator')
+    def test_scrape_should_authenticate_user(self, mock_authenticator):
+        attrs = self.__scraper.__dict__
+        qrs_api_helper = attrs['_MetadataScraper__qrs_api_helper']
+
+        streams_metadata = [{
+            'id': 'stream-id',
+        }]
+
+        qrs_api_helper.get_windows_authentication_url.return_value = 'test-url'
+        mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
+            scrape_ops_mocks.FakeQPSSessionCookie()
+        qrs_api_helper.get_full_stream_list.return_value = streams_metadata
+
+        streams = self.__scraper.scrape_all_streams()
+
+        self.assertEqual(1, len(streams))
+        self.assertEqual('stream-id', streams[0].get('id'))
+        mock_authenticator.get_qps_session_cookie_windows_auth \
+            .assert_called_with(
+                ad_domain='test-domain',
+                username='test-username',
+                password='test-password',
+                auth_url='test-url')
+        qrs_api_helper.get_full_stream_list.assert_called_once()
 
     def test_scrape_all_apps_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__
@@ -67,6 +87,8 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'app-id',
         }]
 
+        attrs['_MetadataScraper__qrs_api_session'] = \
+            scrape_ops_mocks.FakeSessionWithCookies()
         qrs_api_helper.get_full_app_list.return_value = apps_metadata
 
         apps = self.__scraper.scrape_all_apps()
@@ -83,6 +105,8 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'stream-id',
         }]
 
+        attrs['_MetadataScraper__qrs_api_session'] = \
+            scrape_ops_mocks.FakeSessionWithCookies()
         qrs_api_helper.get_full_stream_list.return_value = streams_metadata
 
         streams = self.__scraper.scrape_all_streams()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -56,26 +56,22 @@ class MetadataScraperTest(unittest.TestCase):
         attrs = self.__scraper.__dict__
         qrs_api_helper = attrs['_MetadataScraper__qrs_api_helper']
 
-        streams_metadata = [{
-            'id': 'stream-id',
-        }]
-
         qrs_api_helper.get_windows_authentication_url.return_value = 'test-url'
         mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
             mock.MagicMock()
-        qrs_api_helper.get_full_stream_list.return_value = streams_metadata
+        qrs_api_helper.get_full_stream_list.return_value = []
 
-        streams = self.__scraper.scrape_all_streams()
+        self.__scraper.scrape_all_streams()
 
-        self.assertEqual(1, len(streams))
-        self.assertEqual('stream-id', streams[0].get('id'))
+        qrs_api_helper.get_windows_authentication_url.assert_called_once()
+        mock_authenticator.get_qps_session_cookie_windows_auth\
+            .assert_called_once()
         mock_authenticator.get_qps_session_cookie_windows_auth \
             .assert_called_with(
                 ad_domain='test-domain',
                 username='test-username',
                 password='test-password',
                 auth_url='test-url')
-        qrs_api_helper.get_full_stream_list.assert_called_once()
 
     def test_scrape_all_apps_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__
@@ -117,27 +113,23 @@ class MetadataScraperTest(unittest.TestCase):
         attrs = self.__scraper.__dict__
         engine_api_helper = attrs['_MetadataScraper__engine_api_helper']
 
-        sheets_metadata = [{
-            'id': 'sheet-id',
-        }]
-
         engine_api_helper.get_windows_authentication_url.return_value = \
             'test-url'
         mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
             mock.MagicMock()
-        engine_api_helper.get_sheets.return_value = sheets_metadata
+        engine_api_helper.get_sheets.return_value = None
 
-        sheets = self.__scraper.scrape_sheets({'id': 'app-id'})
+        self.__scraper.scrape_sheets({'id': 'app-id'})
 
-        self.assertEqual(1, len(sheets))
-        self.assertEqual('sheet-id', sheets[0].get('id'))
+        engine_api_helper.get_sheets.assert_called_once()
+        mock_authenticator.get_qps_session_cookie_windows_auth\
+            .assert_called_once()
         mock_authenticator.get_qps_session_cookie_windows_auth \
             .assert_called_with(
                 ad_domain='test-domain',
                 username='test-username',
                 password='test-password',
                 auth_url='test-url')
-        engine_api_helper.get_sheets.assert_called_once()
 
     def test_scrape_sheets_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -35,43 +35,8 @@ class MetadataScraperTest(unittest.TestCase):
 
     def test_constructor_should_set_instance_attributes(self):
         attrs = self.__scraper.__dict__
-
-        self.assertEqual('test-server',
-                         attrs['_MetadataScraper__server_address'])
-        self.assertEqual('test-domain', attrs['_MetadataScraper__ad_domain'])
-        self.assertEqual('test-username', attrs['_MetadataScraper__username'])
-        self.assertEqual('test-password', attrs['_MetadataScraper__password'])
-
         self.assertIsNotNone(attrs['_MetadataScraper__qrs_api_helper'])
         self.assertIsNotNone(attrs['_MetadataScraper__engine_api_helper'])
-
-    def test_constructor_should_not_set_session_related_attributes(self):
-        attrs = self.__scraper.__dict__
-
-        self.assertIsNone(attrs['_MetadataScraper__qrs_api_session'])
-        self.assertIsNone(attrs['_MetadataScraper__engine_api_auth_cookie'])
-
-    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator')
-    def test_scrape_qrs_api_should_authenticate_user(self, mock_authenticator):
-        attrs = self.__scraper.__dict__
-        qrs_api_helper = attrs['_MetadataScraper__qrs_api_helper']
-
-        qrs_api_helper.get_windows_authentication_url.return_value = 'test-url'
-        mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
-            mock.MagicMock()
-        qrs_api_helper.get_full_stream_list.return_value = []
-
-        self.__scraper.scrape_all_streams()
-
-        qrs_api_helper.get_windows_authentication_url.assert_called_once()
-        mock_authenticator.get_qps_session_cookie_windows_auth\
-            .assert_called_once()
-        mock_authenticator.get_qps_session_cookie_windows_auth \
-            .assert_called_with(
-                ad_domain='test-domain',
-                username='test-username',
-                password='test-password',
-                auth_url='test-url')
 
     def test_scrape_all_apps_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__
@@ -106,30 +71,6 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(1, len(streams))
         self.assertEqual('stream-id', streams[0].get('id'))
         qrs_api_helper.get_full_stream_list.assert_called_once()
-
-    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator')
-    def test_scrape_engine_api_should_authenticate_user(
-            self, mock_authenticator):
-        attrs = self.__scraper.__dict__
-        engine_api_helper = attrs['_MetadataScraper__engine_api_helper']
-
-        engine_api_helper.get_windows_authentication_url.return_value = \
-            'test-url'
-        mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
-            mock.MagicMock()
-        engine_api_helper.get_sheets.return_value = None
-
-        self.__scraper.scrape_sheets({'id': 'app-id'})
-
-        engine_api_helper.get_sheets.assert_called_once()
-        mock_authenticator.get_qps_session_cookie_windows_auth\
-            .assert_called_once()
-        mock_authenticator.get_qps_session_cookie_windows_auth \
-            .assert_called_with(
-                ad_domain='test-domain',
-                username='test-username',
-                password='test-password',
-                auth_url='test-url')
 
     def test_scrape_sheets_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -144,7 +144,10 @@ class MetadataScraperTest(unittest.TestCase):
         engine_api_helper = attrs['_MetadataScraper__engine_api_helper']
 
         sheets_metadata = [{
-            'id': 'sheet-id',
+            'qInfo': {
+                'qId': 'sheet-id',
+                'qType': 'sheet'
+            },
         }]
 
         attrs['_MetadataScraper__engine_api_auth_cookie'] = mock.MagicMock()
@@ -153,5 +156,19 @@ class MetadataScraperTest(unittest.TestCase):
         sheets = self.__scraper.scrape_sheets({'id': 'app-id'})
 
         self.assertEqual(1, len(sheets))
-        self.assertEqual('sheet-id', sheets[0].get('id'))
+        self.assertEqual('sheet-id', sheets[0].get('qInfo').get('qId'))
+        engine_api_helper.get_sheets.assert_called_once()
+
+    def test_scrape_sheets_should_return_empty_list_on_no_server_response(
+            self):
+
+        attrs = self.__scraper.__dict__
+        engine_api_helper = attrs['_MetadataScraper__engine_api_helper']
+
+        attrs['_MetadataScraper__engine_api_auth_cookie'] = mock.MagicMock()
+        engine_api_helper.get_sheets.return_value = None
+
+        sheets = self.__scraper.scrape_sheets({'id': 'app-id'})
+
+        self.assertEqual(0, len(sheets))
         engine_api_helper.get_sheets.assert_called_once()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -36,7 +36,8 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         self.assertEqual(
             'test-server/qrs',
             attrs['_RepositoryServicesAPIHelper__base_api_endpoint'])
-        self.assertIsNotNone(attrs['_RepositoryServicesAPIHelper__headers'])
+        self.assertIsNotNone(
+            attrs['_RepositoryServicesAPIHelper__common_headers'])
 
     def test_get_full_app_list_should_use_session_to_call_api(self):
         mock_session = mock.Mock(sessions.Session())
@@ -48,7 +49,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/app/hublist/full?Xrfkey={constants.XRFKEY}',
             headers=self.__helper.
-            __dict__['_RepositoryServicesAPIHelper__headers'],
+            __dict__['_RepositoryServicesAPIHelper__common_headers'],
         )
 
     def test_get_full_stream_list_should_use_session_to_call_api(self):
@@ -61,7 +62,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/stream/full?Xrfkey={constants.XRFKEY}',
             headers=self.__helper.
-            __dict__['_RepositoryServicesAPIHelper__headers'],
+            __dict__['_RepositoryServicesAPIHelper__common_headers'],
         )
 
     @mock.patch(f'{__SCRAPE_PACKAGE}.repository_services_api_helper.requests')

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests import sessions
 import unittest
 from unittest import mock
 
@@ -40,7 +39,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
             attrs['_RepositoryServicesAPIHelper__common_headers'])
 
     def test_get_full_app_list_should_use_session_to_call_api(self):
-        mock_session = mock.Mock(sessions.Session())
+        mock_session = mock.MagicMock()
 
         apps = self.__helper.get_full_app_list(mock_session)
 
@@ -53,7 +52,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         )
 
     def test_get_full_stream_list_should_use_session_to_call_api(self):
-        mock_session = mock.Mock(sessions.Session())
+        mock_session = mock.MagicMock()
 
         streams = self.__helper.get_full_stream_list(mock_session)
 
@@ -69,7 +68,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
     def test_get_windows_authentication_url_should_return_url_from_header(
             self, mock_requests):
 
-        mock_session = mock.Mock(sessions.Session())
+        mock_session = mock.MagicMock()
         mock_session.get_redirect_target.return_value = 'redirect-url'
 
         url = self.__helper.get_windows_authentication_url(mock_session)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -20,6 +20,8 @@ from unittest import mock
 from google.datacatalog_connectors.qlik.scrape import \
     constants, repository_services_api_helper
 
+from . import scrape_ops_mocks
+
 
 class RepositoryServicesAPIHelperTest(unittest.TestCase):
     __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
@@ -38,12 +40,15 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         self.assertIsNotNone(
             attrs['_RepositoryServicesAPIHelper__common_headers'])
 
-    def test_get_full_app_list_should_use_session_to_call_api(self):
+    def test_get_full_app_list_should_return_list_on_success(self):
         mock_session = mock.MagicMock()
+        mock_session.get.return_value = \
+            scrape_ops_mocks.FakeResponseWithContent('[{\"id\": \"app-id\"}]')
 
         apps = self.__helper.get_full_app_list(mock_session)
 
-        self.assertIsNotNone(apps)
+        self.assertEqual(1, len(apps))
+        self.assertEqual('app-id', apps[0].get('id'))
         mock_session.get.assert_called_once()
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/app/hublist/full?Xrfkey={constants.XRFKEY}',
@@ -53,10 +58,14 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
 
     def test_get_full_stream_list_should_use_session_to_call_api(self):
         mock_session = mock.MagicMock()
+        mock_session.get.return_value = \
+            scrape_ops_mocks.FakeResponseWithContent(
+                '[{\"id\": \"stream-id\"}]')
 
         streams = self.__helper.get_full_stream_list(mock_session)
 
-        self.assertIsNotNone(streams)
+        self.assertEqual(1, len(streams))
+        self.assertEqual('stream-id', streams[0].get('id'))
         mock_session.get.assert_called_once()
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/stream/full?Xrfkey={constants.XRFKEY}',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests import sessions
 import unittest
 from unittest import mock
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from requests import sessions
 import unittest
 from unittest import mock
 
@@ -25,14 +26,27 @@ from . import scrape_ops_mocks
 
 class RepositoryServicesAPIHelperTest(unittest.TestCase):
     __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
+    __HELPER_MODULE = f'{__SCRAPE_PACKAGE}.repository_services_api_helper'
 
     def setUp(self):
         self.__helper = \
             repository_services_api_helper.RepositoryServicesAPIHelper(
-                server_address='test-server')
+                server_address='test-server',
+                ad_domain='test-domain',
+                username='test-username',
+                password='test-password')
 
     def test_constructor_should_set_instance_attributes(self):
         attrs = self.__helper.__dict__
+
+        self.assertEqual('test-server',
+                         attrs['_RepositoryServicesAPIHelper__server_address'])
+        self.assertEqual('test-domain',
+                         attrs['_RepositoryServicesAPIHelper__ad_domain'])
+        self.assertEqual('test-username',
+                         attrs['_RepositoryServicesAPIHelper__username'])
+        self.assertEqual('test-password',
+                         attrs['_RepositoryServicesAPIHelper__password'])
 
         self.assertEqual(
             'test-server/qrs',
@@ -40,47 +54,89 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         self.assertIsNotNone(
             attrs['_RepositoryServicesAPIHelper__common_headers'])
 
-    def test_get_full_app_list_should_return_list_on_success(self):
-        mock_session = mock.MagicMock()
+    def test_constructor_should_not_set_session_related_attributes(self):
+        attrs = self.__helper.__dict__
+        self.assertIsNone(attrs['_RepositoryServicesAPIHelper__http_session'])
+
+    @mock.patch(f'{__HELPER_MODULE}.sessions.Session.get')
+    @mock.patch(f'{__HELPER_MODULE}.requests')
+    @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator')
+    def test_scrape_operations_should_authenticate_user_beforehand(
+            self, mock_authenticator, mock_requests, mock_session_get):
+
+        fake_cookie = scrape_ops_mocks.FakeQPSSessionCookie()
+
+        mock_requests.get.return_value = \
+            scrape_ops_mocks.FakeResponseWithHeader(
+                'location', 'redirect-url', True)
+        mock_authenticator.get_qps_session_cookie_windows_auth.return_value = \
+            fake_cookie
+        mock_session_get.return_value = \
+            scrape_ops_mocks.FakeResponseWithContent('[]')
+
+        # Call a public method to trigger the authentication workflow.
+        self.__helper.get_full_stream_list()
+
+        attrs = self.__helper.__dict__
+        extra_headers = attrs[
+            '_RepositoryServicesAPIHelper__common_headers'].copy()
+        extra_headers['User-Agent'] = 'Windows'
+        mock_requests.get.assert_called_with(
+            url=f'test-server/qrs/about?Xrfkey={constants.XRFKEY}',
+            headers=extra_headers,
+            allow_redirects=False)
+
+        mock_authenticator.get_qps_session_cookie_windows_auth \
+            .assert_called_once()
+        mock_authenticator.get_qps_session_cookie_windows_auth \
+            .assert_called_with(
+                ad_domain='test-domain',
+                username='test-username',
+                password='test-password',
+                auth_url='redirect-url')
+
+        http_session = attrs['_RepositoryServicesAPIHelper__http_session']
+        self.assertIsNotNone(http_session)
+        self.assertEqual('Test cookie',
+                         http_session.cookies.get('X-Qlik-Session'))
+
+    @mock.patch(f'{__HELPER_MODULE}.sessions.Session')
+    def test_get_full_app_list_should_return_list_on_success(
+            self, mock_session):
+
         mock_session.get.return_value = \
             scrape_ops_mocks.FakeResponseWithContent('[{\"id\": \"app-id\"}]')
 
-        apps = self.__helper.get_full_app_list(mock_session)
+        attrs = self.__helper.__dict__
+        attrs['_RepositoryServicesAPIHelper__http_session'] = mock_session
+
+        apps = self.__helper.get_full_app_list()
 
         self.assertEqual(1, len(apps))
         self.assertEqual('app-id', apps[0].get('id'))
         mock_session.get.assert_called_once()
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/app/hublist/full?Xrfkey={constants.XRFKEY}',
-            headers=self.__helper.
-            __dict__['_RepositoryServicesAPIHelper__common_headers'],
+            headers=attrs['_RepositoryServicesAPIHelper__common_headers'],
         )
 
-    def test_get_full_stream_list_should_use_session_to_call_api(self):
-        mock_session = mock.MagicMock()
+    @mock.patch(f'{__HELPER_MODULE}.sessions.Session')
+    def test_get_full_stream_list_should_return_list_on_success(
+            self, mock_session):
+
         mock_session.get.return_value = \
             scrape_ops_mocks.FakeResponseWithContent(
                 '[{\"id\": \"stream-id\"}]')
 
-        streams = self.__helper.get_full_stream_list(mock_session)
+        attrs = self.__helper.__dict__
+        attrs['_RepositoryServicesAPIHelper__http_session'] = mock_session
+
+        streams = self.__helper.get_full_stream_list()
 
         self.assertEqual(1, len(streams))
         self.assertEqual('stream-id', streams[0].get('id'))
         mock_session.get.assert_called_once()
         mock_session.get.assert_called_with(
             url=f'test-server/qrs/stream/full?Xrfkey={constants.XRFKEY}',
-            headers=self.__helper.
-            __dict__['_RepositoryServicesAPIHelper__common_headers'],
+            headers=attrs['_RepositoryServicesAPIHelper__common_headers'],
         )
-
-    @mock.patch(f'{__SCRAPE_PACKAGE}.repository_services_api_helper.requests')
-    def test_get_windows_authentication_url_should_return_url_from_header(
-            self, mock_requests):
-
-        mock_session = mock.MagicMock()
-        mock_session.get_redirect_target.return_value = 'redirect-url'
-
-        url = self.__helper.get_windows_authentication_url(mock_session)
-
-        self.assertEqual('redirect-url', url)
-        mock_requests.get.assert_called_once()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
@@ -46,15 +46,3 @@ class FakeResponseWithNoCookies:
 
     def __init__(self):
         self.cookies = []
-
-
-class FakeResponseWithLocationHeader:
-
-    def __init__(self, auth_url):
-        self.headers = {'Location': auth_url}
-
-
-class FakeSessionWithCookies:
-
-    def __init__(self):
-        self.cookies = [FakeQPSSessionCookie()]

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
@@ -46,3 +46,9 @@ class FakeResponseWithNoCookies:
 
     def __init__(self):
         self.cookies = []
+
+
+class FakeSessionWithCookies:
+
+    def __init__(self):
+        self.cookies = [FakeQPSSessionCookie()]

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
@@ -31,6 +31,15 @@ class FakeQPSSessionCookie:
 # ============== #
 # HTTP Responses #
 # ============== #
+class FakeResponseWithContent:
+
+    def __init__(self, content):
+        self.__content = content
+
+    def json(self):
+        return json.loads(self.__content)
+
+
 class FakeResponseWithCookies:
 
     def __init__(self):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
@@ -51,12 +51,6 @@ class FakeResponseWithNoCookies:
 # the 'AsyncMock' class. The present solution is based on the 'Strategies for #
 # Testing Async Code in Python' blog post (https://www.agari.com/email-security-blog/strategies-testing-async-code-python/)  # noqa E510
 # =========================================================================== #
-class AsyncMock(mock.MagicMock):
-
-    async def __call__(self, *args, **kwargs):
-        return super().__call__(*args, **kwargs)
-
-
 class AsyncContextManager(mock.MagicMock):
 
     def __init__(self, *args, **kwargs):
@@ -84,4 +78,4 @@ class AsyncContextManager(mock.MagicMock):
         self.itr_index = -1
 
     async def send(self, *args, **kwargs):
-        return AsyncMock()
+        pass

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/scrape_ops_mocks.py
@@ -26,6 +26,8 @@ class FakeQPSSessionCookie:
     def __init__(self):
         self.name = 'X-Qlik-Session'
         self.value = 'Test cookie'
+        self.domain = 'localhost'
+        self.path = '/'
 
 
 # ============== #
@@ -50,6 +52,13 @@ class FakeResponseWithNoCookies:
 
     def __init__(self):
         self.cookies = []
+
+
+class FakeResponseWithHeader:
+
+    def __init__(self, header_name, header_value, is_redirect=False):
+        self.headers = {header_name: header_value}
+        self.is_redirect = is_redirect
 
 
 # =========================================================================== #

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -84,7 +84,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         self.__synchronizer.run()
 
-        expected_make_assembled_entries_call_arg = {'id': 'test_stream'}
+        expected_make_assembled_entries_call_arg = {
+            'id': 'test_stream',
+        }
 
         make_assembled_entries_args = \
             assembled_entry_factory.make_assembled_entries_list.call_args[0]
@@ -112,6 +114,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
         scraper.scrape_all_apps.return_value = \
             [self.__make_fake_published_app()]
+        scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
 
@@ -123,7 +126,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
                 'published': True,
                 'stream': {
                     'id': 'test_stream'
-                }
+                },
+                'sheets': [],
             }]
         }
 
@@ -154,7 +158,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         self.__synchronizer.run()
 
-        expected_make_assembled_entries_call_arg = {'id': 'test_stream'}
+        expected_make_assembled_entries_call_arg = {
+            'id': 'test_stream',
+        }
 
         make_assembled_entries_args = \
             assembled_entry_factory.make_assembled_entries_list.call_args[0]
@@ -181,9 +187,12 @@ class MetadataSynchronizerTest(unittest.TestCase):
         return {
             'id': 'test_app',
             'published': True,
-            'stream': cls.__make_fake_stream()
+            'stream': cls.__make_fake_stream(),
         }
 
     @classmethod
     def __make_fake_wip_app(cls):
-        return {'id': 'test_app', 'published': False}
+        return {
+            'id': 'test_app',
+            'published': False,
+        }

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -75,9 +75,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
     def test_run_stream_metadata_should_succeed(self, mock_mapper,
                                                 mock_cleaner, mock_ingestor):
 
-        scraper = self.__synchronizer.__dict__[
-            '_MetadataSynchronizer__metadata_scraper']
-        assembled_entry_factory = self.__synchronizer.__dict__[
+        attrs = self.__synchronizer.__dict__
+        scraper = attrs['_MetadataSynchronizer__metadata_scraper']
+        assembled_entry_factory = attrs[
             '_MetadataSynchronizer__assembled_entry_factory']
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
@@ -106,9 +106,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
                                                        mock_cleaner,
                                                        mock_ingestor):
 
-        scraper = self.__synchronizer.__dict__[
-            '_MetadataSynchronizer__metadata_scraper']
-        assembled_entry_factory = self.__synchronizer.__dict__[
+        attrs = self.__synchronizer.__dict__
+        scraper = attrs['_MetadataSynchronizer__metadata_scraper']
+        assembled_entry_factory = attrs[
             '_MetadataSynchronizer__assembled_entry_factory']
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
@@ -148,9 +148,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
     def test_run_wip_app_metadata_should_succeed(self, mock_mapper,
                                                  mock_cleaner, mock_ingestor):
 
-        scraper = self.__synchronizer.__dict__[
-            '_MetadataSynchronizer__metadata_scraper']
-        assembled_entry_factory = self.__synchronizer.__dict__[
+        attrs = self.__synchronizer.__dict__
+        scraper = attrs['_MetadataSynchronizer__metadata_scraper']
+        assembled_entry_factory = attrs[
             '_MetadataSynchronizer__assembled_entry_factory']
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]


### PR DESCRIPTION
**- What I did**
Added elementary code to consume the Engine API

**- How I did it**
The most relevant changes are:
1. Added the `prepare.EngineAPIHelper` class. It wraps requests to the Qlik Engine JSON API.
1. Changed the `prepare.MetadataScraper` class, adding code that enables it to scrape Sheets by consuming the Qlik Engine JSON API.

**- How to verify it**
Run the unit tests and/or the connector and take a look at the output logs. The below lines are expected to be in part of the output:

```
...
INFO:root:Objects to be scraped: Streams, Apps, and Sheets
INFO:root:
INFO:root: . Scraping Sheets from "Qlik to GCP Test"
INFO:root: .. The App has 5 Sheets
INFO:root:
INFO:root: . Scraping Sheets from "Sample App"
INFO:root: .. The App has 3 Sheets
INFO:root:
INFO:root:==== DONE ========================================
...
```

**- Description for the changelog**
Added elementary code to consume the Engine API
