### PR TITLE
Add support for ingesting Sheets metadata

### DIFF
--- a/google-datacatalog-looker-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-looker-connector/tools/scripts/cleanup_datacatalog.py
@@ -46,7 +46,7 @@ def __delete_entries_and_groups(project_ids):
     entry_group_names = []
     for result in search_results:
         try:
-            __datacatalog.delete_entry(result.relative_resource_name)
+            __datacatalog.delete_entry(name=result.relative_resource_name)
             print('Entry deleted: {}'.format(result.relative_resource_name))
             entry_group_name = re.match(
                 pattern=entry_name_pattern,

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -3,8 +3,8 @@
 Package for ingesting Qlik Sense metadata into Google Cloud Data Catalog,
 currently supporting below asset types:
 - Stream
-- App (public only)
-- Sheet (public only)
+- App (only the published ones)
+- Sheet (only the published ones)
 
 **Disclaimer: This is not an officially supported Google product.**
 

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -3,7 +3,8 @@
 Package for ingesting Qlik Sense metadata into Google Cloud Data Catalog,
 currently supporting below asset types:
 - Stream
-- App (published only)
+- App (public only)
+- Sheet (public only)
 
 **Disclaimer: This is not an officially supported Google product.**
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -87,11 +87,9 @@ class AssembledEntryFactory:
         for app_metadata in apps_metadata:
             assembled_entries.append(
                 self.__make_assembled_entry_for_app(app_metadata))
-
-            app_id = app_metadata.get('id')
             assembled_entries.extend(
                 self.__make_assembled_entries_for_sheets(
-                    app_id, app_metadata.get('sheets')))
+                    app_metadata.get('sheets')))
 
         return assembled_entries
 
@@ -107,23 +105,21 @@ class AssembledEntryFactory:
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 
-    def __make_assembled_entries_for_sheets(self, app_id, sheets_metadata):
+    def __make_assembled_entries_for_sheets(self, sheets_metadata):
         return [
-            self.__make_assembled_entry_for_sheet(app_id, sheet_metadata)
+            self.__make_assembled_entry_for_sheet(sheet_metadata)
             for sheet_metadata in sheets_metadata
         ] if sheets_metadata else []
 
-    def __make_assembled_entry_for_sheet(self, app_id, sheet_metadata):
+    def __make_assembled_entry_for_sheet(self, sheet_metadata):
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_sheet(
-                app_id, sheet_metadata)
+                sheet_metadata)
 
         tags = []
-        """
         if self.__sheet_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_sheet(
                     self.__sheet_tag_template, sheet_metadata))
-        """
 
         return prepare.AssembledEntryData(entry_id, entry, tags)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -26,69 +26,104 @@ class AssembledEntryFactory:
 
     def __init__(self, project_id, location_id, entry_group_id,
                  user_specified_system, site_url):
+
         self.__datacatalog_entry_factory = datacatalog_entry_factory \
             .DataCatalogEntryFactory(
                 project_id, location_id, entry_group_id, user_specified_system,
                 site_url)
 
+        self.__app_tag_template = None
+        self.__sheet_tag_template = None
+        self.__stream_tag_template = None
+
         self.__datacatalog_tag_factory = \
             datacatalog_tag_factory.DataCatalogTagFactory(site_url)
 
     def make_assembled_entries_list(self, stream_metadata, tag_templates_dict):
-        stream_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_STREAM, tag_templates_dict)
+        self.__initialize_tag_templates(tag_templates_dict)
 
         assembled_entries = [
-            self.__make_assembled_entry_for_stream(stream_metadata,
-                                                   stream_tag_template)
+            self.__make_assembled_entry_for_stream(stream_metadata)
         ]
 
-        app_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_APP, tag_templates_dict)
-
         assembled_entries.extend(
-            self.__make_assembled_entries_for_apps(stream_metadata,
-                                                   app_tag_template))
+            self.__make_assembled_entries_for_apps(
+                stream_metadata.get('apps')))
 
         return assembled_entries
+
+    def __initialize_tag_templates(self, tag_templates_dict):
+        self.__app_tag_template = self.__get_tag_template(
+            constants.TAG_TEMPLATE_ID_APP, tag_templates_dict)
+        self.__sheet_tag_template = self.__get_tag_template(
+            constants.TAG_TEMPLATE_ID_SHEET, tag_templates_dict)
+        self.__stream_tag_template = self.__get_tag_template(
+            constants.TAG_TEMPLATE_ID_STREAM, tag_templates_dict)
 
     @classmethod
     def __get_tag_template(cls, tag_template_id, tag_templates_dict):
         return tag_templates_dict[tag_template_id] \
             if tag_template_id in tag_templates_dict else None
 
-    def __make_assembled_entry_for_stream(self, stream_metadata, tag_template):
+    def __make_assembled_entry_for_stream(self, stream_metadata):
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_stream(
                 stream_metadata)
 
         tags = []
-        if tag_template:
+        if self.__stream_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_stream(
-                    tag_template, stream_metadata))
+                    self.__stream_tag_template, stream_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 
-    def __make_assembled_entries_for_apps(self, stream_metadata, tag_template):
-        apps_metadata = stream_metadata.get('apps')
+    def __make_assembled_entries_for_apps(self, apps_metadata):
+        assembled_entries = []
 
         if not apps_metadata:
-            return []
+            return assembled_entries
 
-        return [
-            self.__make_assembled_entry_for_app(app_metadata, tag_template)
-            for app_metadata in apps_metadata
-        ]
+        for app_metadata in apps_metadata:
+            assembled_entries.append(
+                self.__make_assembled_entry_for_app(app_metadata))
 
-    def __make_assembled_entry_for_app(self, app_metadata, tag_template):
+            app_id = app_metadata.get('id')
+            assembled_entries.extend(
+                self.__make_assembled_entries_for_sheets(
+                    app_id, app_metadata.get('sheets')))
+
+        return assembled_entries
+
+    def __make_assembled_entry_for_app(self, app_metadata):
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_app(app_metadata)
 
         tags = []
-        if tag_template:
+        if self.__app_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_app(
-                    tag_template, app_metadata))
+                    self.__app_tag_template, app_metadata))
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)
+
+    def __make_assembled_entries_for_sheets(self, app_id, sheets_metadata):
+        return [
+            self.__make_assembled_entry_for_sheet(app_id, sheet_metadata)
+            for sheet_metadata in sheets_metadata
+        ] if sheets_metadata else []
+
+    def __make_assembled_entry_for_sheet(self, app_id, sheet_metadata):
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_sheet(
+                app_id, sheet_metadata)
+
+        tags = []
+        """
+        if self.__sheet_tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.make_tag_for_sheet(
+                    self.__sheet_tag_template, sheet_metadata))
+        """
 
         return prepare.AssembledEntryData(entry_id, entry, tags)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -53,17 +53,12 @@ class AssembledEntryFactory:
         return assembled_entries
 
     def __initialize_tag_templates(self, tag_templates_dict):
-        self.__app_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_APP, tag_templates_dict)
-        self.__sheet_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_SHEET, tag_templates_dict)
-        self.__stream_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_STREAM, tag_templates_dict)
-
-    @classmethod
-    def __get_tag_template(cls, tag_template_id, tag_templates_dict):
-        return tag_templates_dict[tag_template_id] \
-            if tag_template_id in tag_templates_dict else None
+        self.__app_tag_template = \
+            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_APP)
+        self.__sheet_tag_template = \
+            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_SHEET)
+        self.__stream_tag_template = \
+            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_STREAM)
 
     def __make_assembled_entry_for_stream(self, stream_metadata):
         entry_id, entry = \

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -19,6 +19,7 @@ ENTRY_ID_MAX_LENGTH = 64
 # The below asset type specific strings are appended to the standard
 # ENTRY_ID_PREFIX when generating Qlik Entry IDs.
 ENTRY_ID_PART_APP = 'app_'
