### PR TITLE
Scrape Custom Property Definitions

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -219,13 +219,13 @@ already validated:
 
 - Qlik Sense Repository Service API
 
-| Version                 | Result  |
+| VERSION                 | RESULT  |
 | ----------------------- | :-----: |
 | 34.16.0 (September2020) | SUCCESS |
 
 - Qlik Engine JSON API
 
-| Version                  | Result  |
+| VERSION                  | RESULT  |
 | ------------------------ | :-----: |
 | 12.763.4 (September2020) | SUCCESS |
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -48,6 +48,17 @@ class MetadataScraper:
 
         return apps
 
+    def scrape_all_custom_property_definitions(self):
+        self.__log_scrape_start('Scraping all Custom Property Definitions...')
+        defs = self.__qrs_api_helper.get_full_custom_property_definition_list()
+
+        logging.info('  %s Custom Property Definitions found:', len(defs))
+        for defintion in defs:
+            logging.info('    - %s [%s]', defintion.get('name'),
+                         defintion.get('id'))
+
+        return defs
+
     def scrape_all_streams(self):
         self.__log_scrape_start('Scraping all Streams...')
         streams = self.__qrs_api_helper.get_full_stream_list()

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -59,7 +59,7 @@ class MetadataScraper:
         return streams
 
     def scrape_sheets(self, app_metadata):
