### PR TITLE
Add support to ingest Custom Prop Definitions

### DIFF
--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -39,7 +39,25 @@ class AssembledEntryFactory:
         self.__datacatalog_tag_factory = \
             datacatalog_tag_factory.DataCatalogTagFactory(site_url)
 
-    def make_assembled_entries_list(self, stream_metadata, tag_templates_dict):
+    def make_assembled_entry_for_custom_property_def(
+            self, custom_property_def_metadata, tag_template):
+
+        entry_id, entry = self.__datacatalog_entry_factory\
+            .make_entry_for_custom_property_definition(
+                custom_property_def_metadata)
+
+        tags = []
+        if tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.
+                make_tag_for_custom_property_defintion(
+                    tag_template, custom_property_def_metadata))
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)
+
+    def make_assembled_entries_for_stream(self, stream_metadata,
+                                          tag_templates_dict):
+
         self.__initialize_tag_templates(tag_templates_dict)
 
         assembled_entries = [

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -32,10 +32,6 @@ class AssembledEntryFactory:
                 project_id, location_id, entry_group_id, user_specified_system,
                 site_url)
 
-        self.__app_tag_template = None
-        self.__sheet_tag_template = None
-        self.__stream_tag_template = None
-
         self.__datacatalog_tag_factory = \
             datacatalog_tag_factory.DataCatalogTagFactory(site_url)
 
@@ -58,40 +54,37 @@ class AssembledEntryFactory:
     def make_assembled_entries_for_stream(self, stream_metadata,
                                           tag_templates_dict):
 
-        self.__initialize_tag_templates(tag_templates_dict)
-
         assembled_entries = [
-            self.__make_assembled_entry_for_stream(stream_metadata)
+            self.__make_assembled_entry_for_stream(stream_metadata,
+                                                   tag_templates_dict)
         ]
 
         assembled_entries.extend(
-            self.__make_assembled_entries_for_apps(
-                stream_metadata.get('apps')))
+            self.__make_assembled_entries_for_apps(stream_metadata.get('apps'),
+                                                   tag_templates_dict))
 
         return assembled_entries
 
-    def __initialize_tag_templates(self, tag_templates_dict):
-        self.__app_tag_template = \
-            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_APP)
-        self.__sheet_tag_template = \
-            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_SHEET)
-        self.__stream_tag_template = \
-            tag_templates_dict.get(constants.TAG_TEMPLATE_ID_STREAM)
+    def __make_assembled_entry_for_stream(self, stream_metadata,
+                                          tag_templates_dict):
 
-    def __make_assembled_entry_for_stream(self, stream_metadata):
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_stream(
                 stream_metadata)
 
+        tag_template = tag_templates_dict.get(constants.TAG_TEMPLATE_ID_STREAM)
+
         tags = []
-        if self.__stream_tag_template:
+        if tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_stream(
-                    self.__stream_tag_template, stream_metadata))
+                    tag_template, stream_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 
-    def __make_assembled_entries_for_apps(self, apps_metadata):
+    def __make_assembled_entries_for_apps(self, apps_metadata,
+                                          tag_templates_dict):
+
         assembled_entries = []
 
         if not apps_metadata:
@@ -99,40 +92,50 @@ class AssembledEntryFactory:
 
         for app_metadata in apps_metadata:
             assembled_entries.append(
-                self.__make_assembled_entry_for_app(app_metadata))
+                self.__make_assembled_entry_for_app(app_metadata,
+                                                    tag_templates_dict))
             assembled_entries.extend(
                 self.__make_assembled_entries_for_sheets(
-                    app_metadata.get('sheets')))
+                    app_metadata.get('sheets'), tag_templates_dict))
 
         return assembled_entries
 
-    def __make_assembled_entry_for_app(self, app_metadata):
+    def __make_assembled_entry_for_app(self, app_metadata, tag_templates_dict):
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_app(app_metadata)
 
+        tag_template = tag_templates_dict.get(constants.TAG_TEMPLATE_ID_APP)
+
         tags = []
-        if self.__app_tag_template:
+        if tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_app(
-                    self.__app_tag_template, app_metadata))
+                    tag_template, app_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 
-    def __make_assembled_entries_for_sheets(self, sheets_metadata):
+    def __make_assembled_entries_for_sheets(self, sheets_metadata,
+                                            tag_templates_dict):
+
         return [
-            self.__make_assembled_entry_for_sheet(sheet_metadata)
+            self.__make_assembled_entry_for_sheet(sheet_metadata,
+                                                  tag_templates_dict)
             for sheet_metadata in sheets_metadata
         ] if sheets_metadata else []
 