+ENTRY_ID_PART_SHEET = 'sht_'
 ENTRY_ID_PART_STREAM = 'str_'
 # This is the common prefix for all Qlik Entries.
 ENTRY_ID_PREFIX = 'qlik_'
@@ -28,14 +29,19 @@ ENTRY_ID_PREFIX = 'qlik_'
 # of this constant.
 NO_PREFIX_ENTRY_ID_MAX_LENGTH = ENTRY_ID_MAX_LENGTH - len(ENTRY_ID_PREFIX)
 
-# The ID of the Tag Template created to store additional metadata for
+# The ID of the Tag Template created to store additional metadata for the
 # App-related Entries.
 TAG_TEMPLATE_ID_APP = 'qlik_app_metadata'
-# The ID of the Tag Template created to store additional metadata for
+# The ID of the Tag Template created to store additional metadata for the
+# Sheet-related Entries.
+TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'
+# The ID of the Tag Template created to store additional metadata for the
 # Stream-related Entries.
 TAG_TEMPLATE_ID_STREAM = 'qlik_stream_metadata'
 
-# The user specified type of App-related Entries.
+# The user specified type of the App-related Entries.
 USER_SPECIFIED_TYPE_APP = 'app'
-# The user specified type of Stream-related Entries.
+# The user specified type of the Sheet-related Entries.
+USER_SPECIFIED_TYPE_SHEET = 'sheet'
+# The user specified type of the Stream-related Entries.
 USER_SPECIFIED_TYPE_STREAM = 'stream'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -49,8 +49,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         entry.display_name = self._format_display_name(
             app_metadata.get("name"))
-        entry.description = self._format_display_name(
-            app_metadata.get("description"))
+        entry.description = app_metadata.get("description")
 
         entry.linked_resource = f'{self.__site_url}' \
                                 f'/sense/app/{app_metadata.get("id")}'
@@ -63,8 +62,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.source_system_timestamps.create_time = create_timestamp
 
         modified_date = app_metadata.get('modifiedDate')
