### PR TITLE
Create Tags for Custom Property Values

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -38,14 +38,16 @@ currently supporting below asset types:
 - [3. Running the connector](#3-running-the-connector)
   * [3.1. Python entry point](#31-python-entry-point)
   * [3.2. Docker entry point](#32-docker-entry-point)
-- [4. Developer environment](#4-developer-environment)
-  * [4.1. Install and run Yapf formatter](#41-install-and-run-yapf-formatter)
-  * [4.2. Install and run Flake8 linter](#42-install-and-run-flake8-linter)
-  * [4.3. Run Tests](#43-run-tests)
-  * [4.4. Additional resources](#44-additional-resources)
-- [5. Troubleshooting](#5-troubleshooting)
-  * [5.1. Qlik APIs compatibility](#51-qlik-apis-compatibility)
-  * [5.2. Data Catalog quota](#52-data-catalog-quota)
+- [4. Design decisions](#4-design-decisions)
+  * [4.1. Tag Templates for Custom Property Choice Values](#41-tag-templates-for-custom-property-choice-values)
+- [5. Developer environment](#5-developer-environment)
+  * [5.1. Install and run Yapf formatter](#51-install-and-run-yapf-formatter)
+  * [5.2. Install and run Flake8 linter](#52-install-and-run-flake8-linter)
+  * [5.3. Run Tests](#53-run-tests)
+  * [5.4. Additional resources](#54-additional-resources)
+- [6. Troubleshooting](#6-troubleshooting)
+  * [6.1. Qlik APIs compatibility](#61-qlik-apis-compatibility)
+  * [6.2. Data Catalog quota](#62-data-catalog-quota)
 
 <!-- tocstop -->
 
@@ -172,9 +174,29 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   [--datacatalog-location-id $QLIK2DC_DATACATALOG_LOCATION_ID]
 ```
 
-## 4. Developer environment
+## 4. Design decisions
 
-### 4.1. Install and run Yapf formatter
+### 4.1. Tag Templates for Custom Property Choice Values
+
+The current implementation creates a Tag Template for each Custom Property 
+Choice Value assigned to Streams or Apps in the provided Qlik Sense site. The
+rationale behind this decision comprises allowing the connector to synchronize
+all metadata scraped from each Custom Property, at the same time it enables
+Qlik assets to be easily found by their custom properties — using query strings
+such as `tag:definition_name:<DEFINTION-NAME>` and `tag:value:"<SOME-VALUE>"`.
+
+Data Catalog accepts attaching only one Tag per Template to a given Entry, so
+there could be metadata loss if the Tag Templates were created in different
+ways, e.g. on a Custom Property Definition basis.
+
+Lastly, this approach may lead to the creation of several Tag Templates if
+there are many Custom Property Values in use in your Qlik Sense site. In case
+you would like to suggest a different approach to tackle this problem, please
+[file a feature request][3]. We will be happy to discuss alternative solutions! 
+
+## 5. Developer environment
+
+### 5.1. Install and run Yapf formatter
 
 ```shell script
 pip install --upgrade yapf
@@ -192,27 +214,27 @@ chmod a+x pre-commit.sh
 mv pre-commit.sh .git/hooks/pre-commit
 ```
 
-### 4.2. Install and run Flake8 linter
+### 5.2. Install and run Flake8 linter
 
 ```shell script
 pip install --upgrade flake8
 flake8 src tests
 ```
 
-### 4.3. Run Tests
+### 5.3. Run Tests
 
 ```shell script
 python setup.py test
 ```
 
-### 4.4. Additional resources
+### 5.4. Additional resources
 
 Please refer to the [Developer Resources
 documentation](docs/developer-resources).
 
-## 5. Troubleshooting
+## 6. Troubleshooting
 
-### 5.1. Qlik APIs compatibility
+### 6.1. Qlik APIs compatibility
 
 The connector may fail during the scrape stage if the Qlik APIs do not return
 metadata in the expected format. As a reference, the below versions were
@@ -230,7 +252,7 @@ already validated:
 | ------------------------ | :-----: |
 | 12.763.4 (September2020) | SUCCESS |
 
-### 5.2. Data Catalog quota
+### 6.2. Data Catalog quota
 
 In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed
@@ -248,3 +270,4 @@ quota docs][2].
 
 [1]: https://virtualenv.pypa.io/en/latest/
 [2]: https://cloud.google.com/data-catalog/docs/resources/quotas
+[3]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -2,6 +2,7 @@
 
 Package for ingesting Qlik Sense metadata into Google Cloud Data Catalog,
 currently supporting below asset types:
+- Custom Property Definition
 - Stream
 - App (only the published ones)
 - Sheet (only the published ones)

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -183,7 +183,7 @@ Choice Value assigned to Streams or Apps in the provided Qlik Sense site. The
 rationale behind this decision comprises allowing the connector to synchronize
 all metadata scraped from each Custom Property, at the same time it enables
 Qlik assets to be easily found by their custom properties — using query strings
-such as `tag:definition_name:<DEFINTION-NAME>` and `tag:value:"<SOME-VALUE>"`.
+such as `tag:property_name:"<PROPERTY-NAME>"` and `tag:value:"<SOME-VALUE>"`.
 
 Data Catalog accepts attaching only one Tag per Template to a given Entry, so
 there could be metadata loss if the Tag Templates were created in different

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -46,7 +46,7 @@ class AssembledEntryFactory:
         if tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.
-                make_tag_for_custom_property_defintion(
+                make_tag_for_custom_property_definition(
                     tag_template, custom_property_def_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
@@ -72,13 +72,18 @@ class AssembledEntryFactory:
             self.__datacatalog_entry_factory.make_entry_for_stream(
                 stream_metadata)
 
-        tag_template = tag_templates_dict.get(constants.TAG_TEMPLATE_ID_STREAM)
+        stream_tag_template = tag_templates_dict.get(
+            constants.TAG_TEMPLATE_ID_STREAM)
 
         tags = []
-        if tag_template:
+        if stream_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_stream(
-                    tag_template, stream_metadata))
+                    stream_tag_template, stream_metadata))
+
+        tags.extend(
+            self.__datacatalog_tag_factory.make_tags_for_custom_properties(
+                tag_templates_dict, stream_metadata.get('customProperties')))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 
@@ -104,13 +109,18 @@ class AssembledEntryFactory:
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_app(app_metadata)
 
-        tag_template = tag_templates_dict.get(constants.TAG_TEMPLATE_ID_APP)
+        app_tag_template = tag_templates_dict.get(
+            constants.TAG_TEMPLATE_ID_APP)
 
         tags = []
-        if tag_template:
+        if app_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_app(
-                    tag_template, app_metadata))
+                    app_tag_template, app_metadata))
+
+        tags.extend(
+            self.__datacatalog_tag_factory.make_tags_for_custom_properties(
+                tag_templates_dict, app_metadata.get('customProperties')))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -37,6 +37,9 @@ TAG_TEMPLATE_ID_APP = 'qlik_app_metadata'
 # Custom Property Definition related Entries.
 TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION = \
     'qlik_custom_property_definition_metadata'
+# Prefix for IDs of the Tag Templates created to tag Entries with their
+# Custom Properties.
+TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY = 'qlik_custom_property__'
 # The ID of the Tag Template created to store additional metadata for the
 # Sheet-related Entries.
 TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -39,7 +39,7 @@ TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION = \
     'qlik_custom_property_definition_metadata'
 # Prefix for IDs of the Tag Templates created to tag Entries with their
 # Custom Properties.
-TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY = 'qlik_custom_property__'
+TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY = 'qlik_cp__'
 # The ID of the Tag Template created to store additional metadata for the
 # Sheet-related Entries.
 TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -156,8 +156,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         definition = custom_property_metadata.get('definition')
         if definition:
-            self._set_string_field(tag, 'definition_id', definition.get('id'))
-            self._set_string_field(tag, 'definition_name',
+            self._set_string_field(tag, 'property_definition_id',
+                                   definition.get('id'))
+            self._set_string_field(tag, 'property_name',
                                    definition.get('name'))
 
         self._set_string_field(tag, 'site_url', self.__site_url)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -107,9 +107,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         if not (tag_templates_dict and custom_properties):
             return tags
 
-        print(tag_templates_dict)
-        print(custom_properties)
-
         for property_metadata in custom_properties:
             definition = property_metadata.get('definition')
             value = property_metadata.get('value')
@@ -117,8 +114,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
                 .make_id_for_custom_property_value_tag_template(
                     definition, value)
             property_value_tag_template = tag_templates_dict.get(template_id)
-            print(template_id)
-            print(property_value_tag_template)
 
             if not property_value_tag_template:
                 continue

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -133,11 +133,11 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         self._set_string_field(tag, 'id', custom_property_metadata.get('id'))
 
-        modified_date = custom_property_metadata.get('createdDate')
-        if modified_date:
+        created_date = custom_property_metadata.get('createdDate')
+        if created_date:
             self._set_timestamp_field(
                 tag, 'created_date',
-                datetime.strptime(modified_date,
+                datetime.strptime(created_date,
                                   self.__INCOMING_TIMESTAMP_UTC_FORMAT))
 
         modified_date = custom_property_metadata.get('modifiedDate')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -107,6 +107,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         if not (tag_templates_dict and custom_properties):
             return tags
 
+        print(tag_templates_dict)
+        print(custom_properties)
+
         for property_metadata in custom_properties:
             definition = property_metadata.get('definition')
             value = property_metadata.get('value')
@@ -114,6 +117,8 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
                 .make_id_for_custom_property_value_tag_template(
                     definition, value)
             property_value_tag_template = tag_templates_dict.get(template_id)
+            print(template_id)
+            print(property_value_tag_template)
 
             if not property_value_tag_template:
                 continue

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -19,6 +19,9 @@ from datetime import datetime
 from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import prepare
 
+from google.datacatalog_connectors.qlik.prepare import \
+    dynamic_properties_helper as dph
+
 
 class DataCatalogTagFactory(prepare.BaseTagFactory):
     __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
@@ -96,8 +99,73 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         return tag
 
-    def make_tag_for_custom_property_defintion(self, tag_template,
-                                               custom_property_def_metadata):
+    def make_tags_for_custom_properties(self, tag_templates_dict,
+                                        custom_properties):
+
+        tags = []
+
+        if not (tag_templates_dict and custom_properties):
+            return tags
+
+        for property_metadata in custom_properties:
+            definition = property_metadata.get('definition')
+            value = property_metadata.get('value')
+            template_id = dph.DynamicPropertiesHelper\
+                .make_id_for_custom_property_value_tag_template(
+                    definition, value)
+            property_value_tag_template = tag_templates_dict.get(template_id)
+
+            if not property_value_tag_template:
+                continue
+
+            tags.append(
+                self.make_tag_for_custom_property(property_value_tag_template,
+                                                  property_metadata))
+
+        return tags
+
+    def make_tag_for_custom_property(self, tag_template,
+                                     custom_property_metadata):
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        self._set_string_field(tag, 'id', custom_property_metadata.get('id'))
+
+        modified_date = custom_property_metadata.get('createdDate')
+        if modified_date:
+            self._set_timestamp_field(
+                tag, 'created_date',
+                datetime.strptime(modified_date,
+                                  self.__INCOMING_TIMESTAMP_UTC_FORMAT))
+
+        modified_date = custom_property_metadata.get('modifiedDate')
+        if modified_date:
+            self._set_timestamp_field(
+                tag, 'modified_date',
+                datetime.strptime(modified_date,
+                                  self.__INCOMING_TIMESTAMP_UTC_FORMAT))
+
+        self._set_string_field(
+            tag, 'modified_by_username',
+            custom_property_metadata.get('modifiedByUserName'))
+
+        self._set_string_field(tag, 'value',
+                               custom_property_metadata.get('value'))
+
+        definition = custom_property_metadata.get('definition')
+        if definition:
+            self._set_string_field(tag, 'definition_id', definition.get('id'))
+            self._set_string_field(tag, 'definition_name',
+                                   definition.get('name'))
+
+        self._set_string_field(tag, 'site_url', self.__site_url)
+
+        return tag
+
+    def make_tag_for_custom_property_definition(self, tag_template,
+                                                custom_property_def_metadata):
 
         tag = datacatalog.Tag()
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
-import six
-import unicodedata
-
 from google.cloud import datacatalog
 from google.datacatalog_connectors.commons import prepare
 
-from google.datacatalog_connectors.qlik.prepare import constants
+from google.datacatalog_connectors.qlik.prepare import \
+    constants, dynamic_properties_helper as dph
 
 
 class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
@@ -105,18 +102,16 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
     def make_tag_template_for_custom_property(self, definition_metadata):
         tag_template = datacatalog.TagTemplate()
 
-        generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
-                       f'{definition_metadata.get("id")}'
-
+        template_id = dph.DynamicPropertiesHelper\
+            .make_id_for_custom_property_tag_template(definition_metadata)
         tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
             project=self.__project_id,
             location=self.__location_id,
-            tag_template=re.sub(r'[^a-z0-9_]+', '_', generated_id))
+            tag_template=template_id)
 
-        generated_display_name = f'Qlik {definition_metadata.get("name")}' \
-                                 f' Custom Property'
-        tag_template.display_name = self.__format_display_name(
-            generated_display_name)
+        tag_template.display_name = dph.DynamicPropertiesHelper\
+            .make_display_name_for_custom_property_tag_template(
+                definition_metadata)
 
         self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
                                        'Unique Id')
@@ -262,17 +257,3 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        'Qlik Sense site url')
 
         return tag_template
-
-    @classmethod
-    def __format_display_name(cls, source_name):
-        return re.sub(r'[^\w\- ]+', '_',
-                      cls.__normalize_ascii_chars(source_name).strip())
-
-    @classmethod
-    def __normalize_ascii_chars(cls, source_string):
-        encoding = cls.__ASCII_CHARACTER_ENCODING
-        normalized = unicodedata.normalize(
-            'NFKD', source_string
-            if isinstance(source_string, six.string_types) else u'')
-        encoded = normalized.encode(encoding, 'ignore')
-        return encoded.decode()

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -164,15 +164,23 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self._add_primitive_type_field(tag_template, 'value',
                                        self.__STRING_TYPE, 'Value')
 
-        self._add_primitive_type_field(tag_template, 'definition_id',
-                                       self.__STRING_TYPE, 'Definition Id')
+        self._add_primitive_type_field(tag_template, 'property_definition_id',
+                                       self.__STRING_TYPE,
+                                       'Property Definition Id')
 
-        self._add_primitive_type_field(tag_template, 'definition_name',
-                                       self.__STRING_TYPE, 'Definition name')
+        # According to the Qlik Analytics Platform Architecture Team, there was
+        # no way of searching assets by the Custom Property values using Qlik
+        # when this feature was implemented (Dec, 2020), which means the
+        # catalog search might be helpful to address such a use case. Hence the
+        # 'definition_' part was supressed from this Tag Field Id to turn seach
+        # queries more intuitive, e.g. tag:property_name:<PROPERTY-NAME>.
+        self._add_primitive_type_field(tag_template, 'property_name',
+                                       self.__STRING_TYPE,
+                                       'Property Definition name')
 
         self._add_primitive_type_field(
-            tag_template, 'definition_entry', self.__STRING_TYPE,
-            'Data Catalog Entry for the Definition')
+            tag_template, 'property_definition_entry', self.__STRING_TYPE,
+            'Data Catalog Entry for the Property Definition')
 
         self._add_primitive_type_field(tag_template, 'site_url',
                                        self.__STRING_TYPE,

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -99,52 +99,6 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
-    def make_tag_template_for_custom_property(self, definition_metadata):
-        tag_template = datacatalog.TagTemplate()
-
-        template_id = dph.DynamicPropertiesHelper\
-            .make_id_for_custom_property_tag_template(definition_metadata)
-        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
-            project=self.__project_id,
-            location=self.__location_id,
-            tag_template=template_id)
-
-        tag_template.display_name = dph.DynamicPropertiesHelper\
-            .make_display_name_for_custom_property_tag_template(
-                definition_metadata)
-
-        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
-                                       'Unique Id')
-
-        self._add_primitive_type_field(tag_template, 'created_date',
-                                       self.__TIMESTAMP_TYPE, 'Created date')
-
-        self._add_primitive_type_field(tag_template, 'modified_date',
-                                       self.__TIMESTAMP_TYPE, 'Modified date')
-
-        self._add_primitive_type_field(tag_template, 'modified_by_username',
-                                       self.__STRING_TYPE,
-                                       'Username who modified it')
-
-        self._add_primitive_type_field(tag_template, 'value',
-                                       self.__STRING_TYPE, 'Value')
-
-        self._add_primitive_type_field(tag_template, 'definition_id',
-                                       self.__STRING_TYPE, 'Definition Id')
-
-        self._add_primitive_type_field(tag_template, 'definition_name',
-                                       self.__STRING_TYPE, 'Definition name')
-
-        self._add_primitive_type_field(
-            tag_template, 'definition_entry', self.__STRING_TYPE,
-            'Data Catalog Entry for the Definition')
-
-        self._add_primitive_type_field(tag_template, 'site_url',
-                                       self.__STRING_TYPE,
-                                       'Qlik Sense site url')
-
-        return tag_template
-
     def make_tag_template_for_custom_property_definition(self):
         tag_template = datacatalog.TagTemplate()
 
@@ -176,6 +130,55 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        'Qlik Sense site url')
 
         return tag_template
+
+        return tag_template
+
+    def make_tag_template_for_custom_property_value(self, definition_metadata,
+                                                    value):
+
+        tag_template = datacatalog.TagTemplate()
+
+        template_id = dph.DynamicPropertiesHelper\
+            .make_id_for_custom_property_value_tag_template(
+                definition_metadata, value)
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=template_id)
+
+        tag_template.display_name = dph.DynamicPropertiesHelper\
+            .make_display_name_for_custom_property_value_tag_template(
+                definition_metadata, value)
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_primitive_type_field(tag_template, 'created_date',
+                                       self.__TIMESTAMP_TYPE, 'Created date')
+
+        self._add_primitive_type_field(tag_template, 'modified_date',
+                                       self.__TIMESTAMP_TYPE, 'Modified date')
+
+        self._add_primitive_type_field(tag_template, 'modified_by_username',
+                                       self.__STRING_TYPE,
+                                       'Username who modified it')
+
+        self._add_primitive_type_field(tag_template, 'value',
+                                       self.__STRING_TYPE, 'Value')
+
+        self._add_primitive_type_field(tag_template, 'definition_id',
+                                       self.__STRING_TYPE, 'Definition Id')
+
+        self._add_primitive_type_field(tag_template, 'definition_name',
+                                       self.__STRING_TYPE, 'Definition name')
+
+        self._add_primitive_type_field(
+            tag_template, 'definition_entry', self.__STRING_TYPE,
+            'Data Catalog Entry for the Definition')
+
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
 
         return tag_template
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -131,8 +131,6 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
-        return tag_template
-
     def make_tag_template_for_custom_property_value(self, definition_metadata,
                                                     value):
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import six
+import unicodedata
+
+from google.datacatalog_connectors.qlik.prepare import constants
+
+
+class DynamicPropertiesHelper:
+    __ASCII_CHARACTER_ENCODING = 'ASCII'
+
+    @classmethod
+    def make_id_for_custom_property_tag_template(cls, definition_metadata):
+        generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
+                       f'{definition_metadata.get("id")}'
+        return cls.format_tag_template_id(generated_id)
+
+    @classmethod
+    def make_display_name_for_custom_property_tag_template(
+            cls, definition_metadata):
+
+        display_name = f'Qlik {definition_metadata.get("name")}' \
+                       f' Custom Property'
+        return cls.format_tag_template_display_name(display_name)
+
+    @classmethod
+    def format_tag_template_id(cls, source_id):
+        formatted_id = re.sub(r'[^a-z0-9]+', '_',
+                              cls.__normalize_ascii_chars(source_id.strip()))
+        return formatted_id[:64] if len(formatted_id) > 64 else formatted_id
+
+    @classmethod
+    def format_tag_template_display_name(cls, source_name):
+        formatted_name = re.sub(
+            r'[^\w\- ]+', '_',
+            cls.__normalize_ascii_chars(source_name).strip())
+        return formatted_name
+
+    @classmethod
+    def __normalize_ascii_chars(cls, source_string):
+        encoding = cls.__ASCII_CHARACTER_ENCODING
+        normalized = unicodedata.normalize(
+            'NFKD', source_string
+            if isinstance(source_string, six.string_types) else u'')
+        encoded = normalized.encode(encoding, 'ignore')
+        return encoded.decode()

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
@@ -25,17 +25,22 @@ class DynamicPropertiesHelper:
     __ASCII_CHARACTER_ENCODING = 'ASCII'
 
     @classmethod
-    def make_display_name_for_custom_property_tag_template(
-            cls, definition_metadata):
+    def make_display_name_for_custom_property_value_tag_template(
+            cls, definition_metadata, value):
 
-        display_name = f'Qlik {definition_metadata.get("name")}' \
-                       f' Custom Property'
+        display_name = f'Qlik Custom Property' \
+                       f' - {definition_metadata.get("name")} - {value}'
         return cls.format_tag_template_display_name(display_name)
 
     @classmethod
-    def make_id_for_custom_property_tag_template(cls, definition_metadata):
+    def make_id_for_custom_property_value_tag_template(cls,
+                                                       definition_metadata,
+                                                       value):
+
+        definition_id = definition_metadata.get("id")
+        definition_id_start = definition_id[:definition_id.find('-')]
         generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
-                       f'{definition_metadata.get("id")}'
+                       f'{definition_id_start}__{value}'
         return cls.format_tag_template_id(generated_id)
 
     @classmethod
@@ -47,8 +52,10 @@ class DynamicPropertiesHelper:
 
     @classmethod
     def format_tag_template_id(cls, source_id):
-        formatted_id = re.sub(r'[^a-z0-9]+', '_',
-                              cls.__normalize_ascii_chars(source_id.strip()))
+        lower_case_id = source_id.lower().strip() if source_id else ''
+        formatted_id = re.sub(
+            r'[^a-z0-9_]+', '_',
+            cls.__normalize_ascii_chars(lower_case_id.strip()))
         return formatted_id[:64] if len(formatted_id) > 64 else formatted_id
 
     @classmethod

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
@@ -25,12 +25,6 @@ class DynamicPropertiesHelper:
     __ASCII_CHARACTER_ENCODING = 'ASCII'
 
     @classmethod
-    def make_id_for_custom_property_tag_template(cls, definition_metadata):
-        generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
-                       f'{definition_metadata.get("id")}'
-        return cls.format_tag_template_id(generated_id)
-
-    @classmethod
     def make_display_name_for_custom_property_tag_template(
             cls, definition_metadata):
 
@@ -39,10 +33,10 @@ class DynamicPropertiesHelper:
         return cls.format_tag_template_display_name(display_name)
 
     @classmethod
-    def format_tag_template_id(cls, source_id):
-        formatted_id = re.sub(r'[^a-z0-9]+', '_',
-                              cls.__normalize_ascii_chars(source_id.strip()))
-        return formatted_id[:64] if len(formatted_id) > 64 else formatted_id
+    def make_id_for_custom_property_tag_template(cls, definition_metadata):
+        generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
+                       f'{definition_metadata.get("id")}'
+        return cls.format_tag_template_id(generated_id)
 
     @classmethod
     def format_tag_template_display_name(cls, source_name):
@@ -50,6 +44,12 @@ class DynamicPropertiesHelper:
             r'[^\w\- ]+', '_',
             cls.__normalize_ascii_chars(source_name).strip())
         return formatted_name
+
+    @classmethod
+    def format_tag_template_id(cls, source_id):
+        formatted_id = re.sub(r'[^a-z0-9]+', '_',
+                              cls.__normalize_ascii_chars(source_id.strip()))
+        return formatted_id[:64] if len(formatted_id) > 64 else formatted_id
 
     @classmethod
     def __normalize_ascii_chars(cls, source_string):

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper.py
@@ -30,7 +30,7 @@ class DynamicPropertiesHelper:
 
         display_name = f'Qlik Custom Property' \
                        f' - {definition_metadata.get("name")} - {value}'
-        return cls.format_tag_template_display_name(display_name)
+        return cls.normalize_tag_template_display_name(display_name)
 
     @classmethod
     def make_id_for_custom_property_value_tag_template(cls,
@@ -41,17 +41,17 @@ class DynamicPropertiesHelper:
         definition_id_start = definition_id[:definition_id.find('-')]
         generated_id = f'{constants.TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY}' \
                        f'{definition_id_start}__{value}'
-        return cls.format_tag_template_id(generated_id)
+        return cls.normalize_tag_template_id(generated_id)
 
     @classmethod
-    def format_tag_template_display_name(cls, source_name):
+    def normalize_tag_template_display_name(cls, source_name):
         formatted_name = re.sub(
             r'[^\w\- ]+', '_',
             cls.__normalize_ascii_chars(source_name).strip())
         return formatted_name
 
     @classmethod
-    def format_tag_template_id(cls, source_id):
+    def normalize_tag_template_id(cls, source_id):
         lower_case_id = source_id.lower().strip() if source_id else ''
         formatted_id = re.sub(
             r'[^a-z0-9_]+', '_',

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -21,12 +21,15 @@ from google.datacatalog_connectors.qlik.prepare import constants
 
 class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     __APP = constants.USER_SPECIFIED_TYPE_APP
+    __CUSTOM_PROPERTY_DEFINITION = \
+        constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
     __SHEET = constants.USER_SPECIFIED_TYPE_SHEET
     __STREAM = constants.USER_SPECIFIED_TYPE_STREAM
 
     def fulfill_tag_fields(self, assembled_entries):
         resolvers = (
             self.__resolve_app_mappings,
+            self.__resolve_custom_type_definition_mappings,
             self.__resolve_sheet_mappings,
         )
 
@@ -41,6 +44,21 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         for assembled_entry in app_assembled_entries:
             cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
                                    'stream_entry', id_name_pairs)
+
+    @classmethod
+    def __resolve_custom_type_definition_mappings(cls, assembled_entries,
+                                                  id_name_pairs):
+
+        non_custom_property_def_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if not assembled_entry.entry.user_specified_type ==
+            cls.__CUSTOM_PROPERTY_DEFINITION
+        ]
+        for assembled_entry in non_custom_property_def_assembled_entries:
+            cls._map_related_entry(assembled_entry,
+                                   cls.__CUSTOM_PROPERTY_DEFINITION,
+                                   'definition_id', 'definition_entry',
+                                   id_name_pairs)
 
     @classmethod
     def __resolve_sheet_mappings(cls, assembled_entries, id_name_pairs):

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -44,8 +44,8 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         for assembled_entry in app_assembled_entries:
             cls._map_related_entry(assembled_entry,
                                    cls.__CUSTOM_PROPERTY_DEFINITION,
-                                   'definition_id', 'definition_entry',
-                                   id_name_pairs)
+                                   'property_definition_id',
+                                   'property_definition_entry', id_name_pairs)
             cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
                                    'stream_entry', id_name_pairs)
 
@@ -68,5 +68,5 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         for assembled_entry in stream_assembled_entries:
             cls._map_related_entry(assembled_entry,
                                    cls.__CUSTOM_PROPERTY_DEFINITION,
-                                   'definition_id', 'definition_entry',
-                                   id_name_pairs)
+                                   'property_definition_id',
+                                   'property_definition_entry', id_name_pairs)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -29,8 +29,8 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     def fulfill_tag_fields(self, assembled_entries):
         resolvers = (
             self.__resolve_app_mappings,
-            self.__resolve_custom_type_definition_mappings,
             self.__resolve_sheet_mappings,
+            self.__resolve_stream_mappings,
         )
 
         self._fulfill_tag_fields(assembled_entries, resolvers)
@@ -42,23 +42,12 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
             if assembled_entry.entry.user_specified_type == cls.__APP
         ]
         for assembled_entry in app_assembled_entries:
-            cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
-                                   'stream_entry', id_name_pairs)
-
-    @classmethod
-    def __resolve_custom_type_definition_mappings(cls, assembled_entries,
-                                                  id_name_pairs):
-
-        non_custom_property_def_assembled_entries = [
-            assembled_entry for assembled_entry in assembled_entries
-            if not assembled_entry.entry.user_specified_type ==
-            cls.__CUSTOM_PROPERTY_DEFINITION
-        ]
-        for assembled_entry in non_custom_property_def_assembled_entries:
             cls._map_related_entry(assembled_entry,
                                    cls.__CUSTOM_PROPERTY_DEFINITION,
                                    'definition_id', 'definition_entry',
                                    id_name_pairs)
+            cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
+                                   'stream_entry', id_name_pairs)
 
     @classmethod
     def __resolve_sheet_mappings(cls, assembled_entries, id_name_pairs):
@@ -69,3 +58,15 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         for assembled_entry in sheet_assembled_entries:
             cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
                                    'app_entry', id_name_pairs)
+
+    @classmethod
+    def __resolve_stream_mappings(cls, assembled_entries, id_name_pairs):
+        stream_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__STREAM
+        ]
+        for assembled_entry in stream_assembled_entries:
+            cls._map_related_entry(assembled_entry,
+                                   cls.__CUSTOM_PROPERTY_DEFINITION,
+                                   'definition_id', 'definition_entry',
+                                   id_name_pairs)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -197,10 +197,12 @@ class MetadataSynchronizer:
             self.__tag_template_factory.make_tag_template_for_stream())
 
         for definition in custom_property_defs:
-            self.__add_template_to_dict(
-                templates_dict,
-                self.__tag_template_factory.
-                make_tag_template_for_custom_property(definition))
+            for value in definition.get('choiceValues') or []:
+                self.__add_template_to_dict(
+                    templates_dict,
+                    self.__tag_template_factory.
+                    make_tag_template_for_custom_property_value(
+                        definition, value))
 
         return templates_dict
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -353,10 +353,9 @@ class MetadataSynchronizer:
 
         for assembled_entry in assembled_entries:
             for tag in assembled_entry.tags:
-                template_name = tag.template
                 template_id = re.match(
                     pattern=self.__TAG_TEMPLATE_NAME_PATTERN,
-                    string=template_name).group('id')
+                    string=tag.template).group('id')
                 required_templates_dict[template_id] = tag_templates_dict.get(
                     template_id)
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -68,7 +68,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         tags = assembled_entry.tags
 
         self.assertEqual(1, len(tags))
-        self.__tag_factory.make_tag_for_custom_property_defintion\
+        self.__tag_factory.make_tag_for_custom_property_definition\
             .assert_called_once()
 
     def test_make_assembled_entries_for_stream_should_process_stream(self):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -22,10 +22,11 @@ from google.datacatalog_connectors.qlik import prepare
 
 class AssembledEntryFactoryTest(unittest.TestCase):
     __PREPARE_PACKAGE = 'google.datacatalog_connectors.qlik.prepare'
+    __FACTORY_MODULE = f'{__PREPARE_PACKAGE}.assembled_entry_factory'
 
-    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_factory'
+    @mock.patch(f'{__FACTORY_MODULE}.datacatalog_tag_factory'
                 f'.DataCatalogTagFactory')
-    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_entry_factory'
+    @mock.patch(f'{__FACTORY_MODULE}.datacatalog_entry_factory'
                 f'.DataCatalogEntryFactory')
     def setUp(self, mock_entry_factory, mock_tag_factory):
         self.__factory = prepare.AssembledEntryFactory(

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -232,9 +232,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['modified_by_username'].string_value)
         self.assertEqual('Value 1', tag.fields['value'].string_value)
 
-        self.assertEqual('a123-b456', tag.fields['definition_id'].string_value)
+        self.assertEqual('a123-b456',
+                         tag.fields['property_definition_id'].string_value)
         self.assertEqual('Test definition',
-                         tag.fields['definition_name'].string_value)
+                         tag.fields['property_name'].string_value)
 
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -135,7 +135,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             ],
         }
 
-        tag = self.__factory.make_tag_for_custom_property_defintion(
+        tag = self.__factory.make_tag_for_custom_property_definition(
             tag_template, metadata)
 
         self.assertEqual('a123-b456', tag.fields['id'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -241,21 +241,23 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
 
         self.assertEqual(
             self.__STRING_TYPE,
-            tag_template.fields['definition_id'].type.primitive_type)
-        self.assertEqual('Definition Id',
-                         tag_template.fields['definition_id'].display_name)
+            tag_template.fields['property_definition_id'].type.primitive_type)
+        self.assertEqual(
+            'Property Definition Id',
+            tag_template.fields['property_definition_id'].display_name)
 
         self.assertEqual(
             self.__STRING_TYPE,
-            tag_template.fields['definition_name'].type.primitive_type)
-        self.assertEqual('Definition name',
-                         tag_template.fields['definition_name'].display_name)
+            tag_template.fields['property_name'].type.primitive_type)
+        self.assertEqual('Property Definition name',
+                         tag_template.fields['property_name'].display_name)
 
         self.assertEqual(
-            self.__STRING_TYPE,
-            tag_template.fields['definition_entry'].type.primitive_type)
-        self.assertEqual('Data Catalog Entry for the Definition',
-                         tag_template.fields['definition_entry'].display_name)
+            self.__STRING_TYPE, tag_template.
+            fields['property_definition_entry'].type.primitive_type)
+        self.assertEqual(
+            'Data Catalog Entry for the Property Definition',
+            tag_template.fields['property_definition_entry'].display_name)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['site_url'].type.primitive_type)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+from unittest import mock
 
 from google.cloud import datacatalog
 
@@ -23,6 +24,9 @@ from google.datacatalog_connectors.qlik.prepare import \
 
 
 class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.qlik.prepare'
+    __FACTORY_MODULE = f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory'
+
     __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
     __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
     __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
@@ -134,6 +138,124 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual(
             'Availability status',
             tag_template.fields['availability_status'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
+    def test_make_tag_template_for_custom_property_definition(self):
+        tag_template = \
+            self.__factory.make_tag_template_for_custom_property_definition()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/qlik_custom_property_definition_metadata',
+            tag_template.name)
+
+        self.assertEqual('Qlik Custom Property Definition Metadata',
+                         tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['modified_by_username'].type.primitive_type)
+        self.assertEqual(
+            'Username who modified it',
+            tag_template.fields['modified_by_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['value_type'].type.primitive_type)
+        self.assertEqual('Value type',
+                         tag_template.fields['value_type'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['choice_values'].type.primitive_type)
+        self.assertEqual('Choice values',
+                         tag_template.fields['choice_values'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['object_types'].type.primitive_type)
+        self.assertEqual('Object types',
+                         tag_template.fields['object_types'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
+    @mock.patch(f'{__FACTORY_MODULE}.dph.DynamicPropertiesHelper')
+    def test_make_tag_template_for_custom_property_value(self, mock_dph):
+        mock_dph.make_display_name_for_custom_property_value_tag_template\
+            .return_value = 'Test definition : Value 1'
+        mock_dph.make_id_for_custom_property_value_tag_template\
+            .return_value = 'a123||value_1'
+
+        definition_metadata = {
+            'id': 'a123-b456',
+            'name': 'Test definition',
+        }
+
+        tag_template = \
+            self.__factory.make_tag_template_for_custom_property_value(
+                definition_metadata, 'Value 1')
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/a123||value_1', tag_template.name)
+
+        self.assertEqual('Test definition : Value 1',
+                         tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(
+            self.__TIMESTAMP_TYPE,
+            tag_template.fields['created_date'].type.primitive_type)
+        self.assertEqual('Created date',
+                         tag_template.fields['created_date'].display_name)
+
+        self.assertEqual(
+            self.__TIMESTAMP_TYPE,
+            tag_template.fields['modified_date'].type.primitive_type)
+        self.assertEqual('Modified date',
+                         tag_template.fields['modified_date'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['modified_by_username'].type.primitive_type)
+        self.assertEqual(
+            'Username who modified it',
+            tag_template.fields['modified_by_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['value'].type.primitive_type)
+        self.assertEqual('Value', tag_template.fields['value'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['definition_id'].type.primitive_type)
+        self.assertEqual('Definition Id',
+                         tag_template.fields['definition_id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['definition_name'].type.primitive_type)
+        self.assertEqual('Definition name',
+                         tag_template.fields['definition_name'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['definition_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the Definition',
+                         tag_template.fields['definition_entry'].display_name)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['site_url'].type.primitive_type)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/dynamic_properties_helper_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.qlik.prepare import \
+    dynamic_properties_helper as dph
+
+
+class DynamicPropertiesHelperTest(unittest.TestCase):
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.qlik.prepare'
+    __HELPER_MODULE = f'{__PREPARE_PACKAGE}.dynamic_properties_helper'
+
+    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory.dph'
+                f'.DynamicPropertiesHelper'
+                f'.normalize_tag_template_display_name')
+    def test_make_display_name_for_custom_property_value_tag_template_should_concat_fields(  # noqa E510
+            self, mock_normalize):
+
+        dph.DynamicPropertiesHelper\
+            .make_display_name_for_custom_property_value_tag_template(
+                {'name': 'Test definition'}, 'Value 1')
+
+        mock_normalize.assert_called_with(
+            'Qlik Custom Property - Test definition - Value 1')
+
+    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory.dph'
+                f'.DynamicPropertiesHelper'
+                f'.normalize_tag_template_display_name')
+    def test_make_display_name_for_custom_property_value_tag_template_should_format_name(  # noqa E510
+            self, mock_normalize):
+
+        dph.DynamicPropertiesHelper \
+            .make_display_name_for_custom_property_value_tag_template(
+                {}, 'Value 1')
+
+        mock_normalize.assert_called_once()
+
+    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory.dph'
+                f'.DynamicPropertiesHelper.normalize_tag_template_id')
+    def test_make_id_for_custom_property_value_tag_template_should_concat_fields(  # noqa E510
+            self, mock_normalize):
+
+        dph.DynamicPropertiesHelper\
+            .make_id_for_custom_property_value_tag_template(
+                {'id': 'a123-b456'}, 'Value 1')
+
+        mock_normalize.assert_called_with('qlik_cp__a123__Value 1')
+
+    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory.dph'
+                f'.DynamicPropertiesHelper.normalize_tag_template_id')
+    def test_make_id_for_custom_property_value_tag_template_should_format_id(
+            self, mock_normalize):
+
+        dph.DynamicPropertiesHelper\
+            .make_id_for_custom_property_value_tag_template(
+                {'id': 'a123-b456'}, 'Value 1')
+
+        mock_normalize.assert_called_once()
+
+    def test_normalize_tag_template_display_name_should_replace_invalid_chars(
+            self):
+
+        normalized_name = dph.DynamicPropertiesHelper\
+            .normalize_tag_template_display_name('Test definition :: Value 1')
+
+        self.assertEqual('Test definition _ Value 1', normalized_name)
+
+    def test_normalize_tag_template_id_should_replace_invalid_chars(self):
+
+        normalized_id = dph.DynamicPropertiesHelper \
+            .normalize_tag_template_id('qlik_cp__a123__Value 1')
+
+        self.assertEqual('qlik_cp__a123__value_1', normalized_id)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -49,8 +49,8 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             [definition_assembled_entry, app_assembled_entry])
 
         self.assertEqual(
-            f'https://console.cloud.google.com/datacatalog/'
-            f'fake_entries/test_definition',
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_definition',
             app_tag.fields['property_definition_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_app_stream_mapping(self):
@@ -72,8 +72,8 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             [stream_assembled_entry, app_assembled_entry])
 
         self.assertEqual(
-            f'https://console.cloud.google.com/datacatalog/'
-            f'fake_entries/test_stream',
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_stream',
             app_tag.fields['stream_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
@@ -95,8 +95,8 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             [app_assembled_entry, sheet_assembled_entry])
 
         self.assertEqual(
-            f'https://console.cloud.google.com/datacatalog/'
-            f'fake_entries/test_app',
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_app',
             sheet_tag.fields['app_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_stream_custom_prop_def_mapping(
@@ -123,8 +123,8 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             [definition_assembled_entry, stream_assembled_entry])
 
         self.assertEqual(
-            f'https://console.cloud.google.com/datacatalog/'
-            f'fake_entries/test_definition',
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_definition',
             stream_tag.fields['property_definition_entry'].string_value)
 
     @classmethod

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -25,6 +25,34 @@ from google.datacatalog_connectors.qlik import prepare
 
 class EntryRelationshipMapperTest(unittest.TestCase):
 
+    def test_fulfill_tag_fields_should_resolve_app_custom_prop_def_mapping(
+            self):
+
+        definition_id = 'test_definition'
+        definition_entry = self.__make_fake_entry(
+            definition_id, 'custom_property_definition')
+        definition_tag = self.__make_fake_tag(string_fields=(('id',
+                                                              definition_id),))
+
+        app_id = 'test_app'
+        app_entry = self.__make_fake_entry(app_id, 'app')
+        string_fields = ('id', app_id), ('property_definition_id',
+                                         definition_id)
+        app_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        definition_assembled_entry = commons_prepare.AssembledEntryData(
+            definition_id, definition_entry, [definition_tag])
+        app_assembled_entry = commons_prepare.AssembledEntryData(
+            app_id, app_entry, [app_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [definition_assembled_entry, app_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'fake_entries/test_definition',
+            app_tag.fields['property_definition_entry'].string_value)
+
     def test_fulfill_tag_fields_should_resolve_app_stream_mapping(self):
         stream_id = 'test_stream'
         stream_entry = self.__make_fake_entry(stream_id, 'stream')
@@ -45,7 +73,7 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             f'https://console.cloud.google.com/datacatalog/'
-            f'{stream_entry.name}',
+            f'fake_entries/test_stream',
             app_tag.fields['stream_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
@@ -68,7 +96,36 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             f'https://console.cloud.google.com/datacatalog/'
-            f'{app_entry.name}', sheet_tag.fields['app_entry'].string_value)
+            f'fake_entries/test_app',
+            sheet_tag.fields['app_entry'].string_value)
+
+    def test_fulfill_tag_fields_should_resolve_stream_custom_prop_def_mapping(
+            self):
+
+        definition_id = 'test_definition'
+        definition_entry = self.__make_fake_entry(
+            definition_id, 'custom_property_definition')
+        definition_tag = self.__make_fake_tag(string_fields=(('id',
+                                                              definition_id),))
+
+        stream_id = 'test_stream'
+        stream_entry = self.__make_fake_entry(stream_id, 'stream')
+        string_fields = ('id', stream_id), ('property_definition_id',
+                                            definition_id)
+        stream_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        definition_assembled_entry = commons_prepare.AssembledEntryData(
+            definition_id, definition_entry, [definition_tag])
+        stream_assembled_entry = commons_prepare.AssembledEntryData(
+            stream_id, stream_entry, [stream_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [definition_assembled_entry, stream_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'fake_entries/test_definition',
+            stream_tag.fields['property_definition_entry'].string_value)
 
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -113,6 +113,27 @@ class MetadataSynchronizerTest(unittest.TestCase):
         ingestor = mock_ingestor.return_value
         ingestor.ingest_metadata.assert_called_once()
 
+    @mock.patch(f'{_SYNCR_MODULE}.prepare.DataCatalogTagTemplateFactory'
+                f'.make_tag_template_for_custom_property_value')
+    def test_run_custom_property_def_should_make_template_for_choice_value(
+            self, mock_make_tag_template_for_custom_property_value,
+            mock_mapper, mock_cleaner, mock_ingestor):
+
+        mock_make_tag_template_for_custom_property_value.return_value.name = \
+            'parent/tagTemplates/def__value_1'
+
+        attrs = self.__synchronizer.__dict__
+        scraper = attrs['_MetadataSynchronizer__metadata_scraper']
+
+        scraper.scrape_all_custom_property_definitions.return_value = [{
+            'id': 'test_def',
+            'choiceValues': ['Value 1']
+        }]
+
+        self.__synchronizer.run()
+
+        mock_make_tag_template_for_custom_property_value.assert_called_once()
+
     def test_run_stream_metadata_should_traverse_main_workflow_steps(
             self, mock_mapper, mock_cleaner, mock_ingestor):
 

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -66,26 +66,52 @@ def __delete_entries_and_groups(project_ids):
             print(e)
 
 
-def __delete_tag_template(project_id, location_id, tag_template_id):
+def __delete_tag_templates(project_id, location_id):
+    query = 'type=TAG_TEMPLATE name:\"Qlik Custom Property\"'
+
+    scope = datacatalog.SearchCatalogRequest.Scope()
+    scope.include_project_ids.append(project_id)
+
+    request = datacatalog.SearchCatalogRequest()
+    request.scope = scope
+    request.query = query
+    request.page_size = 1000
+
+    search_results = [
+        result for result in __datacatalog.search_catalog(request)
+    ]
+
+    # Add the dynamic Tag Template names
+    template_names = [
+        result.relative_resource_name for result in search_results
+    ]
+
+    # Add the static Tag Template names
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_app_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id,
+            'qlik_custom_property_definition_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_sheet_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_stream_metadata'))
+
+    for name in template_names:
+        __delete_tag_template(name)
+
+
+def __delete_tag_template(name):
     try:
-        __datacatalog.delete_tag_template(
-            name=datacatalog.DataCatalogClient.tag_template_path(
-                project=project_id,
-                location=location_id,
-                tag_template=tag_template_id),
-            force=True)
-        print('--> Tag Template deleted: {}'.format(tag_template_id))
+        __datacatalog.delete_tag_template(name=name, force=True)
+        print('--> Tag Template deleted: {}'.format(name))
     except Exception as e:
         print('Exception deleting Tag Template')
         print(e)
-
-
-def __delete_tag_templates(project_id, location_id):
-    __delete_tag_template(project_id, location_id, 'qlik_app_metadata')
-    __delete_tag_template(project_id, location_id,
-                          'qlik_custom_property_definition_metadata')
-    __delete_tag_template(project_id, location_id, 'qlik_sheet_metadata')
-    __delete_tag_template(project_id, location_id, 'qlik_stream_metadata')
 
 
 def __parse_args():

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -82,6 +82,8 @@ def __delete_tag_template(project_id, location_id, tag_template_id):
 
 def __delete_tag_templates(project_id, location_id):
     __delete_tag_template(project_id, location_id, 'qlik_app_metadata')
+    __delete_tag_template(project_id, location_id,
+                          'qlik_custom_property_definition_metadata')
     __delete_tag_template(project_id, location_id, 'qlik_sheet_metadata')
     __delete_tag_template(project_id, location_id, 'qlik_stream_metadata')
 


### PR DESCRIPTION
**- What I did**
Added the required code to create Tags for Custom Property Values.

**- How I did it**
Added a mechanism that creates a new Tag Template for each `choiceValue` found in the Custom Property Definitions. Then, such Tag Templates are used to store all metadata from the Custom Property Values. Each Value is stored as a Tag.

Please notice the `qlik/prepare/dynamic_properties_helper.py` file might be part of the commons package. Maybe we can move it as a follow-up change.

**- How to verify it**
Run the unit tests or, preferably, the Qlik Sense connector against a Qlik site that contains Streams and Apps with Custom Properties. Then, check the Tags created for such assets.

**- Description for the changelog**
Added support for creating Tags for Custom Property Values
