### PR TITLE
Turn async unit tests more realistic

### DIFF
--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/base_engine_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/base_engine_api_helper_test.py
@@ -105,7 +105,8 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
                     }],
                 },
             },
-        ])
+        ],
+                               stop_itr_on_no_data=True)
 
         helper = base_engine_api_helper.BaseEngineAPIHelper
         results = helper._run_until_complete(
@@ -131,7 +132,8 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
                     'id': 'test-id',
                 },
             },
-        ])
+        ],
+                               stop_itr_on_no_data=True)
 
         helper = base_engine_api_helper.BaseEngineAPIHelper
         results = helper._run_until_complete(
@@ -153,7 +155,8 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
             {
                 'method': 'OnTestMethod',
             },
-        ])
+        ],
+                               stop_itr_on_no_data=True)
 
         helper = base_engine_api_helper.BaseEngineAPIHelper
         helper._run_until_complete(
@@ -176,7 +179,8 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
                     'message': 'Test message',
                 },
             },
-        ])
+        ],
+                               stop_itr_on_no_data=True)
 
         helper = base_engine_api_helper.BaseEngineAPIHelper
         try:

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
@@ -54,9 +54,8 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
             self, mock_websocket, mock_send_open_doc, mock_send_get_all_infos,
             mock_generate_request_id):
 
-        mock_send_open_doc.return_value = asyncio.sleep(delay=0.15, result=1)
-        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0.15,
-                                                             result=2)
+        mock_send_open_doc.return_value = asyncio.sleep(delay=0, result=1)
+        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0, result=2)
         mock_generate_request_id.side_effect = [3, 4]
 
         websocket_ctx = mock_websocket.return_value.__enter__.return_value
@@ -103,6 +102,8 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
 
         self.assertEqual(1, len(dimensions))
         self.assertEqual('dimension-id', dimensions[0].get('qInfo').get('qId'))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()
 
     @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
@@ -136,3 +137,5 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
         dimensions = self.__helper.get_dimensions('app-id')
 
         self.assertEqual(0, len(dimensions))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
@@ -45,6 +45,9 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
         dimensions = self.__helper.get_dimensions('app-id')
         self.assertEqual(0, len(dimensions))
 
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in test case in order to simulate an end-to-end scenario with
+    # responses that represent an App with Dimensions.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
@@ -105,6 +108,9 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
         mock_send_open_doc.assert_called_once()
         mock_send_get_all_infos.assert_called_once()
 
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in test case in order to simulate an end-to-end scenario with
+    # responses that represent an App with no Dimensions.
     @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
@@ -117,6 +117,9 @@ class EngineAPIScraperTest(unittest.TestCase):
     def test_get_windows_authentication_url_should_pass_appropriate_auth_args(
             self, mock_websocket):
 
+        mock_websocket.return_value.__enter__.return_value.set_data(
+            [], stop_itr_on_no_data=True)
+
         # Call a public method to trigger the authentication workflow.
         self.__scraper.get_sheets('app-id')
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
@@ -44,6 +44,9 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
         sheets = self.__helper.get_sheets('app-id')
         self.assertEqual(0, len(sheets))
 
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in test case in order to simulate an end-to-end scenario with
+    # responses that represent an App with Sheets.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',
@@ -84,6 +87,9 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
         self.assertEqual('sheet-id', sheets[0].get('qInfo').get('qId'))
         mock_send_open_doc.assert_called_once()
 
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in test case in order to simulate an end-to-end scenario with
+    # responses that represent an App with no Sheets.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
@@ -82,6 +82,7 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
 
         self.assertEqual(1, len(sheets))
         self.assertEqual('sheet-id', sheets[0].get('qInfo').get('qId'))
+        mock_send_open_doc.assert_called_once()
 
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
@@ -116,3 +117,5 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
         sheets = self.__helper.get_sheets('app-id')
 
         self.assertEqual(0, len(sheets))
+        mock_send_open_doc.assert_called_once()
+        mock_generate_request_id.assert_called_once()


### PR DESCRIPTION
**- What I did**
Changed the `AsyncContextManager` mock in order to enable more realistic scenarios.

**- How I did it**
1. Added a `__stop_itr_on_no_data` flag that will let the context manager know whether iteration should stop on no more data available or keep sending empty responses when requested. This is not what an actual WebSocket does: it simply does not send any response, but keeps the communication channel open. I didn't find a way to emulate this behavior yet. 
2. Changed the `close` method to force the flag value to `True`; hence stopping the iteration as an actual `websocket.close()` call does.
3. Updated existing unit tests to leverage the new `stop_itr_on_no_data` argument.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Changed the `AsyncContextManager` mock in order to enable more realistic scenarios.