-        resolved_modified_date = modified_date \
-            if modified_date else app_metadata.get('createdDate')
+        resolved_modified_date = modified_date or app_metadata.get(
+            'createdDate')
         modified_datetime = datetime.strptime(
             resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
         update_timestamp = timestamp_pb2.Timestamp()
@@ -99,8 +98,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.source_system_timestamps.create_time = create_timestamp
 
         modified_date = stream_metadata.get('modifiedDate')
-        resolved_modified_date = modified_date \
-            if modified_date else stream_metadata.get('createdDate')
+        resolved_modified_date = modified_date or stream_metadata.get(
+            'createdDate')
         modified_datetime = datetime.strptime(
             resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
         update_timestamp = timestamp_pb2.Timestamp()
@@ -109,13 +108,41 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
-    def make_entry_for_sheet(self, sheet_metadata):
+    def make_entry_for_sheet(self, app_id, sheet_metadata):
         entry = datacatalog.Entry()
 
+        sheet_id = sheet_metadata.get('qInfo').get('qId')
         generated_id = self.__format_id(constants.ENTRY_ID_PART_STREAM,
-                                        sheet_metadata.get('id'))
+                                        sheet_id)
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
 
-        return
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_SHEET
+
+        q_meta = sheet_metadata.get('qMeta')
+        entry.display_name = self._format_display_name(q_meta.get("title"))
+        entry.description = q_meta.get("description")
+
+        entry.linked_resource = f'{self.__site_url}' \
+                                f'/sense/app/{app_id}/sheet/{sheet_id}'
+
+        created_datetime = datetime.strptime(
+            q_meta.get('createdDate'), self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        create_timestamp = timestamp_pb2.Timestamp()
+        create_timestamp.FromDatetime(created_datetime)
+        entry.source_system_timestamps.create_time = create_timestamp
+
+        modified_date = q_meta.get('modifiedDate')
+        resolved_modified_date = modified_date or q_meta.get('createdDate')
+        modified_datetime = datetime.strptime(
+            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        update_timestamp = timestamp_pb2.Timestamp()
+        update_timestamp.FromDatetime(modified_datetime)
+        entry.source_system_timestamps.update_time = update_timestamp
+
+        return generated_id, entry
 
     @classmethod
     def __format_id(cls, source_type_identifier, source_id):

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -72,7 +72,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
-    def make_entry_for_sheet(self, app_id, sheet_metadata):
+    def make_entry_for_sheet(self, sheet_metadata):
         entry = datacatalog.Entry()
 
         sheet_id = sheet_metadata.get('qInfo').get('qId')
@@ -90,7 +90,9 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.description = q_meta.get("description")
 
         entry.linked_resource = f'{self.__site_url}' \
-                                f'/sense/app/{app_id}/sheet/{sheet_id}'
+                                f'/sense/app/' \
+                                f'{sheet_metadata.get("app").get("id")}' \
+                                f'/sheet/{sheet_id}'
 
         created_datetime = datetime.strptime(
             q_meta.get('createdDate'), self.__INCOMING_TIMESTAMP_UTC_FORMAT)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -109,6 +109,14 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
+    def make_entry_for_sheet(self, sheet_metadata):
+        entry = datacatalog.Entry()
+
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_STREAM,
+                                        sheet_metadata.get('id'))
+
+        return
+
     @classmethod
     def __format_id(cls, source_type_identifier, source_id):
         no_prefix_fmt_id = cls._format_id(

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -72,6 +72,42 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
+    def make_entry_for_sheet(self, app_id, sheet_metadata):
+        entry = datacatalog.Entry()
+
+        sheet_id = sheet_metadata.get('qInfo').get('qId')
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_SHEET,
+                                        sheet_id)
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_SHEET
+
+        q_meta = sheet_metadata.get('qMeta')
+        entry.display_name = self._format_display_name(q_meta.get("title"))
+        entry.description = q_meta.get("description")
+
+        entry.linked_resource = f'{self.__site_url}' \
+                                f'/sense/app/{app_id}/sheet/{sheet_id}'
+
+        created_datetime = datetime.strptime(
+            q_meta.get('createdDate'), self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        create_timestamp = timestamp_pb2.Timestamp()
+        create_timestamp.FromDatetime(created_datetime)
+        entry.source_system_timestamps.create_time = create_timestamp
+
+        modified_date = q_meta.get('modifiedDate')
+        resolved_modified_date = modified_date or q_meta.get('createdDate')
+        modified_datetime = datetime.strptime(
+            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        update_timestamp = timestamp_pb2.Timestamp()
+        update_timestamp.FromDatetime(modified_datetime)
+        entry.source_system_timestamps.update_time = update_timestamp
+
+        return generated_id, entry
+
     def make_entry_for_stream(self, stream_metadata):
         entry = datacatalog.Entry()
 
@@ -100,42 +136,6 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         modified_date = stream_metadata.get('modifiedDate')
         resolved_modified_date = modified_date or stream_metadata.get(
             'createdDate')
-        modified_datetime = datetime.strptime(
-            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
-        update_timestamp = timestamp_pb2.Timestamp()
-        update_timestamp.FromDatetime(modified_datetime)
-        entry.source_system_timestamps.update_time = update_timestamp
-
-        return generated_id, entry
-
-    def make_entry_for_sheet(self, app_id, sheet_metadata):
-        entry = datacatalog.Entry()
-
-        sheet_id = sheet_metadata.get('qInfo').get('qId')
-        generated_id = self.__format_id(constants.ENTRY_ID_PART_STREAM,
-                                        sheet_id)
-        entry.name = datacatalog.DataCatalogClient.entry_path(
-            self.__project_id, self.__location_id, self.__entry_group_id,
-            generated_id)
-
-        entry.user_specified_system = self.__user_specified_system
-        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_SHEET
-
-        q_meta = sheet_metadata.get('qMeta')
-        entry.display_name = self._format_display_name(q_meta.get("title"))
-        entry.description = q_meta.get("description")
-
-        entry.linked_resource = f'{self.__site_url}' \
-                                f'/sense/app/{app_id}/sheet/{sheet_id}'
-
-        created_datetime = datetime.strptime(
-            q_meta.get('createdDate'), self.__INCOMING_TIMESTAMP_UTC_FORMAT)
-        create_timestamp = timestamp_pb2.Timestamp()
-        create_timestamp.FromDatetime(created_datetime)
-        entry.source_system_timestamps.create_time = create_timestamp
-
-        modified_date = q_meta.get('modifiedDate')
-        resolved_modified_date = modified_date or q_meta.get('createdDate')
         modified_datetime = datetime.strptime(
             resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
         update_timestamp = timestamp_pb2.Timestamp()

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -47,12 +47,12 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'modified_by_username',
                                app_metadata.get('modifiedByUserName'))
 
+        self._set_bool_field(tag, 'published', app_metadata.get('published'))
+
         self._set_timestamp_field(
             tag, 'publish_time',
             datetime.strptime(app_metadata.get('publishTime'),
                               self.__INCOMING_TIMESTAMP_UTC_FORMAT))
-
-        self._set_bool_field(tag, 'published', app_metadata.get('published'))
 
         last_reload_time = app_metadata.get('lastReloadTime')
         if last_reload_time:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -37,7 +37,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         if owner:
             owner_user_dir = owner.get('userDirectory')
             owner_user_id = owner.get('userId')
-
             if owner_user_dir and owner_user_id:
                 self._set_string_field(tag, 'owner_username',
                                        f'{owner_user_dir}\\\\{owner_user_id}')
@@ -49,10 +48,12 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         self._set_bool_field(tag, 'published', app_metadata.get('published'))
 
-        self._set_timestamp_field(
-            tag, 'publish_time',
-            datetime.strptime(app_metadata.get('publishTime'),
-                              self.__INCOMING_TIMESTAMP_UTC_FORMAT))
+        publish_time = app_metadata.get('publishTime')
+        if publish_time:
+            self._set_timestamp_field(
+                tag, 'publish_time',
+                datetime.strptime(publish_time,
+                                  self.__INCOMING_TIMESTAMP_UTC_FORMAT))
 
         last_reload_time = app_metadata.get('lastReloadTime')
         if last_reload_time:
@@ -90,6 +91,52 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'schema_path',
                                app_metadata.get('schemaPath'))
 
+        self._set_string_field(tag, 'site_url', self.__site_url)
+
+        return tag
+
+    def make_tag_for_sheet(self, tag_template, sheet_metadata):
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        self._set_string_field(tag, 'id',
+                               sheet_metadata.get('qInfo').get('qId'))
+
+        q_meta = sheet_metadata.get('qMeta')
+        owner = q_meta.get('owner')
+        if owner:
+            owner_user_dir = owner.get('userDirectory')
+            owner_user_id = owner.get('userId')
+            if owner_user_dir and owner_user_id:
+                self._set_string_field(tag, 'owner_username',
+                                       f'{owner_user_dir}\\\\{owner_user_id}')
+
+            self._set_string_field(tag, 'owner_name', owner.get('name'))
+
+        self._set_bool_field(tag, 'published', q_meta.get('published'))
+
+        publish_time = q_meta.get('publishTime')
+        if publish_time:
+            self._set_timestamp_field(
+                tag, 'publish_time',
+                datetime.strptime(publish_time,
+                                  self.__INCOMING_TIMESTAMP_UTC_FORMAT))
+
+        self._set_bool_field(tag, 'approved', q_meta.get('approved'))
+
+        app_metadata = sheet_metadata.get('app')
+        if app_metadata:
+            self._set_string_field(tag, 'app_id', app_metadata.get('id'))
+            self._set_string_field(tag, 'app_name', app_metadata.get('name'))
+
+        self._set_string_field(tag, 'source_object',
+                               q_meta.get('sourceObject'))
+
+        self._set_string_field(tag, 'draft_object', q_meta.get('draftObject'))
+
+        self._set_string_field(tag, 'site_url', self.__site_url)
+
         return tag
 
     def make_tag_for_stream(self, tag_template, stream_metadata):
@@ -103,7 +150,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         if owner:
             owner_user_dir = owner.get('userDirectory')
             owner_user_id = owner.get('userId')
-
             if owner_user_dir and owner_user_id:
                 self._set_string_field(tag, 'owner_username',
                                        f'{owner_user_dir}\\\\{owner_user_id}')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -53,11 +53,11 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        self.__STRING_TYPE,
                                        'Username who modified it')
 
-        self._add_primitive_type_field(tag_template, 'publish_time',
-                                       self.__TIMESTAMP_TYPE, 'Publish time')
-
         self._add_primitive_type_field(tag_template, 'published',
                                        self.__BOOL_TYPE, 'Published')
+
+        self._add_primitive_type_field(tag_template, 'publish_time',
+                                       self.__TIMESTAMP_TYPE, 'Publish time')
 
         self._add_primitive_type_field(tag_template, 'last_reload_time',
                                        self.__TIMESTAMP_TYPE,
@@ -93,6 +93,52 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         self._add_primitive_type_field(tag_template, 'schema_path',
                                        self.__STRING_TYPE, 'Schema path')
+
+        return tag_template
+
+    def make_tag_template_for_sheet(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_SHEET)
+
+        tag_template.display_name = 'Qlik Sheet Metadata'
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_primitive_type_field(tag_template, 'owner_username',
+                                       self.__STRING_TYPE, 'Owner username')
+
+        self._add_primitive_type_field(tag_template, 'owner_name',
+                                       self.__STRING_TYPE, 'Owner name')
+
+        self._add_primitive_type_field(tag_template, 'published',
+                                       self.__BOOL_TYPE, 'Published')
+
+        self._add_primitive_type_field(tag_template, 'publish_time',
+                                       self.__TIMESTAMP_TYPE, 'Publish time')
+
+        self._add_primitive_type_field(tag_template, 'approved',
+                                       self.__BOOL_TYPE, 'Approved')
+
+        self._add_primitive_type_field(tag_template, 'app_id',
+                                       self.__STRING_TYPE, 'App Id')
+
+        self._add_primitive_type_field(tag_template, 'app_name',
+                                       self.__STRING_TYPE, 'App name')
+
+        self._add_primitive_type_field(tag_template, 'app_entry',
+                                       self.__STRING_TYPE,
+                                       'Data Catalog Entry for the App')
+
+        self._add_primitive_type_field(tag_template, 'source_object',
+                                       self.__STRING_TYPE, 'Source object')
+
+        self._add_primitive_type_field(tag_template, 'draft_object',
+                                       self.__STRING_TYPE, 'Draft object')
 
         return tag_template
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -94,6 +94,10 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self._add_primitive_type_field(tag_template, 'schema_path',
                                        self.__STRING_TYPE, 'Schema path')
 
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
+
         return tag_template
 
     def make_tag_template_for_sheet(self):
@@ -139,6 +143,10 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         self._add_primitive_type_field(tag_template, 'draft_object',
                                        self.__STRING_TYPE, 'Draft object')
+
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
 
         return tag_template
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -21,19 +21,33 @@ from google.datacatalog_connectors.qlik.prepare import constants
 
 class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     __APP = constants.USER_SPECIFIED_TYPE_APP
+    __SHEET = constants.USER_SPECIFIED_TYPE_SHEET
     __STREAM = constants.USER_SPECIFIED_TYPE_STREAM
 
-    def fulfill_tag_fields(self, assembled_entries_data):
-        resolvers = (self.__resolve_app_mappings,)
+    def fulfill_tag_fields(self, assembled_entries):
+        resolvers = (
+            self.__resolve_app_mappings,
+            self.__resolve_sheet_mappings,
+        )
 
-        self._fulfill_tag_fields(assembled_entries_data, resolvers)
+        self._fulfill_tag_fields(assembled_entries, resolvers)
 
     @classmethod
-    def __resolve_app_mappings(cls, assembled_entries_data, id_name_pairs):
-        for assembled_entry_data in assembled_entries_data:
-            entry = assembled_entry_data.entry
-            if not entry.user_specified_type == cls.__APP:
-                continue
+    def __resolve_app_mappings(cls, assembled_entries, id_name_pairs):
+        app_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__APP
+        ]
+        for assembled_entry in app_assembled_entries:
+            cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
+                                   'stream_entry', id_name_pairs)
 
-            cls._map_related_entry(assembled_entry_data, cls.__STREAM,
-                                   'stream_id', 'stream_entry', id_name_pairs)
+    @classmethod
+    def __resolve_sheet_mappings(cls, assembled_entries, id_name_pairs):
+        sheet_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__SHEET
+        ]
+        for assembled_entry in sheet_assembled_entries:
+            cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
+                                   'app_entry', id_name_pairs)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -43,7 +43,7 @@ class MetadataScraper:
             logging.info(
                 '    - %s :: %s [%s]',
                 app.get('stream').get('name')
-                if app.get('published') else 'NOT PUBLIC!', app.get('name'),
+                if app.get('published') else 'NOT PUBLISHED!', app.get('name'),
                 app.get('id'))
 
         return apps
