### PR TITLE
FIX "Requires authentication" error when Looker connector ran for too long 2 hours~

### DIFF
--- a/google-datacatalog-looker-connector/README.md
+++ b/google-datacatalog-looker-connector/README.md
@@ -46,6 +46,8 @@ supporting below asset types:
   * [4.3. Run Tests](#43-run-tests)
   * [4.4. Additional resources](#44-additional-resources)
 - [5. Troubleshooting](#5-troubleshooting)
+  * [5.1. Looker APIs compatibility](#51-looker-apis-compatibility)
+  * [5.2. Data Catalog quota](#52-data-catalog-quota)
 
 <!-- tocstop -->
 
@@ -207,6 +209,19 @@ documentation](docs/developer-resources).
 
 ## 5. Troubleshooting
 
+### 5.1. Looker APIs compatibility
+
+The connector may fail during the scrape stage if the Looker APIs do not return
+metadata in the expected format. The code base uses the `init31` looker_sdk client.  
+As a reference, the below versions were already validated:
+
+| VERSION                 | RESULT  |
+| ----------------------- | :-----: |
+| [Looker API 3.1][10]    | SUCCESS |
+
+
+### 5.2. Data Catalog quota
+
 In the case a connector execution hits Data Catalog quota limit, an error will
 be raised and logged with the following detailment, depending on the performed
 operation READ/WRITE/SEARCH: 
@@ -230,3 +245,4 @@ quota docs][2].
 [7]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
 [8]: https://img.shields.io/github/issues/GoogleCloudPlatform/datacatalog-connectors-bi.svg
 [9]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues
+[10]: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1

--- a/google-datacatalog-looker-connector/cloudbuild.yaml
+++ b/google-datacatalog-looker-connector/cloudbuild.yaml
@@ -78,4 +78,4 @@ steps:
   args: ['-c',
          "docker tag gcr.io/$PROJECT_ID/looker2datacatalog:$COMMIT_SHA gcr.io/$PROJECT_ID/looker2datacatalog:$(cat _TAG)"]
 images: ['gcr.io/$PROJECT_ID/looker2datacatalog']
-timeout: 3600s
+timeout: 7200s

--- a/google-datacatalog-looker-connector/setup.py
+++ b/google-datacatalog-looker-connector/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('looker_sdk == 0.1.3b7',
+    install_requires=('looker_sdk == 0.1.3b20',
                       'google-datacatalog-connectors-commons >= 0.6.0'),
     setup_requires=('pytest-runner',),
     tests_require=('pytest-cov',),

--- a/google-datacatalog-looker-connector/setup.py
+++ b/google-datacatalog-looker-connector/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=('looker_sdk == 0.1.3b20',
-                      'google-datacatalog-connectors-commons >= 0.6.0'),
+                      'google-datacatalog-connectors-commons ~= 0.6.6'),
     setup_requires=('pytest-runner',),
     tests_require=('pytest-cov',),
     classifiers=[

--- a/google-datacatalog-looker-connector/setup.py
+++ b/google-datacatalog-looker-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-looker-connector',
-    version='0.6.0',
+    version='0.6.1',
     author='Google LLC',
     description='Package for ingesting Looker metadata'
     ' into Google Cloud Data Catalog',

--- a/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/scrape/metadata_scraper.py
+++ b/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/scrape/metadata_scraper.py
@@ -17,7 +17,7 @@
 from functools import lru_cache
 import logging
 
-from looker_sdk import init31, error
+from looker_sdk import error, init31
 
 
 class MetadataScraper:

--- a/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/scrape/metadata_scraper.py
+++ b/google-datacatalog-looker-connector/src/google/datacatalog_connectors/looker/scrape/metadata_scraper.py
@@ -17,7 +17,7 @@
 from functools import lru_cache
 import logging
 
-from looker_sdk import client, error
+from looker_sdk import init31, error
 
 
 class MetadataScraper:
@@ -33,7 +33,7 @@ class MetadataScraper:
                     'last_viewed_at,deleted,deleter_id'
 
     def __init__(self, looker_credentials_file):
-        self.__sdk = client.setup(looker_credentials_file)
+        self.__sdk = init31(looker_credentials_file)
 
     def scrape_dashboard(self, dashboard_id):
         self.__log_scrape_start('Scraping dashboard by id: %s...',

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/assembled_entry_factory_test.py
@@ -90,8 +90,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         dashboard_data = {
             'id': 'test_dashboard',
         }
-        dashboard = serialize.deserialize(json.dumps(dashboard_data),
-                                          models.Dashboard)
+        dashboard = serialize.deserialize31(data=json.dumps(dashboard_data),
+                                            structure=models.Dashboard)
 
         tag_templates_dict = {
             'looker_dashboard_metadata': {
@@ -135,8 +135,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
                 'id': 194,
             }],
         }
-        dashboard = serialize.deserialize(json.dumps(dashboard_data),
-                                          models.Dashboard)
+        dashboard = serialize.deserialize31(data=json.dumps(dashboard_data),
+                                            structure=models.Dashboard)
         folder = self.__make_fake_folder()
         folder.dashboards = [dashboard]
 
@@ -178,8 +178,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
                 'id': 194,
             }],
         }
-        dashboard = serialize.deserialize(json.dumps(dashboard_data),
-                                          models.Dashboard)
+        dashboard = serialize.deserialize31(data=json.dumps(dashboard_data),
+                                            structure=models.Dashboard)
         folder = self.__make_fake_folder()
         folder.dashboards = [dashboard]
 
@@ -201,7 +201,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         look_data = {
             'id': 10,
         }
-        look = serialize.deserialize(json.dumps(look_data), models.Look)
+        look = serialize.deserialize31(data=json.dumps(look_data),
+                                       structure=models.Look)
 
         tag_templates_dict = {
             'looker_look_metadata': {
@@ -273,7 +274,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             'dashboards': [dashboard_data] if dashboard_data else None,
             'looks': [look_data] if look_data else None,
         }
-        return serialize.deserialize(json.dumps(folder_data), models.Folder)
+        return serialize.deserialize31(data=json.dumps(folder_data),
+                                       structure=models.Folder)
 
     @classmethod
     def __make_fake_query(cls):
@@ -282,7 +284,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             'model': '',
             'view': '',
         }
-        return serialize.deserialize(json.dumps(query_data), models.Query)
+        return serialize.deserialize31(data=json.dumps(query_data),
+                                       structure=models.Query)
 
     @classmethod
     def __mock_make_entry(cls, asset):

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_entry_factory_test.py
@@ -58,8 +58,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_dashboard(
-            serialize.deserialize(json.dumps(dashboard_data),
-                                  models.Dashboard))
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard))
         self.assertEqual('lkr_test_server_com_db_a123_b456', entry_id)
 
         self.assertEqual(
@@ -87,8 +87,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_dashboard(
-            serialize.deserialize(json.dumps(dashboard_data),
-                                  models.Dashboard))
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard))
 
         self.assertIsNone(entry.source_system_timestamps.create_time)
         self.assertIsNone(entry.source_system_timestamps.update_time)