-    def __make_assembled_entry_for_sheet(self, sheet_metadata):
+    def __make_assembled_entry_for_sheet(self, sheet_metadata,
+                                         tag_templates_dict):
+
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_sheet(
                 sheet_metadata)
 
+        tag_template = tag_templates_dict.get(constants.TAG_TEMPLATE_ID_SHEET)
+
         tags = []
-        if self.__sheet_tag_template:
+        if tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_sheet(
-                    self.__sheet_tag_template, sheet_metadata))
+                    tag_template, sheet_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -19,6 +19,7 @@ ENTRY_ID_MAX_LENGTH = 64
 # The below asset type specific strings are appended to the standard
 # ENTRY_ID_PREFIX when generating Qlik Entry IDs.
 ENTRY_ID_PART_APP = 'app_'
+ENTRY_ID_PART_CUSTOM_PROPERTY_DEFINITION = 'cpd_'
 ENTRY_ID_PART_SHEET = 'sht_'
 ENTRY_ID_PART_STREAM = 'str_'
 # This is the common prefix for all Qlik Entries.
@@ -33,6 +34,10 @@ NO_PREFIX_ENTRY_ID_MAX_LENGTH = ENTRY_ID_MAX_LENGTH - len(ENTRY_ID_PREFIX)
 # App-related Entries.
 TAG_TEMPLATE_ID_APP = 'qlik_app_metadata'
 # The ID of the Tag Template created to store additional metadata for the
+# Custom Property Definition related Entries.
+TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION = \
+    'qlik_custom_property_definition_metadata'
+# The ID of the Tag Template created to store additional metadata for the
 # Sheet-related Entries.
 TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'
 # The ID of the Tag Template created to store additional metadata for the
@@ -41,6 +46,8 @@ TAG_TEMPLATE_ID_STREAM = 'qlik_stream_metadata'
 
 # The user specified type of the App-related Entries.
 USER_SPECIFIED_TYPE_APP = 'app'
+# The user specified type of the Custom Property Definition related Entries.
+USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION = 'custom_property_definition'
 # The user specified type of the Sheet-related Entries.
 USER_SPECIFIED_TYPE_SHEET = 'sheet'
 # The user specified type of the Stream-related Entries.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -92,6 +92,15 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             custom_property_def_metadata.get("name"))
         entry.description = custom_property_def_metadata.get("description")
 
+        # The linked_resource field is not fulfilled because there is no way to
+        # jump directly to an 'edit' page in the QlikView Management Console
+        # (QMC). The the ID wee see in the URL of the Custom Property
+        # Definition edit page is generated at the client side as a wrapper
+        # around the object. The reason for this is: if someone select a bunch
+        # of things in the QMC, it can't pick one, or have a list, so it
+        # generates a new 'synthetic' key for the edit page.
+        # -- from the Qlik Analytics Platform Architecture Team
+
         created_datetime = datetime.strptime(
             custom_property_def_metadata.get('createdDate'),
             self.__INCOMING_TIMESTAMP_UTC_FORMAT)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -72,6 +72,46 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