@@ -68,7 +68,7 @@ class MetadataScraper:
         for sheet in sheets:
             q_meta = sheet.get('qMeta')
             logging.info('    - %s%s [%s]',
-                         '' if q_meta.get('published') else 'NOT PUBLIC! ',
+                         '' if q_meta.get('published') else 'NOT PUBLISHED! ',
                          q_meta.get('title'),
                          sheet.get('qInfo').get('qId'))
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -41,9 +41,9 @@ class MetadataScraper:
         logging.info('  %s Apps found:', len(apps))
         for app in apps:
             logging.info(
-                '    - %s/%s [%s]',
+                '    - %s :: %s [%s]',
                 app.get('stream').get('name')
-                if app.get('published') else 'NOT PUBLISHED', app.get('name'),
+                if app.get('published') else 'NOT PUBLIC!', app.get('name'),
                 app.get('id'))
 
         return apps
@@ -59,15 +59,17 @@ class MetadataScraper:
         return streams
 
     def scrape_sheets(self, app_metadata):
-        self.__log_scrape_start('Scraping Sheets from "%s"',
+        self.__log_scrape_start('Scraping Sheets from the "%s" App',
                                 app_metadata.get('name'))
-        sheets = self.__engine_api_helper.get_sheets(app_metadata.get('id'))
-        sheets = sheets if sheets else []
+        sheets = self.__engine_api_helper.get_sheets(
+            app_metadata.get('id')) or []
 
         logging.info('  %s Sheets found:', len(sheets))
         for sheet in sheets:
-            logging.info('    - %s [%s]',
-                         sheet.get('qMeta').get('title'),
+            q_meta = sheet.get('qMeta')
+            logging.info('    - %s%s [%s]',
+                         '' if q_meta.get('published') else 'NOT PUBLIC! ',
+                         q_meta.get('title'),
                          sheet.get('qInfo').get('qId'))
 
         return sheets

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from google.datacatalog_connectors.qlik.scrape import \
     engine_api_helper, repository_services_api_helper
 
@@ -33,11 +35,45 @@ class MetadataScraper:
             server_address, ad_domain, username, password)
 
     def scrape_all_apps(self):
-        return self.__qrs_api_helper.get_full_app_list()
+        self.__log_scrape_start('Scraping all Apps...')
+        apps = self.__qrs_api_helper.get_full_app_list()
+
+        logging.info('  %s Apps found:', len(apps))
+        for app in apps:
+            logging.info(
+                '    - %s/%s [%s]',
+                app.get('stream').get('name')
+                if app.get('published') else 'NOT PUBLISHED', app.get('name'),
+                app.get('id'))
+
+        return apps
 
     def scrape_all_streams(self):
-        return self.__qrs_api_helper.get_full_stream_list()
+        self.__log_scrape_start('Scraping all Streams...')
+        streams = self.__qrs_api_helper.get_full_stream_list()
+
+        logging.info('  %s Streams found:', len(streams))
+        for stream in streams:
+            logging.info('    - %s [%s]', stream.get('name'), stream.get('id'))
+
+        return streams
 
     def scrape_sheets(self, app_metadata):
+        self.__log_scrape_start('Scraping Sheets from "%s"',
+                                app_metadata.get('name'))
         sheets = self.__engine_api_helper.get_sheets(app_metadata.get('id'))
-        return sheets if sheets else []
+        sheets = sheets if sheets else []
+
+        logging.info('  %s Sheets found:', len(sheets))
+        for sheet in sheets:
+            logging.info('    - %s [%s]',
+                         sheet.get('qMeta').get('title'),
+                         sheet.get('qInfo').get('qId'))
+
+        return sheets
+
+    @classmethod
+    def __log_scrape_start(cls, message, *args):
+        logging.info('')
+        logging.info(message, *args)
+        logging.info('-------------------------------------------------')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -102,47 +102,47 @@ class MetadataSynchronizer:
         all_streams = self.__metadata_scraper.scrape_all_streams()
         all_apps = self.__metadata_scraper.scrape_all_apps()
 
-        # Being not public means the app is a work in progress, so it can be
+        # Not being published means the app is a work in progress, so it can be
         # skipped.
-        public_apps = [app for app in all_apps if app.get('published')]
+        published_apps = [app for app in all_apps if app.get('published')]
 
-        for app in public_apps:
+        for app in published_apps:
             # The 'sheets' field is not available in the scrape apps API
             # response, so it is injected into the returned metadata object to
             # turn further processing more efficient.
-            app['sheets'] = self.__scrape_public_sheets(app)
+            app['sheets'] = self.__scrape_published_sheets(app)
 
         self.__assemble_streams_metadata_from_flat_lists(
-            all_streams, public_apps)
+            all_streams, published_apps)
 
         return all_streams
 