@@ -100,8 +100,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_dashboard_element(
-            serialize.deserialize(json.dumps(dashboard_element_data),
-                                  models.DashboardElement))
+            serialize.deserialize31(data=json.dumps(dashboard_element_data),
+                                    structure=models.DashboardElement))
         self.assertEqual('lkr_test_server_com_de_196', entry_id)
 
         self.assertEqual(
@@ -120,8 +120,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_dashboard_element(
-            serialize.deserialize(json.dumps(dashboard_element_data),
-                                  models.DashboardElement))
+            serialize.deserialize31(data=json.dumps(dashboard_element_data),
+                                    structure=models.DashboardElement))
         self.assertEqual('Test Name', entry.display_name)
 
     def test_make_entry_for_dashboard_tile_should_skip_empty_titles(self):
@@ -130,9 +130,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_dashboard_element(
-            serialize.deserialize(json.dumps(dashboard_element_data),
-                                  models.DashboardElement))
-
+            serialize.deserialize31(data=json.dumps(dashboard_element_data),
+                                    structure=models.DashboardElement))
         self.assertIsNone(entry_id)
         self.assertIsNone(entry)
 
@@ -144,7 +143,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_folder(
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
         self.assertEqual('lkr_test_server_com_fd_a123_b456', entry_id)
 
         self.assertEqual(
@@ -166,7 +166,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_look(
-            serialize.deserialize(json.dumps(look_data), models.Look))
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.Look))
         self.assertEqual('lkr_test_server_com_lk_123', entry_id)
 
         self.assertEqual(
@@ -196,8 +197,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_look(
-            serialize.deserialize(json.dumps(look_data), models.Look))
-
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.Look))
         created_datetime = self.__parse_datetime('2019-09-12T16:30:00+0000')
         self.assertEqual(
             created_datetime.timestamp(),
@@ -215,7 +216,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         entry_id, entry = self.__factory.make_entry_for_query(
-            serialize.deserialize(json.dumps(query_data), models.Query))
+            serialize.deserialize31(data=json.dumps(query_data),
+                                    structure=models.Query))
         self.assertEqual('lkr_test_server_com_qr_837', entry_id)
 
         self.assertEqual(

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_tag_factory_test.py
@@ -400,10 +400,15 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'view': 'test-view',
         }
 
