### PR TITLE
Use site contentUrl to generate the Linked Resources

### DIFF
--- a/google-datacatalog-tableau-connector/docs/developer-resources/postman.md
+++ b/google-datacatalog-tableau-connector/docs/developer-resources/postman.md
@@ -7,16 +7,16 @@ requests. The available collections cover both Tableau GraphQL and REST APIs.
 
 1. File: [tools/postman/Tableau GraphQL API.postman_collection.json](../../tools/postman/Tableau%20GraphQL%20API.postman_collection.json)
 
-1. Postman Environment Variables:
+1. Environment Variables:
 
-   | NAME          | DESCRIPTION                                                             |
-   | ------------- | ----------------------------------------------------------------------- |
-   | `SCHEME`      | The URI scheme: `http` or `https`                                       |
-   | `SERVER`      | URL of the Tableau server, e.g. `10ax.online.tableau.com`               |
-   | `API_VERSION` | Version of the Tableau REST API (for user authentication*), e.g. `3.6`  |
-   | `USERNAME`    | Username to authenticate* the API calls                                 |
-   | `PASSWORD`    | Password to authenticate* the API calls                                 |
-   | `SITE_URL`    | Name of the site to authenticate* (a single server can host many sites) |
+   | NAME               | DESCRIPTION                                                                                                                                                                                                                           |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `SCHEME`           | The URI scheme: `http` or `https`                                                                                                                                                                                                     |
+   | `SERVER`           | URL of the Tableau server, e.g. `10ax.online.tableau.com`                                                                                                                                                                             |
+   | `API_VERSION`      | Version of the Tableau REST API for user authentication*, e.g. `3.6`                                                                                                                                                                  |
+   | `USERNAME`         | Username to authenticate* the API calls                                                                                                                                                                                               |
+   | `PASSWORD`         | Password to authenticate* the API calls                                                                                                                                                                                               |
+   | `SITE_CONTENT_URL` | The URL of the site to get information for. Mandatory for Tableau Online, optional for Tableau Server (the connector will read metadata from all sites the user has access to in the given server if this variable is not fulfilled). |
    
    \* Authentication is always performed through the REST API.
 
@@ -24,13 +24,17 @@ requests. The available collections cover both Tableau GraphQL and REST APIs.
 
 1. File: [tools/postman/Tableau REST API.postman_collection.json](../../tools/postman/Tableau%20REST%20API.postman_collection.json)
 
-1. Postman Environment Variables:
+1. Environment Variables:
 
-   | NAME          | DESCRIPTION                                                            |
-   | ------------- | ---------------------------------------------------------------------- |
-   | `PROTOCOL`    | `http` or `https`                                                      |
-   | `SERVER`      | URL of the Tableau server, e.g. `10ax.online.tableau.com`              |
-   | `API_VERSION` | Version of the Tableau REST API, e.g. `3.6`                            |
-   | `USERNAME`    | Username to authenticate the API calls                                 |
-   | `PASSWORD`    | Password to authenticate the API calls                                 |
-   | `SITE_URL`    | Name of the site to authenticate (a single server can host many sites) |
+   | NAME               | DESCRIPTION                                                                                                                                                                                                                           |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `SCHEME`           | The URI scheme: `http` or `https`                                                                                                                                                                                                     |
+   | `SERVER`           | URL of the Tableau server, e.g. `10ax.online.tableau.com`                                                                                                                                                                             |
+   | `API_VERSION`      | Version of the Tableau REST API, e.g. `3.6`                                                                                                                                                                                           |
+   | `USERNAME`         | Username to authenticate the API calls                                                                                                                                                                                                |
+   | `PASSWORD`         | Password to authenticate the API calls                                                                                                                                                                                                |
+   | `SITE_CONTENT_URL` | The URL of the site to get information for. Mandatory for Tableau Online, optional for Tableau Server (the connector will read metadata from all sites the user has access to in the given server if this variable is not fulfilled). |
+
+## Sample environment
+
+1. File: [tools/postman/tableau-sample-environment.postman_environment.json](../../tools/postman/tableau-sample-environment.postman_environment.json)

--- a/google-datacatalog-tableau-connector/setup.py
+++ b/google-datacatalog-tableau-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-tableau-connector',
-    version='0.6.1',
+    version='0.6.2',
     author='Google LLC',
     description='Package for ingesting Tableau metadata'
     ' into Google Cloud Data Catalog',

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -16,7 +16,6 @@
 
 from datetime import datetime
 import logging
-import re
 
 from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import prepare

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -173,14 +173,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
     @classmethod
     def __format_site_content_url(cls, workbook_metadata):
-        site_name = workbook_metadata.get('site').get('name')
-
-        # TODO Remove the below workaround when there is a definitive fix for
-        #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
-        #  Valid Linked Resource chars: letters, numbers, periods, colons,
-        #  slashes, underscores, dashes and hashes.
-        compliant_site_name = re.sub(r'[^\w.,/\-#]', '_', site_name)
-
+        site_content_url = workbook_metadata.get('site').get('contentUrl')
         return '' \
-            if site_name.lower() == 'default' \
-            else f'/site/{compliant_site_name}'
+            if site_content_url.lower() == 'default' \
+            else f'/site/{site_content_url}'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -83,8 +83,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         else:
             generated_id = self.__format_id(sheet_metadata.get('id'))
             logging.info(
-                'Sheet %s does not have a luid.'
-                ' Its id attribute was used as a fallback.',
+                'Sheet "%s" is hidden in the Workbook and does not have an'
+                ' luid. Using its id attribute as a fallback...',
                 sheet_metadata.get('name'))
 
         entry.name = datacatalog.DataCatalogClient.entry_path(
@@ -97,8 +97,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.display_name = self._format_display_name(
             sheet_metadata.get('name'))
 
-        # A null path that means the sheet was hidden and included on a
-        # dashboard, or deleted from server but it is still in the workbook.
+        # A null path means the Sheet is hidden and included in a Dashboard,
+        # or deleted from the server but still remains in the Workbook.
         path = sheet_metadata.get('path')
         if path:
             site_content_url = self.__format_site_content_url(
@@ -172,7 +172,10 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
     @classmethod
     def __format_site_content_url(cls, workbook_metadata):
+        # The 'contentUrl' field is informed as an empty string for the Default
+        # site and fulfilled for all other sites created by the users.
+        #
+        # The '/site/<content-url>' part should be included in the resulting
+        # url only when 'contentUrl' is not empty.
         site_content_url = workbook_metadata['site'].get('contentUrl')
-        return '' \
-            if not site_content_url or site_content_url.lower() == 'default' \
-            else f'/site/{site_content_url}'
+        return '' if not site_content_url else f'/site/{site_content_url}'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory.py
@@ -173,7 +173,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
     @classmethod
     def __format_site_content_url(cls, workbook_metadata):
-        site_content_url = workbook_metadata.get('site').get('contentUrl')
+        site_content_url = workbook_metadata['site'].get('contentUrl')
         return '' \
-            if site_content_url.lower() == 'default' \
+            if not site_content_url or site_content_url.lower() == 'default' \
             else f'/site/{site_content_url}'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
@@ -16,7 +16,6 @@
 
 import logging
 import requests
-import sys
 
 from google.datacatalog_connectors.tableau.scrape import constants
 
@@ -51,7 +50,7 @@ class Authenticator:
         response = requests.post(url=url, headers=headers, json=body).json()
 
         if not response.get('credentials'):
-            logging.critical(response)
-            sys.exit(1)
+            logging.info(response)
+            return
 
         return response['credentials']

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
@@ -25,7 +25,7 @@ class Authenticator:
                      api_version,
                      username,
                      password,
-                     site=None):
+                     site_content_url=None):
 
         url = f'{server_address}/api/{api_version}/auth/signin'
 
@@ -39,7 +39,7 @@ class Authenticator:
                 'name': username,
                 'password': password,
                 'site': {
-                    'contentUrl': site
+                    'contentUrl': site_content_url
                 }
             }
         }

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
@@ -16,6 +16,7 @@
 
 import logging
 import requests
+import sys
 
 from google.datacatalog_connectors.tableau.scrape import constants
 
@@ -51,6 +52,6 @@ class Authenticator:
 
         if not response.get('credentials'):
             logging.critical(response)
-            exit(1)
+            sys.exit(1)
 
         return response['credentials']

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
@@ -17,6 +17,8 @@
 import logging
 import requests
 
+from google.datacatalog_connectors.tableau.scrape import constants
+
 
 class Authenticator:
 
@@ -31,8 +33,8 @@ class Authenticator:
         url = f'{server_address}/api/{api_version}/auth/signin'
 
         headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
+            'Content-Type': constants.JSON_CONTENT_TYPE,
+            'Accept': constants.JSON_CONTENT_TYPE
         }
 
         body = {

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/authenticator.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import requests
 
 
@@ -44,5 +45,10 @@ class Authenticator:
             }
         }
 
-        return requests.post(url=url, headers=headers,
-                             json=body).json()['credentials']
+        response = requests.post(url=url, headers=headers, json=body).json()
+
+        if not response.get('credentials'):
+            logging.critical(response)
+            exit(1)
+
+        return response['credentials']

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/constants.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/constants.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+JSON_CONTENT_TYPE = 'application/json'
+
 # Name of the HTTP header used to provide authentication info when sending
 # requests to the Tableau APIs.
 X_TABLEAU_AUTH_HEADER_NAME = 'X-Tableau-Auth'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/constants.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/constants.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Name of the HTTP header used to provide authentication info when sending
+# requests to the Tableau APIs.
+X_TABLEAU_AUTH_HEADER_NAME = 'X-Tableau-Auth'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_api_helper.py
@@ -25,15 +25,11 @@ class MetadataAPIHelper:
     def __init__(self, server_address):
         self.__url = f'{server_address}/relationship-service-war/graphql'
 
-    def fetch_dashboards(self,
-                         current_site,
-                         auth_credentials,
-                         query_filter=None):
+    def fetch_dashboards(self, auth_credentials, query_filter=None):
         """
         Read dashboards metadata from a given server.
 
         Args:
-            current_site (dict): Metadata for the current site
             auth_credentials (dict): Credentials to authenticate the request
             query_filter (dict): Filter fields and values
 
@@ -56,16 +52,15 @@ class MetadataAPIHelper:
         for dashboard in dashboards:
             if dashboard.get('workbook') and 'site' in dashboard['workbook']:
                 self.__add_site_content_url_field(
-                    dashboard['workbook']['site'], current_site)
+                    dashboard['workbook']['site'], auth_credentials)
 
         return dashboards
 
-    def fetch_sites(self, current_site, auth_credentials, query_filter=None):
+    def fetch_sites(self, auth_credentials, query_filter=None):
         """
         Read sites metadata from a given server.
 
         Args:
-            current_site (dict): Metadata for the current site
             auth_credentials (dict): Credentials to authenticate the request
             query_filter (dict): Filter fields and values
 
@@ -86,23 +81,19 @@ class MetadataAPIHelper:
 
         # Site contentUrl handling
         for site in sites:
-            self.__add_site_content_url_field(site, current_site)
+            self.__add_site_content_url_field(site, auth_credentials)
             workbooks = site.get('workbooks') or []
             for workbook in workbooks:
                 self.__add_site_content_url_field(workbook['site'],
-                                                  current_site)
+                                                  auth_credentials)
 
         return sites
 
-    def fetch_workbooks(self,
-                        current_site,
-                        auth_credentials,
-                        query_filter=None):
+    def fetch_workbooks(self, auth_credentials, query_filter=None):
         """
         Read workbooks metadata from a given server.
 
         Args:
-            current_site (dict): Metadata for the current site
             auth_credentials (dict): Credentials to authenticate the request
             query_filter (dict): Filter fields and values
 
@@ -130,13 +121,13 @@ class MetadataAPIHelper:
         for workbook in workbooks:
             if workbook.get('site'):
                 self.__add_site_content_url_field(workbook['site'],
-                                                  current_site)
+                                                  auth_credentials)
 
         return workbooks
 
     @classmethod
     def __add_site_content_url_field(cls, original_site_metadata,
-                                     current_site):
+                                     auth_credentials):
         """The `contentUrl` field is not available in the original
         `TableauSite` objects returned by the Metadata API but it is required
         in the prepare stage. So, it is injected into the returned objects to
@@ -144,6 +135,7 @@ class MetadataAPIHelper:
 
         Args:
             original_site_metadata: The object returned by the Metadata API