+    def make_entry_for_custom_property_definition(
+            self, custom_property_def_metadata):
+
+        entry = datacatalog.Entry()
+
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_APP,
+                                        custom_property_def_metadata.get('id'))
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = \
+            constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
+
+        entry.display_name = self._format_display_name(
+            custom_property_def_metadata.get("name"))
+        entry.description = custom_property_def_metadata.get("description")
+
+        entry.linked_resource = f'{self.__site_url}/qmc/customproperties' \
+                                f'/{custom_property_def_metadata.get("id")}'
+
+        created_datetime = datetime.strptime(
+            custom_property_def_metadata.get('createdDate'),
+            self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        create_timestamp = timestamp_pb2.Timestamp()
+        create_timestamp.FromDatetime(created_datetime)
+        entry.source_system_timestamps.create_time = create_timestamp
+
+        modified_date = custom_property_def_metadata.get('modifiedDate')
+        resolved_modified_date = \
+            modified_date or custom_property_def_metadata.get('createdDate')
+        modified_datetime = datetime.strptime(
+            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        update_timestamp = timestamp_pb2.Timestamp()
+        update_timestamp.FromDatetime(modified_datetime)
+        entry.source_system_timestamps.update_time = update_timestamp
+
+        return generated_id, entry
+
     def make_entry_for_sheet(self, sheet_metadata):
         entry = datacatalog.Entry()
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -77,8 +77,9 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         entry = datacatalog.Entry()
 
-        generated_id = self.__format_id(constants.ENTRY_ID_PART_APP,
-                                        custom_property_def_metadata.get('id'))
+        generated_id = self.__format_id(
+            constants.ENTRY_ID_PART_CUSTOM_PROPERTY_DEFINITION,
+            custom_property_def_metadata.get('id'))
         entry.name = datacatalog.DataCatalogClient.entry_path(
             self.__project_id, self.__location_id, self.__entry_group_id,
             generated_id)
@@ -90,9 +91,6 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.display_name = self._format_display_name(
             custom_property_def_metadata.get("name"))
         entry.description = custom_property_def_metadata.get("description")
-
-        entry.linked_resource = f'{self.__site_url}/qmc/customproperties' \
-                                f'/{custom_property_def_metadata.get("id")}'
 
         created_datetime = datetime.strptime(
             custom_property_def_metadata.get('createdDate'),

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -92,8 +92,32 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_double_field(tag, 'availability_status',
                                app_metadata.get('availabilityStatus'))
 
-        self._set_string_field(tag, 'schema_path',
-                               app_metadata.get('schemaPath'))
+        self._set_string_field(tag, 'site_url', self.__site_url)
+
+        return tag
+
+    def make_tag_for_custom_property_defintion(self, tag_template,
+                                               custom_property_def_metadata):
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        self._set_string_field(tag, 'id',
+                               custom_property_def_metadata.get('id'))
+
+        self._set_string_field(
+            tag, 'modified_by_username',
+            custom_property_def_metadata.get('modifiedByUserName'))
+
+        self._set_string_field(tag, 'value_type',
+                               custom_property_def_metadata.get('valueType'))
+
+        choice_values = custom_property_def_metadata.get('choiceValues') or []
+        self._set_string_field(tag, 'choice_values', ', '.join(choice_values))
+
+        object_types = custom_property_def_metadata.get('objectTypes') or []
+        self._set_string_field(tag, 'object_types', ', '.join(object_types))
 
         self._set_string_field(tag, 'site_url', self.__site_url)
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -91,8 +91,37 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        self.__DOUBLE_TYPE,
                                        'Availability status')
 
-        self._add_primitive_type_field(tag_template, 'schema_path',
-                                       self.__STRING_TYPE, 'Schema path')
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
+
+        return tag_template
+
+    def make_tag_template_for_custom_property_definition(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION)
+
+        tag_template.display_name = 'Qlik Custom Property Definition Metadata'
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_primitive_type_field(tag_template, 'modified_by_username',
+                                       self.__STRING_TYPE,
+                                       'Username who modified it')
+
+        self._add_primitive_type_field(tag_template, 'value_type',
+                                       self.__STRING_TYPE, 'Value type')
+
+        self._add_primitive_type_field(tag_template, 'choice_values',
+                                       self.__STRING_TYPE, 'Choice values')
+
+        self._add_primitive_type_field(tag_template, 'object_types',
+                                       self.__STRING_TYPE, 'Object types')
 
         self._add_primitive_type_field(tag_template, 'site_url',
                                        self.__STRING_TYPE,

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -276,6 +276,9 @@ class MetadataSynchronizer:
             '==== %d Custom Property Definition entries to be ingested...',
             custom_property_defs_entries_count)
 
+        if not custom_property_defs_assembled_entries:
+            return 0
+
         required_templates_dict = self.__filter_required_tag_templates(
             custom_property_defs_assembled_entries, tag_templates_dict)
         metadata_ingestor.ingest_metadata(

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -264,7 +264,7 @@ class MetadataSynchronizer:
         custom_property_defs_assembled_entries = []
         for assembled_entries in assembled_entries_dict.values():
             if assembled_entries[0].entry.user_specified_type == \
-                constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION:
+                    constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION:
                 custom_property_defs_assembled_entries.extend(
                     assembled_entries)
 
@@ -292,7 +292,7 @@ class MetadataSynchronizer:
         stream_entries_dict = {}
         for stream_id, assembled_entries in assembled_entries_dict.items():
             if assembled_entries[0].entry.user_specified_type == \
-                constants.USER_SPECIFIED_TYPE_STREAM:
+                    constants.USER_SPECIFIED_TYPE_STREAM:
                 stream_entries_dict[stream_id] = assembled_entries
 
         synced_entries_count = 0

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -45,6 +45,34 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             self.__entry_factory,
             attrs['_AssembledEntryFactory__datacatalog_entry_factory'])
 
+    def test_make_assembled_entry_for_custom_property_def_should_process_def(
+            self):
+
+        entry_factory = self.__entry_factory
+        entry_factory.make_entry_for_custom_property_definition\
+            .return_value = ('id', {})
+
+        tag_templates_dict = {
+            'qlik_custom_property_definition_metadata': {
+                'name': 'tagTemplates/qlik_custom_property_def_metadata',
+            }
+        }
+
+        assembled_entries = \
+            self.__factory.make_assembled_entry_for_custom_property_def(
+                {'id': 'test_definition'}, tag_templates_dict)
+
+        self.assertEqual(1, len(assembled_entries))
+        entry_factory.make_entry_for_custom_property_definition\
+            .assert_called_once()
+
+        custom_property_def_assembled_entry = assembled_entries[0]
+        tags = custom_property_def_assembled_entry.tags
+
+        self.assertEqual(1, len(tags))
+        self.__tag_factory.make_tag_for_custom_property_defintion\
+            .assert_called_once()
+
     def test_make_assembled_entries_for_stream_should_process_stream(self):
         entry_factory = self.__entry_factory
         entry_factory.make_entry_for_stream.return_value = ('id', {})

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -58,16 +58,14 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             }
         }
 