+        # yapf: disable
         assembled_metadata = entities.AssembledQueryMetadata(
-            serialize.deserialize31(data=json.dumps(query_data),
-                                    structure=models.Query), 'select *', None,
+            serialize.deserialize31(
+                data=json.dumps(query_data),
+                structure=models.Query),
+            'select *',
+            None,
             None)
+        # yapf: enable
 
         tag = self.__factory.make_tag_for_query(tag_template,
                                                 assembled_metadata)

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/prepare/datacatalog_tag_factory_test.py
@@ -66,8 +66,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_dashboard(
             tag_template,
-            serialize.deserialize(json.dumps(dashboard_data),
-                                  models.Dashboard))
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard))
 
         self.assertEqual(tag_template.name, tag.template)
 
@@ -123,10 +123,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_dashboard_element(
             tag_template,
-            serialize.deserialize(json.dumps(dashboard_element_data),
-                                  models.DashboardElement),
-            serialize.deserialize(json.dumps(dashboard_data),
-                                  models.Dashboard))
+            serialize.deserialize31(data=json.dumps(dashboard_element_data),
+                                    structure=models.DashboardElement),
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard))
 
         self.assertEqual(tag_template.name, tag.template)
 
@@ -158,8 +158,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_dashboard_element(
             tag_template,
-            serialize.deserialize(json.dumps(dashboard_element_data),
-                                  models.DashboardElement), None)
+            serialize.deserialize31(data=json.dumps(dashboard_element_data),
+                                    structure=models.DashboardElement), None)
 
         self.assertEqual(837, tag.fields['query_id'].double_value)
 
@@ -178,7 +178,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_folder(
             tag_template,
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
 
         self.assertEqual(tag_template.name, tag.template)
 
@@ -209,7 +210,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_folder(
             tag_template,
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
 
         self.assertEqual(False, tag.fields['has_children'].bool_value)
         self.assertEqual(0, tag.fields['children_count'].double_value)
@@ -248,7 +250,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_look(
             tag_template,
-            serialize.deserialize(json.dumps(look_data), models.Look))
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.Look))
 
         self.assertEqual(tag_template.name, tag.template)
 
@@ -303,7 +306,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_look(
             tag_template,
-            serialize.deserialize(json.dumps(look_data), models.LookWithQuery))
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.LookWithQuery))
 
         self.assertEqual('test/url', tag.fields['url'].string_value)
 
@@ -345,12 +349,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         assembled_metadata = entities.AssembledQueryMetadata(
-            serialize.deserialize(json.dumps(query_data), models.Query),
-            'select *',
-            serialize.deserialize(json.dumps(explore_data),
-                                  models.LookmlModelExplore),
-            serialize.deserialize(json.dumps(connection_data),
-                                  models.DBConnection))
+            serialize.deserialize31(data=json.dumps(query_data),
+                                    structure=models.Query), 'select *',
+            serialize.deserialize31(data=json.dumps(explore_data),
+                                    structure=models.LookmlModelExplore),
+            serialize.deserialize31(data=json.dumps(connection_data),
+                                    structure=models.DBConnection))
 
         tag = self.__factory.make_tag_for_query(tag_template,
                                                 assembled_metadata)