-    def __scrape_public_sheets(self, app):
-        """Scrape metadata from all the public Sheets the current user has
+    def __scrape_published_sheets(self, app):
+        """Scrape metadata from all the published Sheets the current user has
         access to within the given App.
 
         :return: A ``list`` of sheet metadata.
         """
         sheets = self.__metadata_scraper.scrape_sheets(app)
-        # Being not public means the sheet is a work in progress, so it can be
-        # skipped.
-        public_sheets = [
+        # Not being published means the sheet is a work in progress, so it can
+        # be skipped.
+        published_sheets = [
             sheet for sheet in sheets if sheet.get('qMeta').get('published')
         ]
         # The 'app' field is not available in the scrape sheets API response,
         # so it is injected into the returned metadata object to turn further
         # processing more efficient.
-        for sheet in public_sheets:
+        for sheet in published_sheets:
             sheet['app'] = {
                 'id': app.get('id'),
                 'name': app.get('name'),
             }
 
-        return public_sheets
+        return published_sheets
 
     @classmethod
     def __assemble_streams_metadata_from_flat_lists(cls, all_streams,
-                                                    public_apps):
+                                                    published_apps):
         """Assemble the streams metadata from the given flat asset lists.
 
         """
@@ -151,7 +151,7 @@ class MetadataSynchronizer:
         for stream in all_streams:
             streams_dict[stream.get('id')] = stream
 
-        for app in public_apps:
+        for app in published_apps:
             stream_id = app.get('stream').get('id')
 
             # The 'apps' field is not available in the scrape streams API

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -103,11 +103,10 @@ class MetadataSynchronizer:
         all_apps = self.__metadata_scraper.scrape_all_apps()
 
         for app in all_apps:
-            logging.info('')
-            logging.info(' . Scraping Sheets from "%s"', app.get('name'))
+            # The 'sheets' field is not available in the API response but is
+            # injected into the returned metadata object to make further
+            # processing more efficient.
             app['sheets'] = self.__metadata_scraper.scrape_sheets(app)
-            logging.info(' .. The App has %d Sheets', len(app['sheets']))
-        logging.info('')
 
         self.__assemble_stream_metadata_from_flat_lists(all_streams, all_apps)
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -94,35 +94,51 @@ class MetadataSynchronizer:
         logging.info('==== DONE ========================================')
 
     def __scrape_streams(self):
-        """Scrape metadata from all streams the current user has access to.
-        Streams metadata include nested objects such as apps.
+        """Scrape metadata from all the Streams the current user has access to.
+        The returned metadata include nested objects such as Apps and Sheets.
 
         :return: A ``list`` of stream metadata.
         """
         all_streams = self.__metadata_scraper.scrape_all_streams()
         all_apps = self.__metadata_scraper.scrape_all_apps()
 
-        # Not being public means the app is a work in progress, so it can be
+        # Being not public means the app is a work in progress, so it can be
         # skipped.
         public_apps = [app for app in all_apps if app.get('published')]
 
         for app in public_apps:
-            sheets = self.__metadata_scraper.scrape_sheets(app)
-            # Not being public means the sheet is a work in progress, so it can
-            # be skipped.
-            public_sheets = [
-                sheet for sheet in sheets
-                if sheet.get('qMeta').get('published')
-            ]
-            # The 'sheets' field is not available in the API response but is
-            # injected into the returned metadata object to make further
-            # processing more efficient.
-            app['sheets'] = public_sheets
+            # The 'sheets' field is not available in the scrape apps API
+            # response, so it is injected into the returned metadata object to
+            # turn further processing more efficient.
+            app['sheets'] = self.__scrape_public_sheets(app)
 
         self.__assemble_streams_metadata_from_flat_lists(
             all_streams, public_apps)
 
         return all_streams
