### PR TITLE
Replace non-compliant Linked Resource chars

### DIFF
--- a/google-datacatalog-tableau-connector/setup.py
+++ b/google-datacatalog-tableau-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-tableau-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Package for ingesting Tableau metadata'
     ' into Google Cloud Data Catalog',

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -177,6 +177,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         # TODO Remove the below workaround when there is a definitive fix for
         #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
+        #  Valid Linked Resource chars: letters, numbers, periods, colons,
+        #  slashes, underscores, dashes and hashes.
         compliant_site_name = re.sub(r'[^\w.,/\-#]', '_', site_name)
 
         return '' \

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -16,6 +16,7 @@
 
 from datetime import datetime
 import logging
+import re
 
 from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import prepare
@@ -173,4 +174,11 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     @classmethod
     def __format_site_content_url(cls, workbook_metadata):
         site_name = workbook_metadata.get('site').get('name')
-        return '' if site_name.lower() == 'default' else f'/site/{site_name}'
+
+        # TODO Remove the below workaround when there is a definitive fix for
+        #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
+        compliant_site_name = re.sub(r'[^\w.,/\-#]', '_', site_name)
+
+        return '' \
+            if site_name.lower() == 'default' \
+            else f'/site/{compliant_site_name}'

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
@@ -209,7 +209,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
     # TODO Remove the below test case when there is a definitive fix for
     #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
-    def test_make_entry_non_compliant_site_name_should_replace_chars(self):
+    def test_make_entry_non_compliant_site_name_should_replace_linked_resource_chars(  # noqa E501
+            self):
+
         metadata = {
             'luid': 'a123-b456',
             'site': {

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
@@ -206,3 +206,20 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'entryGroups/test-entry-group/entries/'
             't__1234567890123456789012345678901234567890123456789012345678901',
             entry.name)
+
+    # TODO Remove the below test case when there is a definitive fix for
+    #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
+    def test_make_entry_non_compliant_site_name_should_replace_chars(self):
+        metadata = {
+            'luid': 'a123-b456',
+            'site': {
+                'name': 'Test site;'
+            },
+            'vizportalUrlId': 1,
+            'createdAt': '2019-09-12T16:30:00Z',
+            'updatedAt': '2019-09-12T16:30:55Z'
+        }
+
+        entry = self.__factory.make_entry_for_workbook(metadata)[1]
+        self.assertEqual('test-server/#/site/Test_site_/workbooks/1',
+                         entry.linked_resource)


### PR DESCRIPTION
**- What I did**
Added a temporary workaround to avoid breaking the metadata ingestion flow when there are characters in the site name that are not compatible with the `entry.linked_resource` field. This is part of the effort to fix https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43 and I'm going to start working on the definitive fix ASAP.

**- How I did it**
Used a regular expression to replace invalid chars with a `_`.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Non-compliant Linked Resource chars temporarily replaced with an underscore.