-        self.__log_scrape_start('Scraping Sheets from the "%s" App',
+        self.__log_scrape_start('Scraping Sheets from the "%s" App...',
                                 app_metadata.get('name'))
         sheets = self.__engine_api_helper.get_sheets(
             app_metadata.get('id')) or []

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
@@ -61,10 +61,11 @@ class RepositoryServicesAPIHelper:
         Returns:
             A list of full app metadata objects.
         """
+        self.__set_up_http_session()
+
         url = f'{self.__base_api_endpoint}' \
               f'/app/hublist/full?Xrfkey={constants.XRFKEY}'
 
-        self.__set_up_http_session()
         return self.__http_session.get(url=url,
                                        headers=self.__common_headers).json()
 
@@ -74,10 +75,11 @@ class RepositoryServicesAPIHelper:
         Returns:
             A list of full stream metadata objects.
         """
+        self.__set_up_http_session()
+
         url = f'{self.__base_api_endpoint}' \
               f'/stream/full?Xrfkey={constants.XRFKEY}'
 
-        self.__set_up_http_session()
         return self.__http_session.get(url=url,
                                        headers=self.__common_headers).json()
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper.py
@@ -55,30 +55,36 @@ class RepositoryServicesAPIHelper:
         self.__http_session = None
 
     def get_full_app_list(self):
-        """Get the list of all apps that can be opened by the current user,
+        """Get the list of all Apps that can be opened by the current user,
         via the current proxy.
 
         Returns:
-            A list of full app metadata objects.
+            A list of full App metadata objects.
         """
-        self.__set_up_http_session()
+        return self.__execute_api_call('app/hublist/full')
 
-        url = f'{self.__base_api_endpoint}' \
-              f'/app/hublist/full?Xrfkey={constants.XRFKEY}'
-
-        return self.__http_session.get(url=url,
-                                       headers=self.__common_headers).json()
-
-    def get_full_stream_list(self):
-        """Get the list of streams with full metadata from a given server.
+    def get_full_custom_property_definition_list(self):
+        """Get the list of Custom Property Definitions with full metadata from
+        a given server.
 
         Returns:
-            A list of full stream metadata objects.
+            A list of full Custom Property Definition metadata objects.
         """
+        return self.__execute_api_call('custompropertydefinition/full')
+
+    def get_full_stream_list(self):
+        """Get the list of Streams with full metadata from a given server.
+
+        Returns:
+            A list of full Stream metadata objects.
+        """
+        return self.__execute_api_call('stream/full')
+
+    def __execute_api_call(self, resource_path):
         self.__set_up_http_session()
 
-        url = f'{self.__base_api_endpoint}' \
-              f'/stream/full?Xrfkey={constants.XRFKEY}'
+        url = f'{self.__base_api_endpoint}/{resource_path}' \
+              f'?Xrfkey={constants.XRFKEY}'
 
         return self.__http_session.get(url=url,
                                        headers=self.__common_headers).json()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -55,6 +55,29 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual('app-id', apps[0].get('id'))
         qrs_api_helper.get_full_app_list.assert_called_once()
 
+    def test_scrape_all_custom_property_definitions_should_return_list_on_success(  # noqa E510
+            self):
+
+        attrs = self.__scraper.__dict__
+        qrs_api_helper = attrs['_MetadataScraper__qrs_api_helper']
+
+        custom_property_defs_metadata = [{
+            'id': 'custom-property-definition-id',
+        }]
+
+        attrs['_MetadataScraper__qrs_api_session'] = mock.MagicMock()
+        qrs_api_helper.get_full_custom_property_definition_list\
+            .return_value = custom_property_defs_metadata
+
+        custom_property_defs = \
+            self.__scraper.scrape_all_custom_property_definitions()
+
+        self.assertEqual(1, len(custom_property_defs))
+        self.assertEqual('custom-property-definition-id',
+                         custom_property_defs[0].get('id'))
+        qrs_api_helper.get_full_custom_property_definition_list\
+            .assert_called_once()
+
     def test_scrape_all_streams_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__
         qrs_api_helper = attrs['_MetadataScraper__qrs_api_helper']

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -77,12 +77,11 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
         self.__helper.get_full_stream_list()
 
         attrs = self.__helper.__dict__
-        extra_headers = attrs[
-            '_RepositoryServicesAPIHelper__common_headers'].copy()
-        extra_headers['User-Agent'] = 'Windows'
+        headers = attrs['_RepositoryServicesAPIHelper__common_headers'].copy()
+        headers['User-Agent'] = 'Windows'
         mock_requests.get.assert_called_with(
             url=f'test-server/qrs/about?Xrfkey={constants.XRFKEY}',
-            headers=extra_headers,
+            headers=headers,
             allow_redirects=False)
 
         mock_authenticator.get_qps_session_cookie_windows_auth \

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/repository_services_api_helper_test.py
@@ -112,9 +112,31 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
 
         self.assertEqual(1, len(apps))
         self.assertEqual('app-id', apps[0].get('id'))
-        mock_session.get.assert_called_once()
-        mock_session.get.assert_called_with(
+        mock_session.get.assert_called_once_with(
             url=f'test-server/qrs/app/hublist/full?Xrfkey={constants.XRFKEY}',
+            headers=attrs['_RepositoryServicesAPIHelper__common_headers'],
+        )
+
+    @mock.patch(f'{__HELPER_MODULE}.sessions.Session')
+    def test_get_full_custom_property_definition_list_should_return_list_on_success(  # noqa E510
+            self, mock_session):
+
+        mock_session.get.return_value = \
+            scrape_ops_mocks.FakeResponseWithContent(
+                '[{\"id\": \"custom-property-definition-id\"}]')
+
+        attrs = self.__helper.__dict__
+        attrs['_RepositoryServicesAPIHelper__http_session'] = mock_session
+
+        custom_property_defs = \
+            self.__helper.get_full_custom_property_definition_list()
+
+        self.assertEqual(1, len(custom_property_defs))
+        self.assertEqual('custom-property-definition-id',
+                         custom_property_defs[0].get('id'))
+        mock_session.get.assert_called_once_with(
+            url=f'test-server/qrs'
+            f'/custompropertydefinition/full?Xrfkey={constants.XRFKEY}',
             headers=attrs['_RepositoryServicesAPIHelper__common_headers'],
         )
 
@@ -133,8 +155,7 @@ class RepositoryServicesAPIHelperTest(unittest.TestCase):
 
         self.assertEqual(1, len(streams))
         self.assertEqual('stream-id', streams[0].get('id'))
-        mock_session.get.assert_called_once()
-        mock_session.get.assert_called_with(
+        mock_session.get.assert_called_once_with(
             url=f'test-server/qrs/stream/full?Xrfkey={constants.XRFKEY}',
             headers=attrs['_RepositoryServicesAPIHelper__common_headers'],
         )


### PR DESCRIPTION
**- What I did**
Added the elementary code to scrape Custom Property Definitions. The current scrape/prepare/ingest workflow has not been changed yet.

**- How I did it**
Added the `scrape_all_custom_property_definitions()` method to `MetadataScraper` class and `get_full_custom_property_definition_list()` to the `RepositoryServicesAPIHelper`.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added elementary code to scrape Custom Property Definitions.