+
+    def __scrape_public_sheets(self, app):
+        """Scrape metadata from all the public Sheets the current user has
+        access to within the given App.
+
+        :return: A ``list`` of sheet metadata.
+        """
+        sheets = self.__metadata_scraper.scrape_sheets(app)
+        # Being not public means the sheet is a work in progress, so it can be
+        # skipped.
+        public_sheets = [
+            sheet for sheet in sheets if sheet.get('qMeta').get('published')
+        ]
+        # The 'app' field is not available in the scrape sheets API response,
+        # so it is injected into the returned metadata object to turn further
+        # processing more efficient.
+        for sheet in public_sheets:
+            sheet['app'] = {
+                'id': app.get('id'),
+                'name': app.get('name'),
+            }
+
+        return public_sheets
 
     @classmethod
     def __assemble_streams_metadata_from_flat_lists(cls, all_streams,
@@ -138,9 +154,9 @@ class MetadataSynchronizer:
         for app in public_apps:
             stream_id = app.get('stream').get('id')
 
-            # The 'apps' field is not available in the API response but is
-            # injected into the returned metadata object to make further
-            # processing more efficient.
+            # The 'apps' field is not available in the scrape streams API
+            # response, so it is injected into the returned metadata object to
+            # turn further processing more efficient.
             if not streams_dict[stream_id].get('apps'):
                 streams_dict[stream_id]['apps'] = []
 
@@ -152,6 +168,8 @@ class MetadataSynchronizer:
         return {
             constants.TAG_TEMPLATE_ID_APP:
                 self.__tag_template_factory.make_tag_template_for_app(),
+            constants.TAG_TEMPLATE_ID_SHEET:
+                self.__tag_template_factory.make_tag_template_for_sheet(),
             constants.TAG_TEMPLATE_ID_STREAM:
                 self.__tag_template_factory.make_tag_template_for_stream(),
         }

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -120,8 +120,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         sheet_assembled_entry = assembled_entries[2]
         tags = sheet_assembled_entry.tags
 
-        self.assertEqual(0, len(tags))
-        # self.__tag_factory.make_tag_for_sheet.assert_called_once()
+        self.assertEqual(1, len(tags))
+        self.__tag_factory.make_tag_for_sheet.assert_called_once()
 
     @classmethod
     def __make_fake_stream(cls):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -17,8 +17,6 @@
 import unittest
 from unittest import mock
 
-from google.cloud import datacatalog
-
 from google.datacatalog_connectors.qlik import prepare
 
 
@@ -49,10 +47,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
     def test_make_assembled_entries_list_should_process_streams(self):
         entry_factory = self.__entry_factory
-        entry_factory.make_entry_for_stream = self.__mock_make_entry
-
-        tag_factory = self.__tag_factory
-        tag_factory.make_tag_for_stream = self.__mock_make_tag
+        entry_factory.make_entry_for_stream.return_value = ('id', {})
 
         tag_templates_dict = {
             'qlik_stream_metadata': {
@@ -65,25 +60,18 @@ class AssembledEntryFactoryTest(unittest.TestCase):
                 self.__make_fake_stream(), tag_templates_dict)
 
         self.assertEqual(1, len(assembled_entries))
+        entry_factory.make_entry_for_stream.assert_called_once()
 
         stream_assembled_entry = assembled_entries[0]
-
-        self.assertEqual('test_stream', stream_assembled_entry.entry_id)
-        self.assertEqual('fake_entries/test_stream',
-                         stream_assembled_entry.entry.name)
-
         tags = stream_assembled_entry.tags
 
         self.assertEqual(1, len(tags))
-        self.assertEqual('tagTemplates/qlik_stream_metadata', tags[0].template)
+        self.__tag_factory.make_tag_for_stream.assert_called_once()
 
     def test_make_assembled_entries_list_should_process_apps(self):
         entry_factory = self.__entry_factory
-        entry_factory.make_entry_for_stream = self.__mock_make_entry
-        entry_factory.make_entry_for_app = self.__mock_make_entry
-
-        tag_factory = self.__tag_factory
-        tag_factory.make_tag_for_app = self.__mock_make_tag
+        entry_factory.make_entry_for_stream.return_value = ('id', {})
+        entry_factory.make_entry_for_app.return_value = ('id', {})
 
         tag_templates_dict = {
             'qlik_app_metadata': {
@@ -91,50 +79,73 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             }
         }
 
+        fake_stream = self.__make_fake_stream()
+        fake_stream['apps'].append(self.__make_fake_app())
         assembled_entries = \
             self.__factory.make_assembled_entries_list(
-                self.__make_fake_stream_with_apps(), tag_templates_dict)
+                fake_stream, tag_templates_dict)
 
         self.assertEqual(2, len(assembled_entries))
+        entry_factory.make_entry_for_stream.assert_called_once()
 
         app_assembled_entry = assembled_entries[1]
-
-        self.assertEqual('test_app', app_assembled_entry.entry_id)
-        self.assertEqual('fake_entries/test_app',
-                         app_assembled_entry.entry.name)
-
         tags = app_assembled_entry.tags
 
         self.assertEqual(1, len(tags))
-        self.assertEqual('tagTemplates/qlik_app_metadata', tags[0].template)
+        self.__tag_factory.make_tag_for_app.assert_called_once()
+
+    def test_make_assembled_entries_list_should_process_sheets(self):
+        entry_factory = self.__entry_factory
+        entry_factory.make_entry_for_stream.return_value = ('id', {})
+        entry_factory.make_entry_for_app.return_value = ('id', {})
+        entry_factory.make_entry_for_sheet.return_value = ('id', {})
+
+        tag_templates_dict = {
+            'qlik_sheet_metadata': {
+                'name': 'tagTemplates/qlik_sheet_metadata',
+            }
+        }
+
+        fake_stream = self.__make_fake_stream()
+        fake_app = self.__make_fake_app()
+        fake_app['sheets'].append(self.__make_fake_sheet())
+        fake_stream['apps'].append(fake_app)
+        assembled_entries = \
+            self.__factory.make_assembled_entries_list(
+                fake_stream, tag_templates_dict)
+
+        self.assertEqual(3, len(assembled_entries))
+        entry_factory.make_entry_for_sheet.assert_called_once()
+
+        sheet_assembled_entry = assembled_entries[2]
+        tags = sheet_assembled_entry.tags
+
+        self.assertEqual(0, len(tags))
+        # self.__tag_factory.make_tag_for_sheet.assert_called_once()
 
     @classmethod
     def __make_fake_stream(cls):
         return {
             'id': 'test_stream',
             'name': 'Test stream',
+            'apps': [],
         }
 
     @classmethod
-    def __make_fake_stream_with_apps(cls):
+    def __make_fake_app(cls):
         return {
-            'id': 'test_stream',
-            'name': 'Test stream',
-            'apps': [{
-                'id': 'test_app',
-                'name': 'Test app',
-            }]
+            'id': 'test_app',
+            'name': 'Test app',
+            'sheets': [],
         }
 
     @classmethod
-    def __mock_make_entry(cls, asset):
-        entry = datacatalog.Entry()
-        entry_id = asset.get('id')
-        entry.name = f'fake_entries/{entry_id}'
-        return entry_id, entry
-
-    @classmethod
-    def __mock_make_tag(cls, tag_template_dict, asset):
-        tag = datacatalog.Tag()
-        tag.template = tag_template_dict['name']
-        return tag
+    def __make_fake_sheet(cls):
+        return {
+            'qInfo': {
+                'qId': 'test_sheet',
+            },
+            'qMeta': {
+                'title': 'Test sheet',
+            },
+        }

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -98,6 +98,68 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+    def test_make_entry_for_sheet_should_set_all_available_fields(self):
+        metadata = {
+            'qInfo': {
+                'qId': 'a123-b456',
+            },
+            'qMeta': {
+                'title': 'Test sheet',
+                'description': 'Description of the Test sheet',
+                'createdDate': '2019-09-12T16:30:00.005Z',
+                'modifiedDate': '2019-09-12T16:31:00.005Z',
+            },
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_sheet(
+            'app-id', metadata)
+        self.assertEqual('qlik_sht_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'qlik_sht_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('sheet', entry.user_specified_type)
+        self.assertEqual('Test sheet', entry.display_name)
+        self.assertEqual('Description of the Test sheet', entry.description)
+        self.assertEqual(
+            'https://test.server.com'
+            '/sense/app/app-id/sheet/a123-b456', entry.linked_resource)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_sheet_should_use_created_on_missing_modified_date(
+            self):
+
+        metadata = {
+            'qInfo': {
+                'qId': 'a123-b456',
+            },
+            'qMeta': {
+                'createdDate': '2019-09-12T16:30:00.005Z',
+            },
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_sheet(
+            'app-id', metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
     def test_make_entry_for_stream_should_set_all_available_fields(self):
         metadata = {
             'id': 'a123-b456',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -57,6 +57,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_app(metadata)
+
         self.assertEqual('qlik_app_a123_b456', entry_id)
 
         self.assertEqual(
@@ -109,10 +110,13 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 'createdDate': '2019-09-12T16:30:00.005Z',
                 'modifiedDate': '2019-09-12T16:31:00.005Z',
             },
+            'app': {
+                'id': 'app-id'
+            },
         }
 
-        entry_id, entry = self.__factory.make_entry_for_sheet(
-            'app-id', metadata)
+        entry_id, entry = self.__factory.make_entry_for_sheet(metadata)
+
         self.assertEqual('qlik_sht_a123_b456', entry_id)
 
         self.assertEqual(
@@ -149,10 +153,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'qMeta': {
                 'createdDate': '2019-09-12T16:30:00.005Z',
             },
+            'app': {
+                'id': 'app-id'
+            },
         }
 
-        entry_id, entry = self.__factory.make_entry_for_sheet(
-            'app-id', metadata)
+        entry_id, entry = self.__factory.make_entry_for_sheet(metadata)
 
         created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
                                              self.__DATETIME_FORMAT)
@@ -169,6 +175,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_stream(metadata)
+
         self.assertEqual('qlik_str_a123_b456', entry_id)
 
         self.assertEqual(

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -53,7 +53,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'name': 'Test app',
             'description': 'Description of the Test app',
             'createdDate': '2019-09-12T16:30:00.005Z',
-            'modifiedDate': '2019-09-12T16:30:00.005Z',
+            'modifiedDate': '2019-09-12T16:31:00.005Z',
         }
 
         entry_id, entry = self.__factory.make_entry_for_app(metadata)
@@ -75,6 +75,25 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual(
             created_datetime.timestamp(),
             entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_app_should_use_created_on_missing_modified_date(
+            self):
+
+        metadata = {
+            'id': 'a123-b456',
+            'createdDate': '2019-09-12T16:30:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_app(metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
         self.assertEqual(
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
@@ -84,7 +103,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'id': 'a123-b456',
             'name': 'Test stream',
             'createdDate': '2019-09-12T16:30:00.005Z',
-            'modifiedDate': '2019-09-12T16:30:00.005Z',
+            'modifiedDate': '2019-09-12T16:31:00.005Z',
         }
 
         entry_id, entry = self.__factory.make_entry_for_stream(metadata)
@@ -105,6 +124,25 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual(
             created_datetime.timestamp(),
             entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_stream_should_use_created_on_missing_modified_date(
+            self):
+
+        metadata = {
+            'id': 'a123-b456',
+            'createdDate': '2019-09-12T16:30:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_stream(metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
         self.assertEqual(
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -49,8 +49,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 'name': 'Test user',
             },
             'modifiedByUserName': 'test-directory\\\\test.userid',
-            'publishTime': '2020-11-04T14:49:14.504Z',
             'published': True,
+            'publishTime': '2020-11-04T14:49:14.504Z',
             'lastReloadTime': '2020-11-03T18:13:37.156Z',
             'stream': {
                 'id': 'a123-b456',
@@ -67,6 +67,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         tag = self.__factory.make_tag_for_app(tag_template, metadata)
 
         self.assertEqual('c987-d654', tag.fields['id'].string_value)
+
         self.assertEqual('test-directory\\\\test.userid',
                          tag.fields['owner_username'].string_value)
         self.assertEqual('Test user', tag.fields['owner_name'].string_value)
@@ -74,13 +75,11 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['modified_by_username'].string_value)
 
         self.assertEqual(True, tag.fields['published'].bool_value)
-
         publish_datetime = datetime.strptime('2020-11-04T14:49:14.504+0000',
                                              self.__DATETIME_FORMAT)
         self.assertEqual(
             publish_datetime.timestamp(),
             tag.fields['publish_time'].timestamp_value.timestamp())
-
         last_reload_datetime = datetime.strptime(
             '2020-11-03T18:13:37.156+0000', self.__DATETIME_FORMAT)
         self.assertEqual(
@@ -90,6 +89,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('a123-b456', tag.fields['stream_id'].string_value)
         self.assertEqual('Test stream', tag.fields['stream_name'].string_value)
         self.assertEqual('41.38 MB', tag.fields['file_size'].string_value)
+
         self.assertEqual(
             'https://test.server.com'
             '/appcontent/c987-d654/test-thumbnail.jpg',
@@ -100,6 +100,60 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['migration_hash'].string_value)
         self.assertEqual(1, tag.fields['availability_status'].double_value)
         self.assertEqual('App', tag.fields['schema_path'].string_value)
+
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)
+
+    def test_make_tag_for_sheet_should_set_all_available_fields(self):
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_sheet()
+
+        metadata = {
+            'qInfo': {
+                'qId': 'c987-d654',
+            },
+            'qMeta': {
+                'published': True,
+                'publishTime': '2020-11-04T14:49:14.504Z',
+                'approved': True,
+                'owner': {
+                    'userDirectory': 'test-directory',
+                    'userId': 'test.userid',
+                    'name': 'Test user',
+                },
+                'sourceObject': 'Test source object',
+                'draftObject': 'Test draft object',
+            },
+            'app': {
+                'id': 'a123-b456',
+                'name': 'Test app',
+            },
+        }
+
+        tag = self.__factory.make_tag_for_sheet(tag_template, metadata)
+
+        self.assertEqual('c987-d654', tag.fields['id'].string_value)
+
+        self.assertEqual('test-directory\\\\test.userid',
+                         tag.fields['owner_username'].string_value)
+        self.assertEqual('Test user', tag.fields['owner_name'].string_value)
+
+        self.assertEqual(True, tag.fields['published'].bool_value)
+        publish_datetime = datetime.strptime('2020-11-04T14:49:14.504+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            publish_datetime.timestamp(),
+            tag.fields['publish_time'].timestamp_value.timestamp())
+        self.assertEqual(True, tag.fields['approved'].bool_value)
+
+        self.assertEqual('a123-b456', tag.fields['app_id'].string_value)
+        self.assertEqual('Test app', tag.fields['app_name'].string_value)
+
+        self.assertEqual('Test source object',
+                         tag.fields['source_object'].string_value)
+        self.assertEqual('Test draft object',
+                         tag.fields['draft_object'].string_value)
+
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)
 
@@ -120,10 +174,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         tag = self.__factory.make_tag_for_stream(tag_template, metadata)
 
         self.assertEqual('a123-b456', tag.fields['id'].string_value)
+
         self.assertEqual('test-directory\\\\test.userid',
                          tag.fields['owner_username'].string_value)
         self.assertEqual('Test user', tag.fields['owner_name'].string_value)
         self.assertEqual('test-directory\\\\test.userid',
                          tag.fields['modified_by_username'].string_value)
+
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -73,13 +73,13 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('test-directory\\\\test.userid',
                          tag.fields['modified_by_username'].string_value)
 
+        self.assertEqual(True, tag.fields['published'].bool_value)
+
         publish_datetime = datetime.strptime('2020-11-04T14:49:14.504+0000',
                                              self.__DATETIME_FORMAT)
         self.assertEqual(
             publish_datetime.timestamp(),
             tag.fields['publish_time'].timestamp_value.timestamp())
-
-        self.assertEqual(True, tag.fields['published'].bool_value)
 
         last_reload_datetime = datetime.strptime(
             '2020-11-03T18:13:37.156+0000', self.__DATETIME_FORMAT)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -100,6 +100,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['migration_hash'].string_value)
         self.assertEqual(1, tag.fields['availability_status'].double_value)
         self.assertEqual('App', tag.fields['schema_path'].string_value)
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)
 
     def test_make_tag_for_stream_should_set_all_available_fields(self):
         tag_template = \

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -141,6 +141,11 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual('Schema path',
                          tag_template.fields['schema_path'].display_name)
 
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
     def test_make_tag_template_for_sheet(self):
         tag_template = self.__factory.make_tag_template_for_sheet()
 
@@ -206,6 +211,11 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
             tag_template.fields['draft_object'].type.primitive_type)
         self.assertEqual('Draft object',
                          tag_template.fields['draft_object'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
 
     def test_make_tag_template_for_stream(self):
         tag_template = self.__factory.make_tag_template_for_stream()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -71,16 +71,16 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
             'Username who modified it',
             tag_template.fields['modified_by_username'].display_name)
 
+        self.assertEqual(self.__BOOL_TYPE,
+                         tag_template.fields['published'].type.primitive_type)
+        self.assertEqual('Published',
+                         tag_template.fields['published'].display_name)
+
         self.assertEqual(
             self.__TIMESTAMP_TYPE,
             tag_template.fields['publish_time'].type.primitive_type)
         self.assertEqual('Publish time',
                          tag_template.fields['publish_time'].display_name)
-
-        self.assertEqual(self.__BOOL_TYPE,
-                         tag_template.fields['published'].type.primitive_type)
-        self.assertEqual('Published',
-                         tag_template.fields['published'].display_name)
 
         self.assertEqual(
             self.__TIMESTAMP_TYPE,
@@ -140,6 +140,72 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
             tag_template.fields['schema_path'].type.primitive_type)
         self.assertEqual('Schema path',
                          tag_template.fields['schema_path'].display_name)
+
+    def test_make_tag_template_for_sheet(self):
+        tag_template = self.__factory.make_tag_template_for_sheet()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/qlik_sheet_metadata', tag_template.name)
+
+        self.assertEqual('Qlik Sheet Metadata', tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['owner_username'].type.primitive_type)
+        self.assertEqual('Owner username',
+                         tag_template.fields['owner_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['owner_name'].type.primitive_type)
+        self.assertEqual('Owner name',
+                         tag_template.fields['owner_name'].display_name)
+
+        self.assertEqual(self.__BOOL_TYPE,
+                         tag_template.fields['published'].type.primitive_type)
+        self.assertEqual('Published',
+                         tag_template.fields['published'].display_name)
+
+        self.assertEqual(
+            self.__TIMESTAMP_TYPE,
+            tag_template.fields['publish_time'].type.primitive_type)
+        self.assertEqual('Publish time',
+                         tag_template.fields['publish_time'].display_name)
+
+        self.assertEqual(self.__BOOL_TYPE,
+                         tag_template.fields['approved'].type.primitive_type)
+        self.assertEqual('Approved',
+                         tag_template.fields['approved'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_id'].type.primitive_type)
+        self.assertEqual('App Id', tag_template.fields['app_id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_name'].type.primitive_type)
+        self.assertEqual('App name',
+                         tag_template.fields['app_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the App',
+                         tag_template.fields['app_entry'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['source_object'].type.primitive_type)
+        self.assertEqual('Source object',
+                         tag_template.fields['source_object'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['draft_object'].type.primitive_type)
+        self.assertEqual('Draft object',
+                         tag_template.fields['draft_object'].display_name)
 
     def test_make_tag_template_for_stream(self):
         tag_template = self.__factory.make_tag_template_for_stream()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -48,6 +48,28 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             f'{stream_entry.name}',
             app_tag.fields['stream_entry'].string_value)
 
+    def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
+        app_id = 'test_app'
+        app_entry = self.__make_fake_entry(app_id, 'app')
+        app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
+
+        sheet_id = 'test_app'
+        sheet_entry = self.__make_fake_entry(sheet_id, 'sheet')
+        string_fields = ('id', sheet_id), ('app_id', app_id)
+        sheet_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        app_assembled_entry = commons_prepare.AssembledEntryData(
+            app_id, app_entry, [app_tag])
+        sheet_assembled_entry = commons_prepare.AssembledEntryData(
+            sheet_id, sheet_entry, [sheet_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [app_assembled_entry, sheet_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'{app_entry.name}', sheet_tag.fields['app_entry'].string_value)
+
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type):
         entry = datacatalog.Entry()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -76,12 +76,15 @@ class MetadataScraperTest(unittest.TestCase):
         attrs = self.__scraper.__dict__
         engine_api_helper = attrs['_MetadataScraper__engine_api_helper']
 
-        sheets_metadata = [{
-            'qInfo': {
-                'qId': 'sheet-id',
-                'qType': 'sheet'
+        sheets_metadata = [
+            {
+                'qInfo': {
+                    'qId': 'sheet-id',
+                    'qType': 'sheet',
+                },
+                'qMeta': {},
             },
-        }]
+        ]
 
         attrs['_MetadataScraper__engine_api_auth_cookie'] = mock.MagicMock()
         engine_api_helper.get_sheets.return_value = sheets_metadata

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -102,9 +102,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
-    def test_run_public_app_metadata_should_succeed(self, mock_mapper,
-                                                    mock_cleaner,
-                                                    mock_ingestor):
+    def test_run_published_app_metadata_should_succeed(self, mock_mapper,
+                                                       mock_cleaner,
+                                                       mock_ingestor):
 
         attrs = self.__synchronizer.__dict__
         scraper = attrs['_MetadataSynchronizer__metadata_scraper']
@@ -113,7 +113,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
         scraper.scrape_all_apps.return_value = \
-            [self.__make_fake_public_app()]
+            [self.__make_fake_published_app()]
         scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
@@ -176,9 +176,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
-    def test_run_public_sheet_metadata_should_succeed(self, mock_mapper,
-                                                      mock_cleaner,
-                                                      mock_ingestor):
+    def test_run_published_sheet_metadata_should_succeed(
+            self, mock_mapper, mock_cleaner, mock_ingestor):
 
         attrs = self.__synchronizer.__dict__
         scraper = attrs['_MetadataSynchronizer__metadata_scraper']
@@ -187,8 +186,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
         scraper.scrape_all_apps.return_value = \
-            [self.__make_fake_public_app()]
-        scraper.scrape_sheets.return_value = [self.__make_fake_public_sheet()]
+            [self.__make_fake_published_app()]
+        scraper.scrape_sheets.return_value = [
+            self.__make_fake_published_sheet()
+        ]
 
         self.__synchronizer.run()
 
@@ -243,7 +244,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
         scraper.scrape_all_apps.return_value = \
-            [self.__make_fake_public_app()]
+            [self.__make_fake_published_app()]
         scraper.scrape_sheets.return_value = [self.__make_fake_wip_sheet()]
 
         self.__synchronizer.run()
@@ -282,7 +283,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         }
 
     @classmethod
-    def __make_fake_public_app(cls):
+    def __make_fake_published_app(cls):
         return {
             'id': 'test_app',
             'published': True,
@@ -306,7 +307,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         }
 
     @classmethod
-    def __make_fake_public_sheet(cls):
+    def __make_fake_published_sheet(cls):
         sheet = cls.__make_fake_sheet()
         sheet['qMeta']['published'] = True
         return sheet

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -102,9 +102,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
-    def test_run_published_app_metadata_should_succeed(self, mock_mapper,
-                                                       mock_cleaner,
-                                                       mock_ingestor):
+    def test_run_public_app_metadata_should_succeed(self, mock_mapper,
+                                                    mock_cleaner,
+                                                    mock_ingestor):
 
         attrs = self.__synchronizer.__dict__
         scraper = attrs['_MetadataSynchronizer__metadata_scraper']
@@ -113,7 +113,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
         scraper.scrape_all_apps.return_value = \
-            [self.__make_fake_published_app()]
+            [self.__make_fake_public_app()]
         scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
@@ -183,7 +183,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         }
 
     @classmethod
-    def __make_fake_published_app(cls):
+    def __make_fake_public_app(cls):
         return {
             'id': 'test_app',
             'published': True,

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -46,7 +46,7 @@ def __delete_entries_and_groups(project_ids):
     entry_group_names = []
     for result in search_results:
         try:
-            __datacatalog.delete_entry(result.relative_resource_name)
+            __datacatalog.delete_entry(name=result.relative_resource_name)
             print('Entry deleted: {}'.format(result.relative_resource_name))
             entry_group_name = re.match(
                 pattern=entry_name_pattern,
@@ -81,6 +81,8 @@ def __delete_tag_template(project_id, location_id, tag_template_id):
 
 
 def __delete_tag_templates(project_id, location_id):
+    __delete_tag_template(project_id, location_id, 'qlik_app_metadata')
+    __delete_tag_template(project_id, location_id, 'qlik_sheet_metadata')
     __delete_tag_template(project_id, location_id, 'qlik_stream_metadata')
 
 

--- a/google-datacatalog-tableau-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-tableau-connector/tools/scripts/cleanup_datacatalog.py
@@ -46,7 +46,7 @@ def __delete_entries_and_groups(project_ids):
     entry_group_names = []
     for result in search_results:
         try:
-            __datacatalog.delete_entry(result.relative_resource_name)
+            __datacatalog.delete_entry(name=result.relative_resource_name)
             print('Entry deleted: {}'.format(result.relative_resource_name))
             entry_group_name = re.match(
                 pattern=entry_name_pattern,


### PR DESCRIPTION
**- What I did**
Added support for ingesting Sheets metadata. This PR is part of the effort to deliver #34.

**- How I did it**
Added code to create Custom Entries, Tag Template, and Tags to store Sheets metadata.

**- How to verify it**
Run the connector following the instructions from the README file.

**- Description for the changelog**
Added support for ingesting Sheets metadata