-        assembled_entries = \
+        assembled_entry = \
             self.__factory.make_assembled_entry_for_custom_property_def(
                 {'id': 'test_definition'}, tag_templates_dict)
 
-        self.assertEqual(1, len(assembled_entries))
         entry_factory.make_entry_for_custom_property_definition\
             .assert_called_once()
 
-        custom_property_def_assembled_entry = assembled_entries[0]
-        tags = custom_property_def_assembled_entry.tags
+        tags = assembled_entry.tags
 
         self.assertEqual(1, len(tags))
         self.__tag_factory.make_tag_for_custom_property_defintion\

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -45,7 +45,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             self.__entry_factory,
             attrs['_AssembledEntryFactory__datacatalog_entry_factory'])
 
-    def test_make_assembled_entries_list_should_process_streams(self):
+    def test_make_assembled_entries_for_stream_should_process_stream(self):
         entry_factory = self.__entry_factory
         entry_factory.make_entry_for_stream.return_value = ('id', {})
 
@@ -56,7 +56,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         }
 
         assembled_entries = \
-            self.__factory.make_assembled_entries_list(
+            self.__factory.make_assembled_entries_for_stream(
                 self.__make_fake_stream(), tag_templates_dict)
 
         self.assertEqual(1, len(assembled_entries))
@@ -68,7 +68,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(tags))
         self.__tag_factory.make_tag_for_stream.assert_called_once()
 
-    def test_make_assembled_entries_list_should_process_apps(self):
+    def test_make_assembled_entries_for_stream_should_process_apps(self):
         entry_factory = self.__entry_factory
         entry_factory.make_entry_for_stream.return_value = ('id', {})
         entry_factory.make_entry_for_app.return_value = ('id', {})
@@ -82,7 +82,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         fake_stream = self.__make_fake_stream()
         fake_stream['apps'].append(self.__make_fake_app())
         assembled_entries = \
-            self.__factory.make_assembled_entries_list(
+            self.__factory.make_assembled_entries_for_stream(
                 fake_stream, tag_templates_dict)
 
         self.assertEqual(2, len(assembled_entries))
@@ -94,7 +94,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(tags))
         self.__tag_factory.make_tag_for_app.assert_called_once()
 
-    def test_make_assembled_entries_list_should_process_sheets(self):
+    def test_make_assembled_entries_for_stream_should_process_sheets(self):
         entry_factory = self.__entry_factory
         entry_factory.make_entry_for_stream.return_value = ('id', {})
         entry_factory.make_entry_for_app.return_value = ('id', {})
@@ -111,7 +111,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         fake_app['sheets'].append(self.__make_fake_sheet())
         fake_stream['apps'].append(fake_app)
         assembled_entries = \