@@ -397,8 +401,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         assembled_metadata = entities.AssembledQueryMetadata(
-            serialize.deserialize(json.dumps(query_data), models.Query),
-            'select *', None, None)
+            serialize.deserialize31(data=json.dumps(query_data),
+                                    structure=models.Query), 'select *', None,
+            None)
 
         tag = self.__factory.make_tag_for_query(tag_template,
                                                 assembled_metadata)
@@ -420,7 +425,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         tag = self.__factory.make_tag_for_folder(
             tag_template,
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
 
         self.assertFalse('parent_id' in tag.fields)
 

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/scrape/metadata_scraper_test.py
@@ -27,7 +27,7 @@ from google.datacatalog_connectors.looker import scrape
 class MetadataScraperTest(unittest.TestCase):
 
     @mock.patch('google.datacatalog_connectors.looker.scrape'
-                '.metadata_scraper.client.setup')
+                '.metadata_scraper.init31')
     def setUp(self, mock_client):
         self.__scraper = scrape.MetadataScraper('looker-credentials-file.ini')
 
@@ -41,8 +41,8 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 'dashboard-id',
         }
 
-        sdk.dashboard.return_value = serialize.deserialize(
-            json.dumps(dashboard_data), models.Dashboard)
+        sdk.dashboard.return_value = serialize.deserialize31(
+            data=json.dumps(dashboard_data), structure=models.Dashboard)
 
         dashboard = self.__scraper.scrape_dashboard('dashboard-id')
 
@@ -72,7 +72,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_dashboards.return_value = [
-            serialize.deserialize(json.dumps(dashboard_data), models.Dashboard)
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard)
         ]
 
         dashboards = self.__scraper.scrape_all_dashboards()
@@ -94,7 +95,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_dashboards.return_value = [
-            serialize.deserialize(json.dumps(dashboard_data), models.Dashboard)
+            serialize.deserialize31(data=json.dumps(dashboard_data),
+                                    structure=models.Dashboard)
         ]
 
         folder_data = {
@@ -104,7 +106,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         dashboards = self.__scraper.scrape_dashboards_from_folder(
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
 
         self.assertEqual(1, len(dashboards))
         self.assertEqual('dashboard-id', dashboards[0].id)
@@ -124,8 +127,8 @@ class MetadataScraperTest(unittest.TestCase):
             'parent_id': '',
         }
 
-        sdk.folder.return_value = serialize.deserialize(
-            json.dumps(folder_data), models.Folder)
+        sdk.folder.return_value = serialize.deserialize31(
+            data=json.dumps(folder_data), structure=models.Folder)
 
         folder = self.__scraper.scrape_folder('folder-id')
 
@@ -145,7 +148,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_folders.return_value = [
-            serialize.deserialize(json.dumps(folder_data), models.Folder)
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder)
         ]
 
         folders = self.__scraper.scrape_all_folders()
@@ -166,7 +170,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_folders.return_value = [
-            serialize.deserialize(json.dumps(folder_data), models.Folder)
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder)
         ]
 
         folders = self.__scraper.scrape_top_level_folders()
@@ -188,7 +193,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.folder_children.return_value = [
-            serialize.deserialize(json.dumps(folder_data), models.Folder)
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder)
         ]
 
         parent_data = {
@@ -198,7 +204,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         folders = self.__scraper.scrape_child_folders(
-            serialize.deserialize(json.dumps(parent_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(parent_data),
+                                    structure=models.Folder))
 
         self.assertEqual(1, len(folders))
         self.assertEqual('folder-id', folders[0].id)
@@ -214,8 +221,8 @@ class MetadataScraperTest(unittest.TestCase):
             'id': 123,
         }
 
-        sdk.look.return_value = serialize.deserialize(json.dumps(look_data),
-                                                      models.Look)
+        sdk.look.return_value = serialize.deserialize31(
+            data=json.dumps(look_data), structure=models.Look)
 
         look = self.__scraper.scrape_look(123)
 
@@ -236,7 +243,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_looks.return_value = [
-            serialize.deserialize(json.dumps(look_data), models.Look)
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.Look)
         ]
 
         looks = self.__scraper.scrape_all_looks()