-            current_site: The site which is being scraped
+            auth_credentials: The auth credentials for the current site
         """
-        original_site_metadata['contentUrl'] = current_site.get('contentUrl')
+        original_site_metadata['contentUrl'] = \
+            auth_credentials['site']['contentUrl']

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_api_helper.py
@@ -35,7 +35,8 @@ class MetadataAPIHelper:
         self.__password = password
         self.__site_content_url = site_content_url
 
-        self.__url = f'{server_address}/relationship-service-war/graphql'
+        self.__api_endpoint = f'{server_address}' \
+                              f'/relationship-service-war/graphql'
 
         self.__auth_credentials = None
 
@@ -57,7 +58,8 @@ class MetadataAPIHelper:
                 self.__auth_credentials['token']
         }
 
-        response = requests.post(url=self.__url, headers=headers,
+        response = requests.post(url=self.__api_endpoint,
+                                 headers=headers,
                                  json=body).json()
 
         dashboards = response['data']['dashboards'] \
@@ -91,7 +93,8 @@ class MetadataAPIHelper:
                 self.__auth_credentials['token']
         }
 
-        response = requests.post(url=self.__url, headers=headers,
+        response = requests.post(url=self.__api_endpoint,
+                                 headers=headers,
                                  json=body).json()
 
         sites = response['data']['tableauSites'] \
@@ -131,7 +134,8 @@ class MetadataAPIHelper:
                 self.__auth_credentials['token']
         }
 
-        response = requests.post(url=self.__url, headers=headers,
+        response = requests.post(url=self.__api_endpoint,
+                                 headers=headers,
                                  json=body).json()
 
         workbooks = response['data']['workbooks'] \
@@ -141,7 +145,7 @@ class MetadataAPIHelper:
 
         # Site contentUrl handling
         for workbook in workbooks:
-            if workbook.get('site'):
+            if 'site' in workbook:
                 self.__add_site_content_url_field(workbook['site'])
 
         return workbooks

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from google.datacatalog_connectors.tableau.scrape import \
     metadata_api_helper, rest_api_helper
 
@@ -52,6 +54,7 @@ class MetadataScraper:
             return metadata
 
         for site_content_url in self.__site_content_urls:
+            logging.info('Current site content URL: "%s"', site_content_url)
             api_helper = metadata_api_helper.MetadataAPIHelper(
                 self.__server_address, self.__api_version, self.__username,
                 self.__password, site_content_url)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -54,6 +54,7 @@ class MetadataScraper:
             return metadata
 
         for site_content_url in self.__site_content_urls:
+            logging.info('')
             logging.info('Current site content URL: "%s"', site_content_url)
             api_helper = metadata_api_helper.MetadataAPIHelper(
                 self.__server_address, self.__api_version, self.__username,
@@ -64,15 +65,24 @@ class MetadataScraper:
 
     @classmethod
     def __scrape_dashboards(cls, api_helper, query_filter):
-        return api_helper.fetch_dashboards(query_filter)
+        cls.__log_scrape_start('Scraping from the Dashboard level...')
+        dashboards_metadata = api_helper.fetch_dashboards(query_filter)
+        logging.info(f'  {len(dashboards_metadata)} Dashboards found')
+        return dashboards_metadata
 
     @classmethod
     def __scrape_sites(cls, api_helper, query_filter):
-        return api_helper.fetch_sites(query_filter)
+        cls.__log_scrape_start('Scraping from the Site level...')
+        sites_metadata = api_helper.fetch_sites(query_filter)
+        cls.__log_site_level_scraping_results(sites_metadata)
+        return sites_metadata
 
     @classmethod
     def __scrape_workbooks(cls, api_helper, query_filter):
-        return api_helper.fetch_workbooks(query_filter)
+        cls.__log_scrape_start('Scraping from the Workbook level...')
+        workbooks_metadata = api_helper.fetch_workbooks(query_filter)
+        cls.__log_workbook_level_scraping_results(workbooks_metadata)
+        return workbooks_metadata
 
     def __initialize_site_content_urls(self):
         # Single site scraping
@@ -88,3 +98,47 @@ class MetadataScraper:
         available_sites = api_helper.get_all_sites_for_server()
         self.__site_content_urls.extend(
             [site['contentUrl'] for site in available_sites])
+
+    @classmethod
+    def __log_scrape_start(cls, message, *args):
+        logging.info(message, *args)
+        logging.info('-------------------------------------------------')
+
+    @classmethod
+    def __log_site_level_scraping_results(cls, sites_metadata):
+        workbooks_count = 0
+        sheets_count = 0
+
+        for site_metadata in sites_metadata:
+            workbooks_metadata = site_metadata['workbooks']
+            workbooks_count += len(workbooks_metadata)
+            for workbook_metadata in workbooks_metadata:
+                sheets_count += len(workbook_metadata['sheets'])
+
+        assets_count = sum([workbooks_count, sheets_count])
+        assets_count_str_len = len(str(assets_count))
+
+        logging.info('  %s assets found!', assets_count)
+        spaces_count = assets_count_str_len - len(str(workbooks_count))
+        logging.info('    - %s%s Workbooks', " " * spaces_count,
+                     workbooks_count)
+        spaces_count = assets_count_str_len - len(str(sheets_count))
+        logging.info('    - %s%s Sheets', " " * spaces_count, sheets_count)
+
+    @classmethod
+    def __log_workbook_level_scraping_results(cls, workbooks_metadata):
+        workbooks_count = len(workbooks_metadata)
+        sheets_count = sum([
+            len(workbook_metadata['sheets'])
+            for workbook_metadata in workbooks_metadata
+        ])
+
+        assets_count = sum([workbooks_count, sheets_count])
+        assets_count_str_len = len(str(assets_count))
+
+        logging.info('  %s assets found!', assets_count)
+        spaces_count = assets_count_str_len - len(str(workbooks_count))
+        logging.info('    - %s%s Workbooks', " " * spaces_count,
+                     workbooks_count)
+        spaces_count = assets_count_str_len - len(str(sheets_count))
+        logging.info('    - %s%s Sheets', " " * spaces_count, sheets_count)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -51,29 +51,25 @@ class MetadataScraper:
         if not self.__site_content_urls:
             return metadata
 
-        api_helper = metadata_api_helper.MetadataAPIHelper(
-            self.__server_address)
-
         for site_content_url in self.__site_content_urls:
-            auth_credentials = authenticator.Authenticator.authenticate(
+            api_helper = metadata_api_helper.MetadataAPIHelper(
                 self.__server_address, self.__api_version, self.__username,
                 self.__password, site_content_url)
-            metadata.extend(
-                reader_method(api_helper, auth_credentials, query_filter))
+            metadata.extend(reader_method(api_helper, query_filter))
 
         return metadata
 
     @classmethod
-    def __scrape_dashboards(cls, api_helper, auth_credentials, query_filter):
-        return api_helper.fetch_dashboards(auth_credentials, query_filter)
+    def __scrape_dashboards(cls, api_helper, query_filter):
+        return api_helper.fetch_dashboards(query_filter)
 
     @classmethod
-    def __scrape_sites(cls, api_helper, auth_credentials, query_filter):
-        return api_helper.fetch_sites(auth_credentials, query_filter)
+    def __scrape_sites(cls, api_helper, query_filter):
+        return api_helper.fetch_sites(query_filter)
 
     @classmethod
-    def __scrape_workbooks(cls, api_helper, auth_credentials, query_filter):
-        return api_helper.fetch_workbooks(auth_credentials, query_filter)
+    def __scrape_workbooks(cls, api_helper, query_filter):
+        return api_helper.fetch_workbooks(query_filter)
 
     def __initialize_site_content_urls(self):
         # Single site scraping
@@ -81,16 +77,10 @@ class MetadataScraper:
             return
 
         # Multiple site scraping (only for Tableau Server)
-        default_site_credentials = \
-            authenticator.Authenticator.authenticate(
-                self.__server_address,
-                self.__api_version,
-                self.__username,
-                self.__password)
-
         api_helper = rest_api_helper.RestAPIHelper(self.__server_address,
-                                                   self.__api_version)
-        available_sites = api_helper.get_all_sites_on_server(
-            default_site_credentials)
+                                                   self.__api_version,
+                                                   self.__username,
+                                                   self.__password)
+        available_sites = api_helper.get_all_sites_on_server()
         self.__site_content_urls.extend(
             [site['contentUrl'] for site in available_sites])

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -33,7 +33,7 @@ class MetadataScraper:
         self.__password = password
         self.__site_content_url = site_content_url
 
-        self.__auth_credentials = {}
+        self.__site_content_urls = [site_content_url]
 
     def scrape_dashboards(self, query_filter=None):
         return self.__scrape_metadata(self.__scrape_dashboards, query_filter)
@@ -47,69 +47,50 @@ class MetadataScraper:
     def __scrape_metadata(self, reader_method, query_filter):
         metadata = []
 
-        sites = self.__get_sites()
-        if not sites:
+        self.__initialize_site_content_urls()
+        if not self.__site_content_urls:
             return metadata
 
         api_helper = metadata_api_helper.MetadataAPIHelper(
             self.__server_address)
 
-        for site in sites:
-            site_content_url = site.get('contentUrl')
-            auth_credentials = self.__auth_credentials.get(site_content_url)
-            if not auth_credentials:
-                auth_credentials = authenticator.Authenticator.authenticate(
-                    self.__server_address, self.__api_version, self.__username,
-                    self.__password, site_content_url)
-                self.__auth_credentials[site_content_url] = auth_credentials
+        for site_content_url in self.__site_content_urls:
+            auth_credentials = authenticator.Authenticator.authenticate(
+                self.__server_address, self.__api_version, self.__username,
+                self.__password, site_content_url)
             metadata.extend(
-                reader_method(api_helper, site, auth_credentials,
-                              query_filter))
+                reader_method(api_helper, auth_credentials, query_filter))
 
         return metadata
 
     @classmethod
-    def __scrape_dashboards(cls, api_helper, current_site, auth_credentials,
-                            query_filter):
-
-        return api_helper.fetch_dashboards(current_site, auth_credentials,
-                                           query_filter)
+    def __scrape_dashboards(cls, api_helper, auth_credentials, query_filter):
+        return api_helper.fetch_dashboards(auth_credentials, query_filter)
 
     @classmethod
-    def __scrape_sites(cls, api_helper, current_site, auth_credentials,
-                       query_filter):
-
-        return api_helper.fetch_sites(current_site, auth_credentials,
-                                      query_filter)
+    def __scrape_sites(cls, api_helper, auth_credentials, query_filter):
+        return api_helper.fetch_sites(auth_credentials, query_filter)
 
     @classmethod
-    def __scrape_workbooks(cls, api_helper, current_site, auth_credentials,
-                           query_filter):
+    def __scrape_workbooks(cls, api_helper, auth_credentials, query_filter):
+        return api_helper.fetch_workbooks(auth_credentials, query_filter)
 
-        return api_helper.fetch_workbooks(current_site, auth_credentials,
-                                          query_filter)
+    def __initialize_site_content_urls(self):
+        # Single site scraping
+        if self.__site_content_urls:
+            return
 
-    def __get_sites(self):
-        api_helper = rest_api_helper.RestAPIHelper(
-            server_address=self.__server_address,
-            api_version=self.__api_version)
-
-        if self.__site_content_url:
-            site_credentials = \
-                authenticator.Authenticator.authenticate(
-                    self.__server_address,
-                    self.__api_version,
-                    self.__username,
-                    self.__password,
-                    site_content_url=self.__site_content_url)
-            self.__auth_credentials[self.__site_content_url] = site_credentials
-            return [api_helper.get_site(site_credentials)]
-
+        # Multiple site scraping (only for Tableau Server)
         default_site_credentials = \
             authenticator.Authenticator.authenticate(
                 self.__server_address,
                 self.__api_version,
                 self.__username,
                 self.__password)
-        self.__auth_credentials['default'] = default_site_credentials
-        return api_helper.get_all_sites_on_server(default_site_credentials)
+
+        api_helper = rest_api_helper.RestAPIHelper(self.__server_address,
+                                                   self.__api_version)
+        available_sites = api_helper.get_all_sites_on_server(
+            default_site_credentials)
+        self.__site_content_urls.extend(
+            [site['contentUrl'] for site in available_sites])

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -110,10 +110,10 @@ class MetadataScraper:
         sheets_count = 0
 
         for site_metadata in sites_metadata:
-            workbooks_metadata = site_metadata['workbooks']
+            workbooks_metadata = site_metadata.get('workbooks') or []
             workbooks_count += len(workbooks_metadata)
             for workbook_metadata in workbooks_metadata:
-                sheets_count += len(workbook_metadata['sheets'])
+                sheets_count += len(workbook_metadata.get('sheets') or [])
 
         assets_count = sum([workbooks_count, sheets_count])
         assets_count_str_len = len(str(assets_count))
@@ -129,7 +129,7 @@ class MetadataScraper:
     def __log_workbook_level_scraping_results(cls, workbooks_metadata):
         workbooks_count = len(workbooks_metadata)
         sheets_count = sum([
-            len(workbook_metadata['sheets'])
+            len(workbook_metadata.get('sheets') or [])
             for workbook_metadata in workbooks_metadata
         ])
 

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -82,6 +82,6 @@ class MetadataScraper:
                                                    self.__api_version,
                                                    self.__username,
                                                    self.__password)
-        available_sites = api_helper.get_all_sites_on_server()
+        available_sites = api_helper.get_all_sites_for_server()
         self.__site_content_urls.extend(
             [site['contentUrl'] for site in available_sites])

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from google.datacatalog_connectors.tableau.scrape import \
-    authenticator, metadata_api_helper, rest_api_helper
+    metadata_api_helper, rest_api_helper
 
 
 class MetadataScraper:

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/metadata_scraper.py
@@ -33,7 +33,7 @@ class MetadataScraper:
         self.__password = password
         self.__site_content_url = site_content_url
 
-        self.__site_content_urls = [site_content_url]
+        self.__site_content_urls = []
 
     def scrape_dashboards(self, query_filter=None):
         return self.__scrape_metadata(self.__scrape_dashboards, query_filter)
@@ -73,7 +73,8 @@ class MetadataScraper:
 
     def __initialize_site_content_urls(self):
         # Single site scraping
-        if self.__site_content_urls:
+        if self.__site_content_url:
+            self.__site_content_urls.append(self.__site_content_url)
             return
 
         # Multiple site scraping (only for Tableau Server)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
@@ -16,24 +16,41 @@
 
 import requests
 
-from google.datacatalog_connectors.tableau.scrape import constants
+from google.datacatalog_connectors.tableau.scrape import \
+    authenticator, constants
 
 
 class RestAPIHelper:
 
-    def __init__(self, server_address, api_version):
+    def __init__(self,
+                 server_address,
+                 api_version,
+                 username,
+                 password,
+                 site_content_url=None):
+
+        self.__server_address = server_address
+        self.__api_version = api_version
+        self.__username = username
+        self.__password = password
+        self.__site_content_url = site_content_url
+
         self.__base_api_endpoint = f'{server_address}/api/{api_version}'
         self.__common_headers = {
             'Content-Type': constants.JSON_CONTENT_TYPE,
             'Accept': constants.JSON_CONTENT_TYPE
         }
 
-    def get_all_sites_on_server(self, auth_credentials):
+        self.__auth_credentials = None
+
+    def get_all_sites_on_server(self):
+        self.__set_up_auth_credentials()
+
         url = f'{self.__base_api_endpoint}/sites'
 
         headers = self.__common_headers.copy()
         headers[constants.X_TABLEAU_AUTH_HEADER_NAME] = \
-            auth_credentials['token']
+            self.__auth_credentials['token']
 
         response = requests.get(url=url, headers=headers).json()
 
@@ -41,3 +58,15 @@ class RestAPIHelper:
             if response and response.get('sites') \
             and 'site' in response['sites'] \
             else []
+
+    def __set_up_auth_credentials(self):
+        if self.__auth_credentials:
+            return
+
+        self.__auth_credentials = \
+            authenticator.Authenticator.authenticate(
+                self.__server_address,
+                self.__api_version,
+                self.__username,
+                self.__password,
+                self.__site_content_url)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
@@ -32,24 +32,12 @@ class RestAPIHelper:
         url = f'{self.__base_api_endpoint}/sites'
 
         headers = self.__common_headers.copy()
-        headers[
-            constants.X_TABLEAU_AUTH_HEADER_NAME] = auth_credentials['token']
+        headers[constants.X_TABLEAU_AUTH_HEADER_NAME] = \
+            auth_credentials['token']
 
         response = requests.get(url=url, headers=headers).json()
 
         return response['sites']['site'] \
-            if response and 'sites' in response and response['sites'] \
+            if response and response.get('sites') \
             and 'site' in response['sites'] \
             else []
-
-    def get_site(self, auth_credentials):
-        url = f'{self.__base_api_endpoint}/sites' \
-              f'/{auth_credentials["site"]["id"]}'
-
-        headers = self.__common_headers.copy()
-        headers[
-            constants.X_TABLEAU_AUTH_HEADER_NAME] = auth_credentials['token']
-
-        response = requests.get(url=url, headers=headers).json()
-
-        return response.get('site')

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
@@ -43,7 +43,7 @@ class RestAPIHelper:
 
         self.__auth_credentials = None
 
-    def get_all_sites_on_server(self):
+    def get_all_sites_for_server(self):
         self.__set_up_auth_credentials()
 
         url = f'{self.__base_api_endpoint}/sites'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
@@ -16,23 +16,40 @@
 
 import requests
 
+from google.datacatalog_connectors.tableau.scrape import constants
+
 
 class RestAPIHelper:
 
-    def __init__(self, server_address, api_version, auth_credentials):
+    def __init__(self, server_address, api_version):
         self.__base_api_endpoint = f'{server_address}/api/{api_version}'
-        self.__headers = {
-            'X-Tableau-Auth': auth_credentials['token'],
+        self.__common_headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json'
         }
 
-    def get_all_sites_on_server(self):
+    def get_all_sites_on_server(self, auth_credentials):
         url = f'{self.__base_api_endpoint}/sites'
 
-        result = requests.get(url=url, headers=self.__headers).json()
+        headers = self.__common_headers.copy()
+        headers[
+            constants.X_TABLEAU_AUTH_HEADER_NAME] = auth_credentials['token']
 
-        return result['sites']['site'] \
-            if result and 'sites' in result and result['sites'] \
-            and 'site' in result['sites'] \
+        response = requests.get(url=url, headers=headers).json()
+
+        return response['sites']['site'] \
+            if response and 'sites' in response and response['sites'] \
+            and 'site' in response['sites'] \
             else []
+
+    def get_site(self, auth_credentials):
+        url = f'{self.__base_api_endpoint}/sites' \
+              f'/{auth_credentials["site"]["id"]}'
+
+        headers = self.__common_headers.copy()
+        headers[
+            constants.X_TABLEAU_AUTH_HEADER_NAME] = auth_credentials['token']
+
+        response = requests.get(url=url, headers=headers).json()
+
+        return response.get('site')

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/scrape/rest_api_helper.py
@@ -24,8 +24,8 @@ class RestAPIHelper:
     def __init__(self, server_address, api_version):
         self.__base_api_endpoint = f'{server_address}/api/{api_version}'
         self.__common_headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
+            'Content-Type': constants.JSON_CONTENT_TYPE,
+            'Accept': constants.JSON_CONTENT_TYPE
         }
 
     def get_all_sites_on_server(self, auth_credentials):

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/metadata_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/metadata_synchronizer.py
@@ -82,7 +82,6 @@ class MetadataSynchronizer(abc.ABC):
         source_system_metadata = self._scrape_source_system_metadata(
             query_filter)
         logging.info('==== DONE =======================================')
-        self._log_scraping_results(source_system_metadata)
 
         # Prepare: convert Tableau metadata into Data Catalog entities model.
         logging.info('')
@@ -141,9 +140,6 @@ class MetadataSynchronizer(abc.ABC):
     @abstractmethod
     def _scrape_source_system_metadata(self, query_filter=None):
         pass
-
-    def _log_scraping_results(self, metadata):
-        logging.info(f'==== {len(metadata)} assets found')
 
     @abstractmethod
     def _make_tag_templates_dict(self):

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/metadata_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/metadata_synchronizer.py
@@ -34,22 +34,22 @@ class MetadataSynchronizer(abc.ABC):
                  tableau_password,
                  datacatalog_project_id,
                  datacatalog_location_id,
-                 assets_type,
+                 asset_types,
                  tableau_site=None):
 
         super().__init__()
 
         self.__project_id = datacatalog_project_id
         self.__location_id = datacatalog_location_id
-        self.__assets_type = assets_type
-        self.__site = tableau_site
+        self.__asset_types = asset_types
+        self.__site_content_url = tableau_site
 
         self._metadata_scraper = scrape.MetadataScraper(
             server_address=tableau_server_address,
             api_version=tableau_api_version,
             username=tableau_username,
             password=tableau_password,
-            site=tableau_site)
+            site_content_url=tableau_site)
 
         self._entry_factory = \
             prepare.AssembledEntryFactory(
@@ -73,9 +73,11 @@ class MetadataSynchronizer(abc.ABC):
 
         # Scrape metadata from Tableau server.
         logging.info('')
-        logging.info(f'===> Scraping Tableau metadata'
-                     f' [site: {self.__site if self.__site else "all"},'
-                     f' type: {self.__assets_type}]...')
+        logging.info(
+            f'===> Scraping Tableau metadata'
+            f' [site: '
+            f'{self.__site_content_url if self.__site_content_url else "all"},'
+            f' type: {self.__asset_types}]...')
 
         source_system_metadata = self._scrape_source_system_metadata(
             query_filter)
@@ -158,7 +160,7 @@ class MetadataSynchronizer(abc.ABC):
 
     def __get_search_query(self):
         search_query = f'system={self.__SPECIFIED_SYSTEM} ('
-        for asset_type in self.__assets_type:
+        for asset_type in self.__asset_types:
             search_query += f'type={asset_type} or '
         search_query = search_query[:-4]
         search_query += ')'

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/sites_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/sites_synchronizer.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from google.datacatalog_connectors.tableau import prepare
 from google.datacatalog_connectors.tableau.sync import metadata_synchronizer
 
@@ -40,27 +38,6 @@ class SitesSynchronizer(metadata_synchronizer.MetadataSynchronizer):
 
     def _scrape_source_system_metadata(self, query_filter=None):
         return self._metadata_scraper.scrape_sites(query_filter)
-
-    def _log_scraping_results(self, metadata):
-        workbooks_count = 0
-        sheets_count = 0
-
-        for site_metadata in metadata:
-            workbooks_metadata = site_metadata['workbooks']
-            workbooks_count += len(workbooks_metadata)
-            for workbook_metadata in workbooks_metadata:
-                sheets_count += len(workbook_metadata['sheets'])
-
-        assets_count = sum([workbooks_count, sheets_count])
-        assets_count_str_len = len(str(assets_count))
-
-        logging.info('')
-        logging.info('==== %s assets found!', assets_count)
-        spaces_count = assets_count_str_len - len(str(workbooks_count))
-        logging.info('   > %s%s workbooks', " " * spaces_count,
-                     workbooks_count)
-        spaces_count = assets_count_str_len - len(str(sheets_count))
-        logging.info('   > %s%s sheets', " " * spaces_count, sheets_count)
 
     def _make_tag_templates_dict(self):
         workbook_tag_template_id, workbook_tag_template = \

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/sites_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/sites_synchronizer.py
@@ -55,7 +55,7 @@ class SitesSynchronizer(metadata_synchronizer.MetadataSynchronizer):
         assets_count_str_len = len(str(assets_count))
 
         logging.info('')
-        logging.info('==== %s assets scraped!', assets_count)
+        logging.info('==== %s assets found!', assets_count)
         spaces_count = assets_count_str_len - len(str(workbooks_count))
         logging.info('   > %s%s workbooks', " " * spaces_count,
                      workbooks_count)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer.py
@@ -51,7 +51,7 @@ class WorkbooksSynchronizer(metadata_synchronizer.MetadataSynchronizer):
         assets_count_str_len = len(str(assets_count))
 
         logging.info('')
-        logging.info('==== %s assets scraped!', assets_count)
+        logging.info('==== %s assets found!', assets_count)
         spaces_count = assets_count_str_len - len(str(workbooks_count))
         logging.info('   > %s%s workbooks', " " * spaces_count,
                      workbooks_count)

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from google.datacatalog_connectors.tableau import prepare
 from google.datacatalog_connectors.tableau.sync import metadata_synchronizer
 
@@ -40,23 +38,6 @@ class WorkbooksSynchronizer(metadata_synchronizer.MetadataSynchronizer):
 
     def _scrape_source_system_metadata(self, query_filter=None):
         return self._metadata_scraper.scrape_workbooks(query_filter)
-
-    def _log_scraping_results(self, metadata):
-        workbooks_count = len(metadata)
-        sheets_count = sum([
-            len(workbook_metadata['sheets']) for workbook_metadata in metadata
-        ])
-
-        assets_count = sum([workbooks_count, sheets_count])
-        assets_count_str_len = len(str(assets_count))
-
-        logging.info('')
-        logging.info('==== %s assets found!', assets_count)
-        spaces_count = assets_count_str_len - len(str(workbooks_count))
-        logging.info('   > %s%s workbooks', " " * spaces_count,
-                     workbooks_count)
-        spaces_count = assets_count_str_len - len(str(sheets_count))
-        logging.info('   > %s%s sheets', " " * spaces_count, sheets_count)
 
     def _make_tag_templates_dict(self):
         workbook_tag_template_id, workbook_tag_template = \

--- a/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/tableau2datacatalog_cli.py
+++ b/google-datacatalog-tableau-connector/src/google/datacatalog_connectors/tableau/tableau2datacatalog_cli.py
@@ -53,7 +53,12 @@ class Tableau2DataCatalogCli:
         parser.add_argument('--tableau-password',
                             help='Tableau password',
                             required=True)
-        parser.add_argument('--tableau-site', help='Tableau site')
+        parser.add_argument('--tableau-site',
+                            help='The URL of the site to get information for.'
+                            ' Mandatory for Tableau Online, optional for'
+                            ' Tableau Server (the connector will read metadata'
+                            ' from all sites the user has access to in the'
+                            ' given server if this arg is not provided).')
         parser.add_argument('--datacatalog-project-id',
                             help='Google Cloud Project ID',
                             required=True)

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/prepare/datacatalog_entry_factory_test.py
@@ -55,9 +55,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'updatedAt': '2019-09-12T16:30:55Z',
             'workbook': {
                 'site': {
-                    'name': 'test-site'
-                }
-            }
+                    'contentUrl': 'test-site',
+                },
+            },
         }
 
         entry = self.__factory.make_entry_for_dashboard(metadata)
@@ -92,10 +92,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'name': 'Test Name',
             'path': 'test/sheet',
             'createdAt': '2019-09-12T16:30:00Z',
-            'updatedAt': '2019-09-12T16:30:55Z'
+            'updatedAt': '2019-09-12T16:30:55Z',
         }
 
-        workbook_metadata = {'site': {'name': 'test-site'}}
+        workbook_metadata = {'site': {'contentUrl': 'test-site'}}
 
         entry = self.__factory.make_entry_for_sheet(metadata,
                                                     workbook_metadata)
@@ -131,10 +131,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'name': 'Test Name',
             'path': 'test/sheet',
             'createdAt': '2019-09-12T16:30:00Z',
-            'updatedAt': '2019-09-12T16:30:55Z'
+            'updatedAt': '2019-09-12T16:30:55Z',
         }
 
-        workbook_metadata = {'site': {'name': 'test-site'}}
+        workbook_metadata = {'site': {'contentUrl': 'test-site'}}
 
         entry = self.__factory.make_entry_for_sheet(metadata,
                                                     workbook_metadata)
@@ -146,12 +146,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'luid': 'a123-b456',
             'name': 'Test Name',
             'site': {
-                'name': 'test-site'
+                'contentUrl': 'test-site',
             },
             'description': 'Test Description',
             'vizportalUrlId': 1,
             'createdAt': '2019-09-12T16:30:00Z',
-            'updatedAt': '2019-09-12T16:30:55Z'
+            'updatedAt': '2019-09-12T16:30:55Z',
         }
 
         entry = self.__factory.make_entry_for_workbook(metadata)
@@ -188,10 +188,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'name': 'Test Name',
             'path': 'test/sheet',
             'createdAt': '2019-09-12T16:30:00Z',
-            'updatedAt': '2019-09-12T16:30:55Z'
+            'updatedAt': '2019-09-12T16:30:55Z',
         }
 
-        workbook_metadata = {'site': {'name': 'test-site'}}
+        workbook_metadata = {'site': {'contentUrl': 'test-site'}}
 
         entry = self.__factory.make_entry_for_sheet(metadata,
                                                     workbook_metadata)
@@ -206,22 +206,3 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'entryGroups/test-entry-group/entries/'
             't__1234567890123456789012345678901234567890123456789012345678901',
             entry.name)
-
-    # TODO Remove the below test case when there is a definitive fix for
-    #  https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues/43  # noqa E501
-    def test_make_entry_non_compliant_site_name_should_replace_linked_resource_chars(  # noqa E501
-            self):
-
-        metadata = {
-            'luid': 'a123-b456',
-            'site': {
-                'name': 'Test site;'
-            },
-            'vizportalUrlId': 1,
-            'createdAt': '2019-09-12T16:30:00Z',
-            'updatedAt': '2019-09-12T16:30:55Z'
-        }
-
-        entry = self.__factory.make_entry_for_workbook(metadata)[1]
-        self.assertEqual('test-server/#/site/Test_site_/workbooks/1',
-                         entry.linked_resource)

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
@@ -41,11 +41,13 @@ class AuthenticatorTest(unittest.TestCase):
 
         self.assertEqual('TEST-TOKEN', credentials['token'])
 
-    def test_authenticate_should_raise_system_exit_on_failure(self, mock_post):
+    def test_authenticate_should_return_none_on_failure(self, mock_post):
 
         mock_post.return_value = metadata_scraper_mocks.make_fake_response(
             {'error': {}}, 401)
 
-        self.assertRaises(SystemExit, authenticator.Authenticator.authenticate,
-                          'https://test-server.com', 'test-api',
-                          'test-username', 'test-password')
+        credentials = authenticator.Authenticator.authenticate(
+            'https://test-server.com', 'test-api', 'test-username',
+            'test-password')
+
+        self.assertIsNone(credentials)

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
@@ -38,7 +38,7 @@ class AuthenticatorTest(unittest.TestCase):
             'https://test-server.com', 'test-api', 'test-username',
             'test-password')
 
-        self.assertEquals('TEST-TOKEN', credentials['token'])
+        self.assertEqual('TEST-TOKEN', credentials['token'])
 
     def test_authenticate_should_raise_system_exit_on_failure(
             self, mock_requests):

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
@@ -32,13 +32,13 @@ class AuthenticatorTest(unittest.TestCase):
 
         mock_requests.post.return_value = \
             metadata_scraper_mocks.make_fake_response(
-                {'credentials': {'token': 'test-token'}}, 200)
+                {'credentials': {'token': 'TEST-TOKEN'}}, 200)
 
         credentials = authenticator.Authenticator.authenticate(
             'https://test-server.com', 'test-api', 'test-username',
             'test-password')
 
-        self.assertEquals('test-token', credentials['token'])
+        self.assertEquals('TEST-TOKEN', credentials['token'])
 
     def test_authenticate_should_raise_system_exit_on_failure(
             self, mock_requests):

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
@@ -24,15 +24,16 @@ from . import metadata_scraper_mocks
 __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
 
 
-@mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests')
+@mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests.post')
 class AuthenticatorTest(unittest.TestCase):
 
     def test_authenticate_should_return_credentials_on_success(
-            self, mock_requests):
+            self, mock_post):
 
-        mock_requests.post.return_value = \
-            metadata_scraper_mocks.make_fake_response(
-                {'credentials': {'token': 'TEST-TOKEN'}}, 200)
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'credentials': {
+                'token': 'TEST-TOKEN',
+            }}, 200)
 
         credentials = authenticator.Authenticator.authenticate(
             'https://test-server.com', 'test-api', 'test-username',
@@ -40,11 +41,10 @@ class AuthenticatorTest(unittest.TestCase):
 
         self.assertEqual('TEST-TOKEN', credentials['token'])
 
-    def test_authenticate_should_raise_system_exit_on_failure(
-            self, mock_requests):
+    def test_authenticate_should_raise_system_exit_on_failure(self, mock_post):
 
-        mock_requests.post.return_value = \
-            metadata_scraper_mocks.make_fake_response({'error': {}}, 401)
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'error': {}}, 401)
 
         self.assertRaises(SystemExit, authenticator.Authenticator.authenticate,
                           'https://test-server.com', 'test-api',

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/authenticator_test.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.tableau.scrape import authenticator
+
+from . import metadata_scraper_mocks
+
+__SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
+
+
+@mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests')
+class AuthenticatorTest(unittest.TestCase):
+
+    def test_authenticate_should_return_credentials_on_success(
+            self, mock_requests):
+
+        mock_requests.post.return_value = \
+            metadata_scraper_mocks.make_fake_response(
+                {'credentials': {'token': 'test-token'}}, 200)
+
+        credentials = authenticator.Authenticator.authenticate(
+            'https://test-server.com', 'test-api', 'test-username',
+            'test-password')
+
+        self.assertEquals('test-token', credentials['token'])
+
+    def test_authenticate_should_raise_system_exit_on_failure(
+            self, mock_requests):
+
+        mock_requests.post.return_value = \
+            metadata_scraper_mocks.make_fake_response({'error': {}}, 401)
+
+        self.assertRaises(SystemExit, authenticator.Authenticator.authenticate,
+                          'https://test-server.com', 'test-api',
+                          'test-username', 'test-password')

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_api_helper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_api_helper_test.py
@@ -20,21 +20,233 @@ from unittest import mock
 
 from google.datacatalog_connectors.tableau.scrape import metadata_api_helper
 
-__SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
+from . import metadata_scraper_mocks
 
 
-@mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests.post')
 class MetadataAPIHelperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
+    __HELPER_MODULE = f'{__SCRAPE_PACKAGE}.metadata_api_helper'
 
     def setUp(self):
-        self.__reader = metadata_api_helper.MetadataAPIHelper(
-            server_address='https://test-server.com',
-            auth_credentials={'token': 'TEST-TOKEN'})
+        self.__helper = metadata_api_helper.MetadataAPIHelper(
+            server_address='test-server',
+            api_version='test-api',
+            username='test-username',
+            password='test-password',
+            site_content_url='test-site-url')
 
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__helper.__dict__
+
+        self.assertEqual('test-server',
+                         attrs['_MetadataAPIHelper__server_address'])
+        self.assertEqual('test-api', attrs['_MetadataAPIHelper__api_version'])
+        self.assertEqual('test-username',
+                         attrs['_MetadataAPIHelper__username'])
+        self.assertEqual('test-password',
+                         attrs['_MetadataAPIHelper__password'])
+        self.assertEqual('test-site-url',
+                         attrs['_MetadataAPIHelper__site_content_url'])
+
+        self.assertEqual('test-server/relationship-service-war/graphql',
+                         attrs['_MetadataAPIHelper__api_endpoint'])
+
+    def test_constructor_should_not_set_auth_related_attributes(self):
+        attrs = self.__helper.__dict__
+        self.assertIsNone(attrs['_MetadataAPIHelper__auth_credentials'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests', mock.MagicMock())
+    @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
+    def test_scrape_operations_should_authenticate_user_beforehand(
+            self, mock_authenticate):
+
+        mock_authenticate.return_value = {'token': 'TEST-TOKEN'}
+
+        # Call a public method to trigger the authentication workflow.
+        self.__helper.fetch_sites()
+
+        mock_authenticate.assert_called_once()
+
+        attrs = self.__helper.__dict__
+        auth_credentials = attrs['_MetadataAPIHelper__auth_credentials']
+        self.assertIsNotNone(auth_credentials)
+        self.assertEqual({'token': 'TEST-TOKEN'}, auth_credentials)
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_dashboards_should_return_nonempty_list_on_success(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'data': {
+                'dashboards': [{
+                    'luid': 'TEST-ID-1',
+                }]
+            }}, 200)
+
+        dashboards = self.__helper.fetch_dashboards()
+
+        self.assertEqual(1, len(dashboards))
+        self.assertEqual('TEST-ID-1', dashboards[0]['luid'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_dashboards_should_add_site_content_url_return_value(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {
+                'data': {
+                    'dashboards': [{
+                        'luid': 'TEST-ID-1',
+                        'workbook': {
+                            'site': {},
+                        },
+                    }]
+                }
+            }, 200)
+
+        dashboards = self.__helper.fetch_dashboards()
+
+        self.assertEqual('test-site-url',
+                         dashboards[0]['workbook']['site']['contentUrl'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_dashboards_should_return_empty_list_on_unexpected_response(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'dashboards': [{
+                'luid': 'TEST-ID-1',
+            }]}, 200)
+
+        dashboards = self.__helper.fetch_dashboards()
+
+        self.assertEqual(0, len(dashboards))
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_sites_should_return_nonempty_list_on_success(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'data': {
+                'tableauSites': [{
+                    'luid': 'TEST-ID-1',
+                }]
+            }}, 200)
+
+        sites = self.__helper.fetch_sites()
+
+        self.assertEqual(1, len(sites))
+        self.assertEqual('TEST-ID-1', sites[0]['luid'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_sites_should_add_site_content_url_return_value(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'data': {
+                'tableauSites': [{
+                    'workbooks': [{
+                        'site': {}
+                    }]
+                }]
+            }}, 200)
+
+        sites = self.__helper.fetch_sites()
+
+        self.assertEqual('test-site-url', sites[0]['contentUrl'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_sites_should_return_empty_list_on_unexpected_response(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'tableauSites': [{
+                'luid': 'TEST-ID-1',
+            }]}, 200)
+
+        sites = self.__helper.fetch_sites()
+
+        self.assertEqual(0, len(sites))
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_workbooks_should_return_nonempty_list_on_success(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'data': {
+                'workbooks': [{
+                    'luid': 'TEST-ID-1',
+                }]
+            }}, 200)
+
+        workbooks = self.__helper.fetch_workbooks()
+
+        self.assertEqual(1, len(workbooks))
+        self.assertEqual('TEST-ID-1', workbooks[0]['luid'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_workbooks_should_add_site_content_url_return_value(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'data': {
+                'workbooks': [{
+                    'site': {}
+                }]
+            }}, 200)
+
+        workbooks = self.__helper.fetch_workbooks()
+
+        self.assertEqual('test-site-url', workbooks[0]['site']['contentUrl'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
+    def test_fetch_workbooks_should_return_empty_list_on_unexpected_response(
+            self, mock_post):
+
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'workbooks': [{
+                'luid': 'TEST-ID-1',
+            }]}, 200)
+
+        workbooks = self.__helper.fetch_workbooks()
+
+        self.assertEqual(0, len(workbooks))
+
+    @mock.patch(f'{__HELPER_MODULE}.requests.post')
     def test_fetch_workbooks_using_filter_should_post_filter_variable(
-            self, mock_post):  # noqa: E125
+            self, mock_post):
 
-        self.__reader.fetch_workbooks(query_filter={'luid': '123456789'})
+        attrs = self.__helper.__dict__
+        attrs['_MetadataAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        self.__helper.fetch_workbooks(query_filter={'luid': '123456789'})
 
         args, kwargs = mock_post.call_args_list[0]
         variables = json.loads(kwargs['json']['variables'])

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
@@ -29,17 +29,5 @@ def make_fake_response(json_data, status_code):
     return __FakeResponse(json_data, status_code)
 
 
-def mock_authenticate(server_address,
-                      api_version,
-                      username,
-                      password,
-                      site=None):
-    return {'token': 'TEST-TOKEN'}
-
-
 def mock_get_default_site(self):
     return [{'contentUrl': ''}]
-
-
-def mock_empty_response(url, data=None, json=None, **kwargs):
-    return make_fake_response({}, 200)

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
@@ -30,4 +30,8 @@ def make_fake_response(json_data, status_code):
 
 
 def mock_get_default_site(self):
+    """Simulates actual metadata for the Default site.
+    The `contentUrl` is always present and its value is an empty string.
+
+    """
     return [{'contentUrl': ''}]

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_mocks.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-class __MockResponse:
+class __FakeResponse:
 
     def __init__(self, json_data, status_code):
         self.__json_data = json_data
@@ -26,7 +26,7 @@ class __MockResponse:
 
 
 def make_fake_response(json_data, status_code):
-    return __MockResponse(json_data, status_code)
+    return __FakeResponse(json_data, status_code)
 
 
 def mock_authenticate(server_address,

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
@@ -41,7 +41,7 @@ class MetadataScraperTest(unittest.TestCase):
                                api_version=None,
                                username=None,
                                password=None,
-                               site='test').scrape_workbooks()
+                               site_content_url='test').scrape_workbooks()
 
         self.assertEqual(mock_post_authenticate.call_count, 1)
 

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
@@ -30,7 +30,7 @@ class MetadataScraperTest(unittest.TestCase):
                                   f'.MetadataAPIHelper'
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_dashboards')
-    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server',
                 metadata_scraper_mocks.mock_get_default_site)
     def test_scrape_dashboards_should_return_nonempty_list_on_success(
             self, mock_fetch_dashboards):
@@ -53,7 +53,7 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(2, len(metadata))
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
-    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server',
                 metadata_scraper_mocks.mock_get_default_site)
     def test_scrape_sites_should_return_nonempty_list_on_success(
             self, mock_fetch_sites):
@@ -76,7 +76,7 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(2, len(metadata))
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_workbooks')
-    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server',
                 metadata_scraper_mocks.mock_get_default_site)
     def test_scrape_workbooks_should_return_nonempty_list_on_success(
             self, mock_fetch_workbooks):
@@ -99,9 +99,9 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(2, len(metadata))
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
-    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server')
     def test_scrape_metadata_specific_site_should_fetch_assets_given_site(
-            self, mock_get_all_sites_on_server, mock_fetch_sites):
+            self, mock_get_all_sites_for_server, mock_fetch_sites):
 
         scrape.MetadataScraper(
             server_address='https://test-server.com',
@@ -110,20 +110,20 @@ class MetadataScraperTest(unittest.TestCase):
             password='test-password',
             site_content_url='test-site-url').scrape_sites()
 
-        mock_get_all_sites_on_server.assert_not_called()
+        mock_get_all_sites_for_server.assert_not_called()
         mock_fetch_sites.assert_called_once()
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
-    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server')
     def test_scrape_metadata_no_sites_available_should_not_fetch_assets(
-            self, mock_get_all_sites_on_server, mock_fetch_sites):
+            self, mock_get_all_sites_for_server, mock_fetch_sites):
 
-        mock_get_all_sites_on_server.return_value = []
+        mock_get_all_sites_for_server.return_value = []
 
         scrape.MetadataScraper(server_address='https://test-server.com',
                                api_version='test-api',
                                username='test-username',
                                password='test-password').scrape_sites()
 
-        mock_get_all_sites_on_server.assert_called_once()
+        mock_get_all_sites_for_server.assert_called_once()
         mock_fetch_sites.assert_not_called()

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
@@ -19,165 +19,111 @@ from unittest import mock
 
 from google.datacatalog_connectors.tableau import scrape
 
-from .metadata_scraper_mocks import make_fake_response, \
-    mock_authenticate, mock_get_default_site, mock_empty_response
+from . import metadata_scraper_mocks
 
 
 class MetadataScraperTest(unittest.TestCase):
     __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
+    __REST_API_HELPER_CLASS = f'{__SCRAPE_PACKAGE}.rest_api_helper' \
+                              f'.RestAPIHelper'
+    __METADATA_API_HELPER_CLASS = f'{__SCRAPE_PACKAGE}.metadata_api_helper' \
+                                  f'.MetadataAPIHelper'
 
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests.post')
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper'
-                f'.MetadataAPIHelper.fetch_workbooks', lambda self, *args: [])
-    def test_scrape_metadata_should_authenticate_user(self,
-                                                      mock_post_authenticate):
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_dashboards')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+                metadata_scraper_mocks.mock_get_default_site)
+    def test_scrape_dashboards_should_return_nonempty_list_on_success(
+            self, mock_fetch_dashboards):
 
-        mock_post_authenticate.return_value = make_fake_response(
-            {'credentials': {
-                'token': 'TEST-TOKEN'
-            }}, 200)
-
-        scrape.MetadataScraper(server_address=None,
-                               api_version=None,
-                               username=None,
-                               password=None,
-                               site_content_url='test').scrape_workbooks()
-
-        self.assertEqual(mock_post_authenticate.call_count, 1)
-
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.requests.get')
-    def test_scrape_metadata_no_sites_available_should_not_raise_exception(
-            self, mock_get_sites):  # noqa: E125
-
-        mock_get_sites.return_value = make_fake_response({}, 200)
-
-        scrape.MetadataScraper(server_address=None,
-                               api_version=None,
-                               username=None,
-                               password=None).scrape_workbooks()
-
-        self.assertEqual(mock_get_sites.call_count, 1)
-
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post')
-    def test_scrape_dashboards_should_return_nonempty_list(
-            self, mock_post_query_dashboards):  # noqa: E125
-
-        mock_post_query_dashboards.return_value = make_fake_response(
+        mock_fetch_dashboards.return_value = [
             {
-                'data': {
-                    'dashboards': [{
-                        'luid': 'TEST-ID-1'
-                    }, {
-                        'luid': 'TEST-ID-2'
-                    }]
-                }
-            }, 200)
+                'luid': 'TEST-ID-1',
+            },
+            {
+                'luid': 'TEST-ID-2',
+            },
+        ]
 
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_dashboards()
+        metadata = scrape.MetadataScraper(
+            server_address='https://test-server.com',
+            api_version='test-api',
+            username='test-username',
+            password='test-password').scrape_dashboards()
 
         self.assertEqual(2, len(metadata))
 
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post',
-                mock_empty_response)
-    def test_scrape_dashboards_no_data_available_should_return_empty_list(
-            self):  # noqa: E125
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+                metadata_scraper_mocks.mock_get_default_site)
+    def test_scrape_sites_should_return_nonempty_list_on_success(
+            self, mock_fetch_sites):
 
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_dashboards()
-
-        self.assertEqual(0, len(metadata))
-
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post')
-    def test_scrape_sites_should_return_nonempty_list(
-            self, mock_post_query_sites):  # noqa: E125
-
-        mock_post_query_sites.return_value = make_fake_response(
+        mock_fetch_sites.return_value = [
             {
-                'data': {
-                    'tableauSites': [{
-                        'luid': 'TEST-ID-1'
-                    }, {
-                        'luid': 'TEST-ID-2'
-                    }]
-                }
-            }, 200)
+                'luid': 'TEST-ID-1',
+            },
+            {
+                'luid': 'TEST-ID-2',
+            },
+        ]
 
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_sites()
+        metadata = scrape.MetadataScraper(
+            server_address='https://test-server.com',
+            api_version='test-api',
+            username='test-username',
+            password='test-password').scrape_sites()
 
         self.assertEqual(2, len(metadata))
 
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post',
-                mock_empty_response)
-    def test_scrape_sites_no_data_available_should_return_empty_list(self):
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_sites()
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_workbooks')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server',
+                metadata_scraper_mocks.mock_get_default_site)
+    def test_scrape_workbooks_should_return_nonempty_list_on_success(
+            self, mock_fetch_workbooks):
 
-        self.assertEqual(0, len(metadata))
-
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post')
-    def test_scrape_workbooks_should_return_nonempty_list(
-            self, mock_post_query_workbooks):  # noqa: E125
-
-        mock_post_query_workbooks.return_value = make_fake_response(
+        mock_fetch_workbooks.return_value = [
             {
-                'data': {
-                    'workbooks': [{
-                        'luid': 'TEST-ID-1'
-                    }, {
-                        'luid': 'TEST-ID-2'
-                    }]
-                }
-            }, 200)
+                'luid': 'TEST-ID-1',
+            },
+            {
+                'luid': 'TEST-ID-2',
+            },
+        ]
 
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_workbooks()
+        metadata = scrape.MetadataScraper(
+            server_address='https://test-server.com',
+            api_version='test-api',
+            username='test-username',
+            password='test-password').scrape_workbooks()
 
         self.assertEqual(2, len(metadata))
 
-    @mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.Authenticator.authenticate',
-                mock_authenticate)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.rest_api_helper.RestAPIHelper'
-                f'.get_all_sites_on_server', mock_get_default_site)
-    @mock.patch(f'{__SCRAPE_PACKAGE}.metadata_api_helper.requests.post',
-                mock_empty_response)
-    def test_scrape_workbooks_no_data_available_should_return_empty_list(self):
-        metadata = scrape.MetadataScraper(server_address=None,
-                                          api_version=None,
-                                          username=None,
-                                          password=None).scrape_workbooks()
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server')
+    def test_scrape_metadata_specific_site_should_fetch_assets_given_site(
+            self, mock_get_all_sites_on_server, mock_fetch_sites):
 
-        self.assertEqual(0, len(metadata))
+        scrape.MetadataScraper(
+            server_address='https://test-server.com',
+            api_version='test-api',
+            username='test-username',
+            password='test-password',
+            site_content_url='test-site-url').scrape_sites()
+
+        mock_get_all_sites_on_server.assert_not_called()
+        mock_fetch_sites.assert_called_once()
+
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_on_server')
+    def test_scrape_metadata_no_sites_available_should_not_fetch_assets(
+            self, mock_get_all_sites_on_server, mock_fetch_sites):
+
+        mock_get_all_sites_on_server.return_value = []
+
+        scrape.MetadataScraper(server_address='https://test-server.com',
+                               api_version='test-api',
+                               username='test-username',
+                               password='test-password').scrape_sites()
+
+        mock_get_all_sites_on_server.assert_called_once()
+        mock_fetch_sites.assert_not_called()

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
@@ -100,6 +100,35 @@ class MetadataScraperTest(unittest.TestCase):
 
     @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
     @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server')
+    def test_scrape_metadata_multiple_sites_should_fetch_assets_from_all(
+            self, mock_get_all_sites_for_server, mock_fetch_sites):
+
+        # The 'contentUrl' field is actually informed as an empty string for
+        # the Default site and fulfilled for all other sites created by the
+        # users.
+        mock_get_all_sites_for_server.return_value = [
+            {
+                'id': 'TEST-ID-1',
+                'name': 'Default',
+                'contentUrl': '',
+            },
+            {
+                'id': 'TEST-ID-2',
+                'name': 'My site',
+                'contentUrl': 'my-site',
+            },
+        ]
+
+        scrape.MetadataScraper(server_address='https://test-server.com',
+                               api_version='test-api',
+                               username='test-username',
+                               password='test-password').scrape_sites()
+
+        mock_get_all_sites_for_server.assert_called_once()
+        self.assertEqual(2, mock_fetch_sites.call_count)
+
+    @mock.patch(f'{__METADATA_API_HELPER_CLASS}.fetch_sites')
+    @mock.patch(f'{__REST_API_HELPER_CLASS}.get_all_sites_for_server')
     def test_scrape_metadata_specific_site_should_fetch_assets_given_site(
             self, mock_get_all_sites_for_server, mock_fetch_sites):
 

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/metadata_scraper_test.py
@@ -61,9 +61,13 @@ class MetadataScraperTest(unittest.TestCase):
         mock_fetch_sites.return_value = [
             {
                 'luid': 'TEST-ID-1',
+                'workbooks': [{
+                    'sheets': []
+                }],
             },
             {
                 'luid': 'TEST-ID-2',
+                'workbooks': [],
             },
         ]
 

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/rest_api_helper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/rest_api_helper_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.tableau.scrape import rest_api_helper
+
+from . import metadata_scraper_mocks
+
+
+class RestAPIHelperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
+    __HELPER_MODULE = f'{__SCRAPE_PACKAGE}.rest_api_helper'
+
+    def setUp(self):
+        self.__helper = rest_api_helper.RestAPIHelper(
+            server_address='test-server',
+            api_version='test-api',
+            username='test-username',
+            password='test-password',
+            site_content_url='test-site-url')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__helper.__dict__
+
+        self.assertEqual('test-server',
+                         attrs['_RestAPIHelper__server_address'])
+        self.assertEqual('test-api', attrs['_RestAPIHelper__api_version'])
+        self.assertEqual('test-username', attrs['_RestAPIHelper__username'])
+        self.assertEqual('test-password', attrs['_RestAPIHelper__password'])
+        self.assertEqual('test-site-url',
+                         attrs['_RestAPIHelper__site_content_url'])
+
+        self.assertEqual('test-server/api/test-api',
+                         attrs['_RestAPIHelper__base_api_endpoint'])
+        self.assertIsNotNone(attrs['_RestAPIHelper__common_headers'])
+
+    def test_constructor_should_not_set_auth_related_attributes(self):
+        attrs = self.__helper.__dict__
+        self.assertIsNone(attrs['_RestAPIHelper__auth_credentials'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests', mock.MagicMock())
+    @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
+    def test_scrape_operations_should_authenticate_user_beforehand(
+            self, mock_authenticate):
+
+        mock_authenticate.return_value = {'token': 'TEST-TOKEN'}
+
+        # Call a public method to trigger the authentication workflow.
+        self.__helper.get_all_sites_for_server()
+
+        mock_authenticate.assert_called_once()
+
+        attrs = self.__helper.__dict__
+        auth_credentials = attrs['_RestAPIHelper__auth_credentials']
+        self.assertIsNotNone(auth_credentials)
+        self.assertEqual({'token': 'TEST-TOKEN'}, auth_credentials)
+
+    @mock.patch(f'{__HELPER_MODULE}.requests')
+    def test_get_all_sites_for_server_should_return_nonempty_list_on_success(
+            self, mock_requests):
+
+        attrs = self.__helper.__dict__
+        attrs['_RestAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_requests.get.return_value = \
+            metadata_scraper_mocks.make_fake_response(
+                {'sites': {
+                    'site': [{
+                        'luid': 'TEST-ID-1',
+                    }]
+                }}, 200)
+
+        sites = self.__helper.get_all_sites_for_server()
+
+        self.assertEqual(1, len(sites))
+        self.assertEqual('TEST-ID-1', sites[0]['luid'])
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Tableau-Auth': 'TEST-TOKEN',
+        }
+        mock_requests.get.assert_called_with(
+            url='test-server/api/test-api/sites', headers=headers)
+
+    @mock.patch(f'{__HELPER_MODULE}.requests')
+    def test_get_all_sites_for_server_should_return_empty_list_on_unexpected_response(  # noqa E510
+            self, mock_requests):
+
+        attrs = self.__helper.__dict__
+        attrs['_RestAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
+
+        mock_requests.get.return_value = \
+            metadata_scraper_mocks.make_fake_response(
+                {'sites': [{
+                    'luid': 'TEST-ID-1',
+                }]}, 200)
+
+        sites = self.__helper.get_all_sites_for_server()
+
+        self.assertEqual(0, len(sites))

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/rest_api_helper_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/scrape/rest_api_helper_test.py
@@ -70,20 +70,19 @@ class RestAPIHelperTest(unittest.TestCase):
         self.assertIsNotNone(auth_credentials)
         self.assertEqual({'token': 'TEST-TOKEN'}, auth_credentials)
 
-    @mock.patch(f'{__HELPER_MODULE}.requests')
+    @mock.patch(f'{__HELPER_MODULE}.requests.get')
     def test_get_all_sites_for_server_should_return_nonempty_list_on_success(
-            self, mock_requests):
+            self, mock_get):
 
         attrs = self.__helper.__dict__
         attrs['_RestAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
 
-        mock_requests.get.return_value = \
-            metadata_scraper_mocks.make_fake_response(
-                {'sites': {
-                    'site': [{
-                        'luid': 'TEST-ID-1',
-                    }]
-                }}, 200)
+        mock_get.return_value = metadata_scraper_mocks.make_fake_response(
+            {'sites': {
+                'site': [{
+                    'luid': 'TEST-ID-1',
+                }]
+            }}, 200)
 
         sites = self.__helper.get_all_sites_for_server()
 
@@ -95,21 +94,20 @@ class RestAPIHelperTest(unittest.TestCase):
             'Accept': 'application/json',
             'X-Tableau-Auth': 'TEST-TOKEN',
         }
-        mock_requests.get.assert_called_with(
-            url='test-server/api/test-api/sites', headers=headers)
+        mock_get.assert_called_with(url='test-server/api/test-api/sites',
+                                    headers=headers)
 
-    @mock.patch(f'{__HELPER_MODULE}.requests')
+    @mock.patch(f'{__HELPER_MODULE}.requests.get')
     def test_get_all_sites_for_server_should_return_empty_list_on_unexpected_response(  # noqa E510
-            self, mock_requests):
+            self, mock_get):
 
         attrs = self.__helper.__dict__
         attrs['_RestAPIHelper__auth_credentials'] = {'token': 'TEST-TOKEN'}
 
-        mock_requests.get.return_value = \
-            metadata_scraper_mocks.make_fake_response(
-                {'sites': [{
-                    'luid': 'TEST-ID-1',
-                }]}, 200)
+        mock_get.return_value = metadata_scraper_mocks.make_fake_response(
+            {'sites': [{
+                'luid': 'TEST-ID-1',
+            }]}, 200)
 
         sites = self.__helper.get_all_sites_for_server()
 

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/dashboards_synchronizer_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/dashboards_synchronizer_test.py
@@ -23,24 +23,20 @@ from google.datacatalog_connectors.commons import prepare
 from google.datacatalog_connectors.tableau.sync import \
     dashboards_synchronizer
 
-_COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
-_PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
-_SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
-
 
 class DashboardsSynchronizerTest(unittest.TestCase):
+    __COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
 
-    @mock.patch(f'{_COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
-    @mock.patch(f'{_COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
-    @mock.patch(f'{_PREPARE_PACKAGE}.EntryRelationshipMapper')
-    @mock.patch(f'{_PREPARE_PACKAGE}.AssembledEntryFactory')
-    @mock.patch(f'{_SCRAPE_PACKAGE}.MetadataScraper')
+    @mock.patch(f'{__COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
+    @mock.patch(f'{__COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
+    @mock.patch(f'{__PREPARE_PACKAGE}.EntryRelationshipMapper')
+    @mock.patch(f'{__PREPARE_PACKAGE}.AssembledEntryFactory')
+    @mock.patch(f'{__SCRAPE_PACKAGE}.MetadataScraper')
     def test_run_should_process_scrape_prepare_ingest_workflow(
             self, mock_scraper, mock_assembled_entry_factory, mock_mapper,
-            mock_cleaner, mock_ingestor):  # noqa: E125
-
-        scraper = mock_scraper.return_value
-        scraper.scrape_dashboards.return_value = [{}]
+            mock_cleaner, mock_ingestor):
 
         assembled_entry_factory = mock_assembled_entry_factory.return_value
         assembled_entry_factory.make_entries_for_dashboards.return_value = [
@@ -57,7 +53,9 @@ class DashboardsSynchronizerTest(unittest.TestCase):
             datacatalog_project_id='test-project-id',
             datacatalog_location_id='test-location-id').run()
 
+        scraper = mock_scraper.return_value
         scraper.scrape_dashboards.assert_called_once()
+
         assembled_entry_factory.make_entries_for_dashboards\
             .assert_called_once()
         mock_mapper.return_value.fulfill_tag_fields.assert_called_once()

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/metadata_synchronizer_mocks.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/metadata_synchronizer_mocks.py
@@ -37,7 +37,7 @@ class FakeSynchronizer(metadata_synchronizer.MetadataSynchronizer):
                          tableau_site='test-site',
                          datacatalog_project_id='test-project-id',
                          datacatalog_location_id='test-location-id',
-                         assets_type=['test-type'])
+                         asset_types=['test-type'])
 
     def _scrape_source_system_metadata(self, query_filter=None):
         return []

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/metadata_synchronizer_test.py
@@ -41,8 +41,9 @@ class MetadataSynchronizerTest(unittest.TestCase):
         self.assertEqual('test-location-id',
                          attrs['_MetadataSynchronizer__location_id'])
         self.assertEqual(['test-type'],
-                         attrs['_MetadataSynchronizer__assets_type'])
-        self.assertEqual('test-site', attrs['_MetadataSynchronizer__site'])
+                         attrs['_MetadataSynchronizer__asset_types'])
+        self.assertEqual('test-site',
+                         attrs['_MetadataSynchronizer__site_content_url'])
 
         self.assertIsNotNone(attrs['_metadata_scraper'])
         self.assertIsNotNone(attrs['_entry_factory'])

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/sites_synchronizer_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/sites_synchronizer_test.py
@@ -21,24 +21,20 @@ from google.datacatalog_connectors.commons import prepare
 from google.datacatalog_connectors.tableau.sync import \
     sites_synchronizer
 
-_COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
-_PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
-_SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
-
 
 class SitesSynchronizerTest(unittest.TestCase):
+    __COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
 
-    @mock.patch(f'{_COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
-    @mock.patch(f'{_COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
-    @mock.patch(f'{_PREPARE_PACKAGE}.EntryRelationshipMapper')
-    @mock.patch(f'{_PREPARE_PACKAGE}.AssembledEntryFactory')
-    @mock.patch(f'{_SCRAPE_PACKAGE}.MetadataScraper')
+    @mock.patch(f'{__COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
+    @mock.patch(f'{__COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
+    @mock.patch(f'{__PREPARE_PACKAGE}.EntryRelationshipMapper')
+    @mock.patch(f'{__PREPARE_PACKAGE}.AssembledEntryFactory')
+    @mock.patch(f'{__SCRAPE_PACKAGE}.MetadataScraper')
     def test_run_should_process_scrape_prepare_ingest_workflow(
             self, mock_scraper, mock_assembled_entry_factory, mock_mapper,
-            mock_cleaner, mock_ingestor):  # noqa: E125
-
-        scraper = mock_scraper.return_value
-        scraper.scrape_sites.return_value = [{'workbooks': [{'sheets': []}]}]
+            mock_cleaner, mock_ingestor):
 
         assembled_entry_factory = mock_assembled_entry_factory.return_value
         assembled_entry_factory.make_entries_for_sites.return_value = \
@@ -53,7 +49,9 @@ class SitesSynchronizerTest(unittest.TestCase):
             datacatalog_project_id='test-project-id',
             datacatalog_location_id='test-location-id').run()
 
+        scraper = mock_scraper.return_value
         scraper.scrape_sites.assert_called_once()
+
         assembled_entry_factory.make_entries_for_sites.assert_called_once()
         mock_mapper.return_value.fulfill_tag_fields.assert_called_once()
         mock_cleaner.return_value.delete_obsolete_metadata.assert_called_once()

--- a/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer_test.py
+++ b/google-datacatalog-tableau-connector/tests/google/datacatalog_connectors/tableau/sync/workbooks_synchronizer_test.py
@@ -21,24 +21,20 @@ from google.datacatalog_connectors.commons import prepare
 from google.datacatalog_connectors.tableau.sync import \
     workbooks_synchronizer
 
-_COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
-_PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
-_SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
-
 
 class WorkbooksSynchronizerTest(unittest.TestCase):
+    __COMMONS_PACKAGE = 'google.datacatalog_connectors.commons'
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.tableau.prepare'
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.tableau.scrape'
 
-    @mock.patch(f'{_COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
-    @mock.patch(f'{_COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
-    @mock.patch(f'{_PREPARE_PACKAGE}.EntryRelationshipMapper')
-    @mock.patch(f'{_PREPARE_PACKAGE}.AssembledEntryFactory')
-    @mock.patch(f'{_SCRAPE_PACKAGE}.MetadataScraper')
+    @mock.patch(f'{__COMMONS_PACKAGE}.ingest.DataCatalogMetadataIngestor')
+    @mock.patch(f'{__COMMONS_PACKAGE}.cleanup.DataCatalogMetadataCleaner')
+    @mock.patch(f'{__PREPARE_PACKAGE}.EntryRelationshipMapper')
+    @mock.patch(f'{__PREPARE_PACKAGE}.AssembledEntryFactory')
+    @mock.patch(f'{__SCRAPE_PACKAGE}.MetadataScraper')
     def test_run_should_process_scrape_prepare_ingest_workflow(
             self, mock_scraper, mock_assembled_entry_factory, mock_mapper,
-            mock_cleaner, mock_ingestor):  # noqa: E125
-
-        scraper = mock_scraper.return_value
-        scraper.scrape_workbooks.return_value = [{'sheets': []}]
+            mock_cleaner, mock_ingestor):
 
         assembled_entry_factory = mock_assembled_entry_factory.return_value
         assembled_entry_factory.make_entries_for_workbooks.return_value = \
@@ -53,7 +49,9 @@ class WorkbooksSynchronizerTest(unittest.TestCase):
             datacatalog_project_id='test-project-id',
             datacatalog_location_id='test-location-id').run()
 
+        scraper = mock_scraper.return_value
         scraper.scrape_workbooks.assert_called_once()
+
         assembled_entry_factory.make_entries_for_workbooks.assert_called_once()
         mock_mapper.return_value.fulfill_tag_fields.assert_called_once()
         mock_cleaner.return_value.delete_obsolete_metadata.assert_called_once()

--- a/google-datacatalog-tableau-connector/tools/postman/Tableau GraphQL API.postman_collection.json
+++ b/google-datacatalog-tableau-connector/tools/postman/Tableau GraphQL API.postman_collection.json
@@ -52,7 +52,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"credentials\": {\n\t\t\"name\": \"{{USERNAME}}\",\n\t\t\"password\": \"{{PASSWORD}}\",\n\t\t\"site\": {\n\t\t\t\"contentUrl\": \"{{SITE_URL}}\"\t\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"credentials\": {\n\t\t\"name\": \"{{USERNAME}}\",\n\t\t\"password\": \"{{PASSWORD}}\",\n\t\t\"site\": {\n\t\t\t\"contentUrl\": \"{{SITE_CONTENT_URL}}\"\t\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/auth/signin",

--- a/google-datacatalog-tableau-connector/tools/postman/Tableau REST API.postman_collection.json
+++ b/google-datacatalog-tableau-connector/tools/postman/Tableau REST API.postman_collection.json
@@ -51,7 +51,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"credentials\": {\n\t\t\"name\": \"{{USERNAME}}\",\n\t\t\"password\": \"{{PASSWORD}}\",\n\t\t\"site\": {\n\t\t\t\"contentUrl\": \"{{SITE_URL}}\"\t\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"credentials\": {\n\t\t\"name\": \"{{USERNAME}}\",\n\t\t\"password\": \"{{PASSWORD}}\",\n\t\t\"site\": {\n\t\t\t\"contentUrl\": \"{{SITE_CONTENT_URL}}\"\t\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/auth/signin",
@@ -517,6 +517,102 @@
 								"api",
 								"{{API_VERSION}}",
 								"sites"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "1.06.02 Get Site by id",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Tableau-Auth",
+								"type": "text",
+								"value": "{{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/sites/{{siteId}}",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"sites",
+								"{{siteId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "1.06.03 Get Site by contentUrl",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Tableau-Auth",
+								"type": "text",
+								"value": "{{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/sites/{{SITE_CONTENT_URL}}?key=contentUrl",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"sites",
+								"{{SITE_CONTENT_URL}}"
+							],
+							"query": [
+								{
+									"key": "key",
+									"value": "contentUrl"
+								}
 							]
 						}
 					},

--- a/google-datacatalog-tableau-connector/tools/postman/tableau-sample-environment.postman_environment.json
+++ b/google-datacatalog-tableau-connector/tools/postman/tableau-sample-environment.postman_environment.json
@@ -1,0 +1,39 @@
+{
+	"id": "878113d5-ee8e-49cb-a3b0-9bab240a52e5",
+	"name": "tableau-sample-environment",
+	"values": [
+		{
+			"key": "SCHEME",
+			"value": "https",
+			"enabled": true
+		},
+		{
+			"key": "SERVER",
+			"value": "server.domain.com",
+			"enabled": true
+		},
+		{
+			"key": "API_VERSION",
+			"value": "3.6",
+			"enabled": true
+		},
+		{
+			"key": "USERNAME",
+			"value": "username@domain.com",
+			"enabled": true
+		},
+		{
+			"key": "PASSWORD",
+			"value": "password",
+			"enabled": true
+		},
+		{
+			"key": "SITE_CONTENT_URL",
+			"value": "mysite",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-12-06T14:03:04.755Z",
+	"_postman_exported_using": "Postman/7.36.0"
+}


### PR DESCRIPTION
**- What I did**
1. Changed the Metadata API scrape results in order to inject the `contentUrl` field into `site` objects.
1. Changed the Data Catalog Entry factory to use this new field when generating the `entry.linkedResource` field.

This PR closes #43.

**- How I did it**
1. Added the `MetadataAPIHelper.__add_site_content_url_field()` method and called it at the end of all public methods of the class.
1. Fixed the `DataCatalogEntryFactory.__format_site_content_url()` method to use the site `contentUrl` instead of the name.

I'm also leveraging this PR to add some improvements to the Tableau connector:
1. The authentication workflows are now fully managed by the API Helper classes to keep consistency with other BI connectors.
1. The scrape result logs are now fully managed by the MetadataScraper class to keep consistency with other BI connectors.
1. Updated the unit tests to cover all changes.
1. Updated the REST API Postman Collection.

**- How to verify it**
Run the unit tests and, **preferably, the connector against a Tableau Server with more than one site** to verify the linked resources generated for entries scraped from the default site and the others.

**- Description for the changelog**
Generate Data Catalog Entry linked resource from the site contentUrl field. 