-            self.__factory.make_assembled_entries_list(
+            self.__factory.make_assembled_entries_for_stream(
                 fake_stream, tag_templates_dict)
 
         self.assertEqual(3, len(assembled_entries))

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -99,6 +99,43 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+    def test_make_entry_for_custom_property_definition_should_set_all_available_fields(  # noqa E510
+            self):
+
+        metadata = {
+            'id': 'a123-b456',
+            'name': 'Test custom property definition',
+            'createdDate': '2019-09-12T16:30:00.005Z',
+            'modifiedDate': '2019-09-12T16:31:00.005Z',
+        }
+
+        entry_id, entry = \
+            self.__factory.make_entry_for_custom_property_definition(metadata)
+
+        self.assertEqual('qlik_cpd_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'qlik_cpd_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('custom_property_definition',
+                         entry.user_specified_type)
+        self.assertEqual('Test custom property definition', entry.display_name)
+        self.assertIsNone(entry.linked_resource)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
     def test_make_entry_for_sheet_should_set_all_available_fields(self):
         metadata = {
             'qInfo': {

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -122,7 +122,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('custom_property_definition',
                          entry.user_specified_type)
         self.assertEqual('Test custom property definition', entry.display_name)
-        self.assertIsNone(entry.linked_resource)
+        self.assertEqual('', entry.linked_resource)
 
         created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
                                              self.__DATETIME_FORMAT)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -61,7 +61,6 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'savedInProductVersion': '12.763.4',
             'migrationHash': '504d4e39a7133ee172fbe29aa58348b1e4054149',
             'availabilityStatus': 1,
-            'schemaPath': 'App',
         }
 
         tag = self.__factory.make_tag_for_app(tag_template, metadata)
@@ -99,7 +98,6 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('504d4e39a7133ee172fbe29aa58348b1e4054149',
                          tag.fields['migration_hash'].string_value)
         self.assertEqual(1, tag.fields['availability_status'].double_value)
-        self.assertEqual('App', tag.fields['schema_path'].string_value)
 
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -115,6 +115,41 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         tag = self.__factory.make_tag_for_app(tag_template, metadata)
         self.assertFalse('publish_time' in tag.fields)
 
+    def test_make_tag_for_custom_property_def_should_set_all_available_fields(
+            self):
+
+        tag_template = self.__tag_template_factory\
+            .make_tag_template_for_custom_property_definition()
+
+        metadata = {
+            'id': 'a123-b456',
+            'modifiedByUserName': 'test-directory\\\\test.userid',
+            'valueType': 'Text',
+            'choiceValues': [
+                'Value 1',
+                'Value 2',
+            ],
+            'objectTypes': [
+                'App',
+                'Stream',
+            ],
+        }
+
+        tag = self.__factory.make_tag_for_custom_property_defintion(
+            tag_template, metadata)
+
+        self.assertEqual('a123-b456', tag.fields['id'].string_value)
+        self.assertEqual('test-directory\\\\test.userid',
+                         tag.fields['modified_by_username'].string_value)
+        self.assertEqual('Text', tag.fields['value_type'].string_value)
+        self.assertEqual('Value 1, Value 2',
+                         tag.fields['choice_values'].string_value)
+        self.assertEqual('App, Stream',
+                         tag.fields['object_types'].string_value)
+
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)
+
     def test_make_tag_for_sheet_should_set_all_available_fields(self):
         tag_template = \
             self.__tag_template_factory.make_tag_template_for_sheet()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -135,12 +135,6 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
             'Availability status',
             tag_template.fields['availability_status'].display_name)
 
-        self.assertEqual(
-            self.__STRING_TYPE,
-            tag_template.fields['schema_path'].type.primitive_type)
-        self.assertEqual('Schema path',
-                         tag_template.fields['schema_path'].display_name)
-
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['site_url'].type.primitive_type)
         self.assertEqual('Qlik Sense site url',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -88,10 +88,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'id': 'test_stream',
         }
 
-        make_assembled_entries_args = \
-            assembled_entry_factory.make_assembled_entries_list.call_args[0]
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
         self.assertEqual(expected_make_assembled_entries_call_arg,
-                         make_assembled_entries_args[0])
+                         actual_call_args[0])
 
         mapper = mock_mapper.return_value
         mapper.fulfill_tag_fields.assert_called_once()
@@ -131,10 +131,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
             }]
         }
 
-        make_assembled_entries_args = \
-            assembled_entry_factory.make_assembled_entries_list.call_args[0]
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
         self.assertEqual(expected_make_assembled_entries_call_arg,
-                         make_assembled_entries_args[0])
+                         actual_call_args[0])
 
         mapper = mock_mapper.return_value
         mapper.fulfill_tag_fields.assert_called_once()