@@ -260,7 +268,8 @@ class MetadataScraperTest(unittest.TestCase):
         }
 
         sdk.search_looks.return_value = [
-            serialize.deserialize(json.dumps(look_data), models.Look)
+            serialize.deserialize31(data=json.dumps(look_data),
+                                    structure=models.Look)
         ]
 
         folder_data = {
@@ -269,7 +278,8 @@ class MetadataScraperTest(unittest.TestCase):
             'parent_id': '',
         }
         looks = self.__scraper.scrape_looks_from_folder(
-            serialize.deserialize(json.dumps(folder_data), models.Folder))
+            serialize.deserialize31(data=json.dumps(folder_data),
+                                    structure=models.Folder))
 
         self.assertEqual(1, len(looks))
         self.assertEqual(123, looks[0].id)
@@ -291,8 +301,8 @@ class MetadataScraperTest(unittest.TestCase):
             'view': '',
         }
 
-        sdk.query.return_value = serialize.deserialize(json.dumps(query_data),
-                                                       models.Query)
+        sdk.query.return_value = serialize.deserialize31(
+            data=json.dumps(query_data), structure=models.Query)
 
         query = self.__scraper.scrape_query(123)
 
@@ -318,8 +328,9 @@ class MetadataScraperTest(unittest.TestCase):
             'connection_name': 'test-connection',
         }
 
-        sdk.lookml_model_explore.return_value = serialize.deserialize(
-            json.dumps(model_explore_data), models.LookmlModelExplore)
+        sdk.lookml_model_explore.return_value = serialize.deserialize31(
+            data=json.dumps(model_explore_data),
+            structure=models.LookmlModelExplore)
 
         model = self.__scraper.scrape_lookml_model_explore(
             'test-model', 'test-view')
@@ -347,8 +358,8 @@ class MetadataScraperTest(unittest.TestCase):
             'name': 'test-connection',
         }
 
-        sdk.connection.return_value = serialize.deserialize(
-            json.dumps(connection_data), models.DBConnection)
+        sdk.connection.return_value = serialize.deserialize31(
+            data=json.dumps(connection_data), structure=models.DBConnection)
 
         connection = self.__scraper.scrape_connection('test-connection')
 

--- a/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-looker-connector/tests/google/datacatalog_connectors/looker/sync/metadata_synchronizer_test.py
@@ -280,7 +280,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'parent_id': parent_data['id'] if parent_data else '',
             'child_count': 1 if parent else 0,
         }
-        return serialize.deserialize(json.dumps(folder_data), models.Folder)
+        return serialize.deserialize31(data=json.dumps(folder_data),
+                                       structure=models.Folder)
 
     @classmethod
     def __make_fake_dashboard(cls, folder):
@@ -289,8 +290,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'space': json.loads(serialize.serialize(folder)),
             'dashboard_elements': [],
         }
-        return serialize.deserialize(json.dumps(dashboard_data),
-                                     models.Dashboard)
+        return serialize.deserialize31(data=json.dumps(dashboard_data),
+                                       structure=models.Dashboard)
 
     @classmethod
     def __make_fake_look(cls, folder):
@@ -298,4 +299,5 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'id': 123,
             'space': json.loads(serialize.serialize(folder)),
         }
-        return serialize.deserialize(json.dumps(look_data), models.Look)
+        return serialize.deserialize31(data=json.dumps(look_data),
+                                       structure=models.Look)


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/docs/contributing.md

Please provide the following information:
-->

**- What I did**
Fixed "Requires authentication" error when Looker connector ran for too long 2 hours~.

**- How I did it**
- Upgraded looker_sdk to latest version `looker_sdk == 0.1.3b20`.
- Changed client initialization logic to use `init31` for API 3.1.

**- How to verify it**
Run the looker connector in a looker server that has 5000+ assets, and takes more than 2 hours to scrape all assets.

**- Description for the changelog**
In the latest version the sdk seems to automatically renew the session token, I was able to scrape a looker server that took more than 3 hours, and the error does not happen anymore. Fixes #32.

