### PR TITLE
Fix minor issues in the Qlik metadata scraping

### DIFF
--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper.py
@@ -35,8 +35,7 @@ class EngineAPIDimensionsHelper(base_engine_api_helper.BaseEngineAPIHelper):
             return self._run_until_complete(
                 self.__get_dimensions(app_id, timeout))
         except Exception:
-            logging.getLogger().warning("error on get_dimensions:",
-                                        exc_info=True)
+            logging.warning("error on get_dimensions:", exc_info=True)
             return []
 
     async def __get_dimensions(self, app_id, timeout):

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper.py
@@ -30,7 +30,7 @@ class EngineAPISheetsHelper(base_engine_api_helper.BaseEngineAPIHelper):
         try:
             return self._run_until_complete(self.__get_sheets(app_id, timeout))
         except Exception:
-            logging.getLogger().warning("error on get_sheets:", exc_info=True)
+            logging.warning("error on get_sheets:", exc_info=True)
             return []
 
     async def __get_sheets(self, app_id, timeout):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/base_engine_api_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/base_engine_api_helper_test.py
@@ -81,7 +81,7 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
         mock_generate_request_id.return_value = 10
         mock_responses_manager = mock.MagicMock()
 
-        base_engine_api_helper.BaseEngineAPIHelper._run_until_complete(
+        asyncio.new_event_loop().run_until_complete(
             self.__helper._start_websocket_communication(
                 mock_websocket, 'app-id', mock_responses_manager))
 
@@ -108,10 +108,9 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
         ],
                                stop_itr_on_no_data=True)
 
-        helper = base_engine_api_helper.BaseEngineAPIHelper
-        results = helper._run_until_complete(
-            helper._consume_messages(websocket_ctx, mock_responses_manager,
-                                     'Test', 'result.list'))
+        results = asyncio.new_event_loop().run_until_complete(
+            base_engine_api_helper.BaseEngineAPIHelper._consume_messages(
+                websocket_ctx, mock_responses_manager, 'Test', 'result.list'))
 
         self.assertEqual(1, len(results))
         self.assertEqual('test-id', results[0]['id'])
@@ -135,10 +134,9 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
         ],
                                stop_itr_on_no_data=True)
 
-        helper = base_engine_api_helper.BaseEngineAPIHelper
-        results = helper._run_until_complete(
-            helper._consume_messages(websocket_ctx, mock_responses_manager,
-                                     'Test', 'result'))
+        results = asyncio.new_event_loop().run_until_complete(
+            base_engine_api_helper.BaseEngineAPIHelper._consume_messages(
+                websocket_ctx, mock_responses_manager, 'Test', 'result'))
 
         self.assertEqual(1, len(results))
         self.assertEqual('test-id', results[0]['id'])
@@ -158,10 +156,9 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
         ],
                                stop_itr_on_no_data=True)
 
-        helper = base_engine_api_helper.BaseEngineAPIHelper
-        helper._run_until_complete(
-            helper._consume_messages(websocket_ctx, mock.MagicMock(), 'Test',
-                                     'result.test'))
+        asyncio.new_event_loop().run_until_complete(
+            base_engine_api_helper.BaseEngineAPIHelper._consume_messages(
+                websocket_ctx, mock.MagicMock(), 'Test', 'result.test'))
 
         mock_handle_response.assert_called_once_with(
             {'method': 'OnTestMethod'})
@@ -182,11 +179,10 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
         ],
                                stop_itr_on_no_data=True)
 
-        helper = base_engine_api_helper.BaseEngineAPIHelper
         try:
-            helper._run_until_complete(
-                helper._consume_messages(websocket_ctx, mock.MagicMock(),
-                                         'Test', 'result.test'))
+            asyncio.new_event_loop().run_until_complete(
+                base_engine_api_helper.BaseEngineAPIHelper._consume_messages(
+                    websocket_ctx, mock.MagicMock(), 'Test', 'result.test'))
         except Exception as e:
             self.assertEqual('Test message', str(e))
 
@@ -197,9 +193,8 @@ class BaseEngineAPIHelperTest(unittest.TestCase):
             self, mock_websocket, mock_generate_request_id):
 
         mock_generate_request_id.return_value = 10
-        request_id = base_engine_api_helper.BaseEngineAPIHelper\
-            ._run_until_complete(
-                self.__helper._send_get_all_infos_request(mock_websocket, 1))
+        request_id = asyncio.new_event_loop().run_until_complete(
+            self.__helper._send_get_all_infos_request(mock_websocket, 1))
 
         mock_generate_request_id.assert_called_once()
         self.assertEqual(10, request_id)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
@@ -46,8 +46,11 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
         self.assertEqual(0, len(dimensions))
 
     # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
-    # mocked in test case in order to simulate an end-to-end scenario with
-    # responses that represent an App with Dimensions.
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with Dimensions. Maybe it's
+    # worth refactoring it in the future to mock that method, and the private
+    # async ones from EngineAPIDimensionsHelper as well, thus testing in a more
+    # granular way.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
@@ -109,8 +112,11 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
         mock_send_get_all_infos.assert_called_once()
 
     # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
-    # mocked in test case in order to simulate an end-to-end scenario with
-    # responses that represent an App with no Dimensions.
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with no Dimensions. Maybe
+    # it's worth refactoring it in the future to mock that method, and the
+    # private async ones from EngineAPIDimensionsHelper as well, thus testing
+    # in a more granular way.
     @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
@@ -45,8 +45,11 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
         self.assertEqual(0, len(sheets))
 
     # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
-    # mocked in test case in order to simulate an end-to-end scenario with
-    # responses that represent an App with Sheets.
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with Sheets. Maybe it's
+    # worth refactoring it in the future to mock that method, and the private
+    # async ones from EngineAPISheetsHelper as well, thus testing in a more
+    # granular way.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',
@@ -88,8 +91,11 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
         mock_send_open_doc.assert_called_once()
 
     # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
-    # mocked in test case in order to simulate an end-to-end scenario with
-    # responses that represent an App with no Sheets.
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with no Sheets. Maybe it's
+    # worth refactoring it in the future to mock that method, and the private
+    # async ones from EngineAPISheetsHelper as well, thus testing in a more
+    # granular way.
     @mock.patch(f'{__BASE_CLASS}._generate_request_id')
     @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
     @mock.patch(f'{__BASE_CLASS}._connect_websocket',


### PR DESCRIPTION
**- What I did**
Fixed minor issues in the Qlik metadata scraping

**- How I did it**
1. In `scrape.base_engine_api_helper_test.py` I've replaced `base_engine_api_helper.BaseEngineAPIHelper._run_until_complete` with `asyncio.new_event_loop().run_until_complete` to avoid calling two methods of the class under test, where possible.
2. In `srape.engine_api_dimensions_helper_test.py` I've detailed the comments on not mocked stuff to let folks know what could be improved in the future towards more granular testing. I'm not sure if I will have the bandwidth to tackle such improvement in the current engagement.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Fixed minor issues in the Qlik metadata scraping.