@@ -162,10 +162,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'id': 'test_stream',
         }
 
-        make_assembled_entries_args = \
-            assembled_entry_factory.make_assembled_entries_list.call_args[0]
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
         self.assertEqual(expected_make_assembled_entries_call_arg,
-                         make_assembled_entries_args[0])
+                         actual_call_args[0])
 
         mapper = mock_mapper.return_value
         mapper.fulfill_tag_fields.assert_called_once()
@@ -219,10 +219,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
             }]
         }
 
-        make_assembled_entries_args = \
-            assembled_entry_factory.make_assembled_entries_list.call_args[0]
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
         self.assertEqual(expected_make_assembled_entries_call_arg,
-                         make_assembled_entries_args[0])
+                         actual_call_args[0])
 
         mapper = mock_mapper.return_value
         mapper.fulfill_tag_fields.assert_called_once()
@@ -261,10 +261,10 @@ class MetadataSynchronizerTest(unittest.TestCase):
             }]
         }
 
-        make_assembled_entries_args = \
-            assembled_entry_factory.make_assembled_entries_list.call_args[0]
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
         self.assertEqual(expected_make_assembled_entries_call_arg,
-                         make_assembled_entries_args[0])
+                         actual_call_args[0])
 
         mapper = mock_mapper.return_value
         mapper.fulfill_tag_fields.assert_called_once()

--- a/google-datacatalog-qlik-connector/tools/postman/Qlik Sense Repository Service API.postman_collection.json
+++ b/google-datacatalog-qlik-connector/tools/postman/Qlik Sense Repository Service API.postman_collection.json
@@ -757,6 +757,194 @@
 			"protocolProfileBehavior": {}
 		},
 		{
+			"name": "4 Custom Property Definitions",
+			"item": [
+				{
+					"name": "4.01.01 Get Custom Property Definition list",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4ac7930d-c5f2-4a57-bd42-da042bca382b",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const jsonData = pm.response.json();",
+									"const streams = jsonData;",
+									"",
+									"pm.globals.unset(\"customPropertyDefinitionId\");",
+									"",
+									"if (streams.length > 0) {",
+									"    pm.globals.set(\"customPropertyDefinitionId\", streams[0].id);",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Qlik-Xrfkey",
+								"type": "text",
+								"value": "{{XRFKEY}}"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/qrs/custompropertydefinition?Xrfkey={{XRFKEY}}",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"qrs",
+								"custompropertydefinition"
+							],
+							"query": [
+								{
+									"key": "Xrfkey",
+									"value": "{{XRFKEY}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.01.02 Get Custom Property Definition (full)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4016c8a7-8e6b-4ca9-be4f-e0f6232c9105",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const jsonData = pm.response.json();",
+									"const streams = jsonData;",
+									"",
+									"pm.globals.unset(\"customPropertyDefinitionId\");",
+									"",
+									"if (streams.length > 0) {",
+									"    pm.globals.set(\"customPropertyDefinitionId\", streams[0].id);",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Qlik-Xrfkey",
+								"type": "text",
+								"value": "{{XRFKEY}}"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/qrs/custompropertydefinition/full?Xrfkey={{XRFKEY}}",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"qrs",
+								"custompropertydefinition",
+								"full"
+							],
+							"query": [
+								{
+									"key": "Xrfkey",
+									"value": "{{XRFKEY}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "4.02.01 Get Custom Property Definition",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "61a23306-004b-4400-b45b-3ebe3335d0c4",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Qlik-Xrfkey",
+								"type": "text",
+								"value": "{{XRFKEY}}"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/qrs/custompropertydefinition/{{customPropertyDefinitionId}}?Xrfkey={{XRFKEY}}",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"qrs",
+								"custompropertydefinition",
+								"{{customPropertyDefinitionId}}"
+							],
+							"query": [
+								{
+									"key": "Xrfkey",
+									"value": "{{XRFKEY}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "X Data connections",
 			"item": [
 				{


### PR DESCRIPTION
**- What I did**
Added support to ingest metadata from the Custom Property Definitions.

**- How I did it**
1. Added new code to the `MetadataSynchronizer` in order to include the scrape/prepare/ingest steps for Custom Property Definitions metadata.
1. Added code to make the related Entries, Tag Templates, and Tags.
1. Added/updated the unit tests.

**- How to verify it**
Run the unit tests and the connector in an integrated environment.

**- Description for the changelog**
Added support to ingest metadata from the Custom Property Definitions.

