### PR TITLE
Improve checks before setting the publish_time field

### DIFF
--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -46,10 +46,14 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'modified_by_username',
                                app_metadata.get('modifiedByUserName'))
 
-        self._set_bool_field(tag, 'published', app_metadata.get('published'))
+        published = app_metadata.get('published')
+        self._set_bool_field(tag, 'published', published)
 
         publish_time = app_metadata.get('publishTime')
-        if publish_time:
+        # The publish time may come with a value such as
+        # '1753-01-01T00:00:00.000Z' when the app has not been published,
+        # so both inputs are tested before setting the tag field.
+        if published and publish_time:
             self._set_timestamp_field(
                 tag, 'publish_time',
                 datetime.strptime(publish_time,
@@ -114,10 +118,14 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
             self._set_string_field(tag, 'owner_name', owner.get('name'))
 
-        self._set_bool_field(tag, 'published', q_meta.get('published'))
+        published = q_meta.get('published')
+        self._set_bool_field(tag, 'published', published)
 
         publish_time = q_meta.get('publishTime')
-        if publish_time:
+        # The publish time may come with a value such as
+        # '1753-01-01T00:00:00.000Z' when the sheet has not been published,
+        # so both inputs are tested before setting the tag field.
+        if published and publish_time:
             self._set_timestamp_field(
                 tag, 'publish_time',
                 datetime.strptime(publish_time,

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -104,6 +104,19 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)
 
+    def test_make_tag_for_app_should_not_set_published_time_if_not_published(
+            self):
+
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_app()
+
+        metadata = {
+            'published': False,
+        }
+
+        tag = self.__factory.make_tag_for_app(tag_template, metadata)
+        self.assertFalse('publish_time' in tag.fields)
+
     def test_make_tag_for_sheet_should_set_all_available_fields(self):
         tag_template = \
             self.__tag_template_factory.make_tag_template_for_sheet()
@@ -156,6 +169,22 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)
+
+    def test_make_tag_for_sheet_should_not_set_published_time_if_not_published(
+            self):
+
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_sheet()
+
+        metadata = {
+            'qInfo': {},
+            'qMeta': {
+                'published': False,
+            },
+        }
+
+        tag = self.__factory.make_tag_for_sheet(tag_template, metadata)
+        self.assertFalse('publish_time' in tag.fields)
 
     def test_make_tag_for_stream_should_set_all_available_fields(self):
         tag_template = \

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -145,8 +145,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
-    def test_run_wip_app_metadata_should_succeed(self, mock_mapper,
-                                                 mock_cleaner, mock_ingestor):
+    def test_run_not_published_app_metadata_should_succeed(
+            self, mock_mapper, mock_cleaner, mock_ingestor):
 
         attrs = self.__synchronizer.__dict__
         scraper = attrs['_MetadataSynchronizer__metadata_scraper']
@@ -233,9 +233,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
-    def test_run_wip_sheet_metadata_should_succeed(self, mock_mapper,
-                                                   mock_cleaner,
-                                                   mock_ingestor):
+    def test_run_not_published_sheet_metadata_should_succeed(
+            self, mock_mapper, mock_cleaner, mock_ingestor):
 
         attrs = self.__synchronizer.__dict__
         scraper = attrs['_MetadataSynchronizer__metadata_scraper']


### PR DESCRIPTION
**- What I did**
Improved the checks before setting the `publish_time` Tag field value to avoid using invalid input.

**- How I did it**
Checked whether the Apps and Sheets were published before setting the value of the `publish_time` Tag field.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Improved the checks before setting the `publish_time` Tag field value to avoid using invalid input.
