### PR TITLE
Add support for ingesting Dimensions metadata

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -5,6 +5,7 @@ currently supporting below asset types:
 - Custom Property Definition
 - Stream
 - App (only the published ones)
+- Master Items: Dimension  
 - Sheet (only the published ones)
 
 **Disclaimer: This is not an officially supported Google product.**

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -99,6 +99,11 @@ class AssembledEntryFactory:
             assembled_entries.append(
                 self.__make_assembled_entry_for_app(app_metadata,
                                                     tag_templates_dict))
+
+            assembled_entries.extend(
+                self.__make_assembled_entries_for_dimensions(
+                    app_metadata.get('dimensions'), tag_templates_dict))
+
             assembled_entries.extend(
                 self.__make_assembled_entries_for_sheets(
                     app_metadata.get('sheets'), tag_templates_dict))
@@ -121,6 +126,33 @@ class AssembledEntryFactory:
         tags.extend(
             self.__datacatalog_tag_factory.make_tags_for_custom_properties(
                 tag_templates_dict, app_metadata.get('customProperties')))
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)
+
+    def __make_assembled_entries_for_dimensions(self, dimensions_metadata,
+                                                tag_templates_dict):
+
+        return [
+            self.__make_assembled_entry_for_dimension(dimension_metadata,
+                                                      tag_templates_dict)
+            for dimension_metadata in dimensions_metadata
+        ] if dimensions_metadata else []
+
+    def __make_assembled_entry_for_dimension(self, dimension_metadata,
+                                             tag_templates_dict):
+
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_dimension(
+                dimension_metadata)
+
+        tag_template = tag_templates_dict.get(
+            constants.TAG_TEMPLATE_ID_DIMENSION)
+
+        tags = []
+        if tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.make_tag_for_dimension(
+                    tag_template, dimension_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -20,6 +20,7 @@ ENTRY_ID_MAX_LENGTH = 64
 # ENTRY_ID_PREFIX when generating Qlik Entry IDs.
 ENTRY_ID_PART_APP = 'app_'
 ENTRY_ID_PART_CUSTOM_PROPERTY_DEFINITION = 'cpd_'
+ENTRY_ID_PART_DIMENSION = 'dim_'
 ENTRY_ID_PART_SHEET = 'sht_'
 ENTRY_ID_PART_STREAM = 'str_'
 # This is the common prefix for all Qlik Entries.
@@ -37,6 +38,9 @@ TAG_TEMPLATE_ID_APP = 'qlik_app_metadata'
 # Custom Property Definition related Entries.
 TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION = \
     'qlik_custom_property_definition_metadata'
+# The ID of the Tag Template created to store additional metadata for the
+# Dimension-related Entries.
+TAG_TEMPLATE_ID_DIMENSION = 'qlik_dimension_metadata'
 # Prefix for IDs of the Tag Templates created to tag Entries with their
 # Custom Properties.
 TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY = 'qlik_cp__'
@@ -51,7 +55,18 @@ TAG_TEMPLATE_ID_STREAM = 'qlik_stream_metadata'
 USER_SPECIFIED_TYPE_APP = 'app'
 # The user specified type of the Custom Property Definition related Entries.
 USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION = 'custom_property_definition'
+# The user specified type of the Dimension-related Entries.
+USER_SPECIFIED_TYPE_DIMENSION = 'dimension'
 # The user specified type of the Sheet-related Entries.
 USER_SPECIFIED_TYPE_SHEET = 'sheet'
 # The user specified type of the Stream-related Entries.
 USER_SPECIFIED_TYPE_STREAM = 'stream'
+
+# The value of the Tag Field that represents a 'Drill down' Dimension.
+DIMENSION_GROUPING_DRILL_DOWN_TAG_FIELD = 'Drill down'
+# The value of the incoming metadata that represents a 'Drill down' Dimension.
+DIMENSION_GROUPING_DRILL_DOWN_QLIK = 'H'
+# The value of the Tag Field that represents a 'Single' Dimension.
+DIMENSION_GROUPING_SINGLE_TAG_FIELD = 'Single'
+# The value of the incoming metadata that represents a 'Single' Dimension.
+DIMENSION_GROUPING_SINGLE_QLIK = 'N'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -2,14 +2,14 @@
 #
 # Copyright 2020 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -48,8 +48,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.user_specified_type = constants.USER_SPECIFIED_TYPE_APP
 
         entry.display_name = self._format_display_name(
-            app_metadata.get("name"))
-        entry.description = app_metadata.get("description")
+            app_metadata.get('name'))
+        entry.description = app_metadata.get('description')
 
         entry.linked_resource = f'{self.__site_url}' \
                                 f'/sense/app/{app_metadata.get("id")}'
@@ -89,8 +89,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
 
         entry.display_name = self._format_display_name(
-            custom_property_def_metadata.get("name"))
-        entry.description = custom_property_def_metadata.get("description")
+            custom_property_def_metadata.get('name'))
+        entry.description = custom_property_def_metadata.get('description')
 
         # The linked_resource field is not fulfilled because there is no way to
         # jump directly to an 'edit' page in the QlikView Management Console
@@ -119,6 +119,36 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
+    def make_entry_for_dimension(self, dimension_metadata):
+        entry = datacatalog.Entry()
+
+        app_metadata = dimension_metadata.get('app')
+
+        # The Dimension ID is usually a 7 letters string, so the App ID is
+        # prepended to prevent overlaping.
+        generated_id = self.__format_id(
+            constants.ENTRY_ID_PART_DIMENSION, f'{app_metadata.get("id")}'
+            f'_{dimension_metadata.get("qInfo").get("qId")}')
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_DIMENSION
+
+        q_meta_def = dimension_metadata.get('qMetaDef')
+
+        entry.display_name = self._format_display_name(q_meta_def.get('title'))
+        entry.description = q_meta_def.get('description')
+
+        # The linked_resource field is not fulfilled because there is no way to
+        # jump directly to a Dimension 'edit' page in Qlik Sense.
+
+        # The create_time and update_time fields are not fulfilled because
+        # there is no such info in the Dimension properties.
+
+        return generated_id, entry
+
     def make_entry_for_sheet(self, sheet_metadata):
         entry = datacatalog.Entry()
 
@@ -133,8 +163,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.user_specified_type = constants.USER_SPECIFIED_TYPE_SHEET
 
         q_meta = sheet_metadata.get('qMeta')
-        entry.display_name = self._format_display_name(q_meta.get("title"))
-        entry.description = q_meta.get("description")
+        entry.display_name = self._format_display_name(q_meta.get('title'))
+        entry.description = q_meta.get('description')
 
         entry.linked_resource = f'{self.__site_url}' \
                                 f'/sense/app/' \
@@ -170,7 +200,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.user_specified_type = constants.USER_SPECIFIED_TYPE_STREAM
 
         entry.display_name = self._format_display_name(
-            stream_metadata.get("name"))
+            stream_metadata.get('name'))
 
         entry.linked_resource = f'{self.__site_url}' \
                                 f'/hub/stream/{stream_metadata.get("id")}'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -2,14 +2,14 @@
 #
 # Copyright 2020 Google LLC
 #
-# Licensed under the Apache License, Version 2.0 (the 'License');
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -188,6 +188,49 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
+    def make_tag_template_for_dimension(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_DIMENSION)
+
+        tag_template.display_name = 'Qlik Dimension Metadata'
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_enum_type_field(tag_template, 'grouping', [
+            constants.DIMENSION_GROUPING_SINGLE_TAG_FIELD,
+            constants.DIMENSION_GROUPING_DRILL_DOWN_TAG_FIELD
+        ], 'Grouping')
+
+        self._add_primitive_type_field(tag_template, 'fields',
+                                       self.__STRING_TYPE, 'Fields')
+
+        self._add_primitive_type_field(tag_template, 'field_labels',
+                                       self.__STRING_TYPE, 'Field labels')
+
+        self._add_primitive_type_field(tag_template, 'tags',
+                                       self.__STRING_TYPE, 'Qlik Tags')
+
+        self._add_primitive_type_field(tag_template, 'app_id',
+                                       self.__STRING_TYPE, 'App Id')
+
+        self._add_primitive_type_field(tag_template, 'app_name',
+                                       self.__STRING_TYPE, 'App name')
+
+        self._add_primitive_type_field(tag_template, 'app_entry',
+                                       self.__STRING_TYPE,
+                                       'Data Catalog Entry for the App')
+
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
+
+        return tag_template
+
     def make_tag_template_for_sheet(self):
         tag_template = datacatalog.TagTemplate()
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -23,12 +23,14 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     __APP = constants.USER_SPECIFIED_TYPE_APP
     __CUSTOM_PROPERTY_DEFINITION = \
         constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
+    __DIMENSION = constants.USER_SPECIFIED_TYPE_DIMENSION
     __SHEET = constants.USER_SPECIFIED_TYPE_SHEET
     __STREAM = constants.USER_SPECIFIED_TYPE_STREAM
 
     def fulfill_tag_fields(self, assembled_entries):
         resolvers = (
             self.__resolve_app_mappings,
+            self.__resolve_dimension_mappings,
             self.__resolve_sheet_mappings,
             self.__resolve_stream_mappings,
         )
@@ -48,6 +50,16 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
                                    'property_definition_entry', id_name_pairs)
             cls._map_related_entry(assembled_entry, cls.__STREAM, 'stream_id',
                                    'stream_entry', id_name_pairs)
+
+    @classmethod
+    def __resolve_dimension_mappings(cls, assembled_entries, id_name_pairs):
+        dimension_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__DIMENSION
+        ]
+        for assembled_entry in dimension_assembled_entries:
+            cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
+                                   'app_entry', id_name_pairs)
 
     @classmethod
     def __resolve_sheet_mappings(cls, assembled_entries, id_name_pairs):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -137,6 +137,38 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             updated_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+    def test_make_entry_for_dimension_should_set_all_available_fields(self):
+        metadata = {
+            'qInfo': {
+                'qId': 'a123-b456',
+            },
+            'qMetaDef': {
+                'title': 'Test dimension',
+                'description': 'Description of the Test dimension',
+            },
+            'app': {
+                'id': 'app-id'
+            },
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_dimension(metadata)
+
+        self.assertEqual('qlik_dim_app_id_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'qlik_dim_app_id_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('dimension', entry.user_specified_type)
+        self.assertEqual('Test dimension', entry.display_name)
+        self.assertEqual('Description of the Test dimension',
+                         entry.description)
+
+        self.assertEqual('', entry.linked_resource)
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+        self.assertIsNone(entry.source_system_timestamps.update_time)
+
     def test_make_entry_for_sheet_should_set_all_available_fields(self):
         metadata = {
             'qInfo': {

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -275,6 +275,54 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)
 
+    def test_make_tag_for_dimension_should_set_all_available_fields(self):
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_dimension()
+
+        metadata = {
+            'qInfo': {
+                'qId': 'c987-d654',
+            },
+            'qDim': {
+                'qGrouping': 'H',
+                'qFieldDefs': [
+                    'FIELD_1',
+                    'FIELD_2',
+                ],
+                'qFieldLabels': [
+                    'Field 1',
+                    'Field 2',
+                ],
+            },
+            'qMetaDef': {
+                'tags': [
+                    'tag 1',
+                    'tag 2',
+                ],
+            },
+            'app': {
+                'id': 'a123-b456',
+                'name': 'Test app',
+            },
+        }
+
+        tag = self.__factory.make_tag_for_dimension(tag_template, metadata)
+
+        self.assertEqual('c987-d654', tag.fields['id'].string_value)
+
+        self.assertEqual('Drill down',
+                         tag.fields['grouping'].enum_value.display_name)
+        self.assertEqual('FIELD_1, FIELD_2', tag.fields['fields'].string_value)
+        self.assertEqual('Field 1, Field 2',
+                         tag.fields['field_labels'].string_value)
+        self.assertEqual('tag 1, tag 2', tag.fields['tags'].string_value)
+
+        self.assertEqual('a123-b456', tag.fields['app_id'].string_value)
+        self.assertEqual('Test app', tag.fields['app_name'].string_value)
+
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)
+
     def test_make_tag_for_sheet_should_set_all_available_fields(self):
         tag_template = \
             self.__tag_template_factory.make_tag_template_for_sheet()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -76,12 +76,35 @@ class EntryRelationshipMapperTest(unittest.TestCase):
             'fake_entries/test_stream',
             app_tag.fields['stream_entry'].string_value)
 
+    def test_fulfill_tag_fields_should_resolve_dimension_app_mapping(self):
+        app_id = 'test_app'
+        app_entry = self.__make_fake_entry(app_id, 'app')
+        app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
+
+        dimension_id = 'test_dimension'
+        dimension_entry = self.__make_fake_entry(dimension_id, 'dimension')
+        string_fields = ('id', dimension_id), ('app_id', app_id)
+        dimension_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        app_assembled_entry = commons_prepare.AssembledEntryData(
+            app_id, app_entry, [app_tag])
+        sheet_assembled_entry = commons_prepare.AssembledEntryData(
+            dimension_id, dimension_entry, [dimension_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [app_assembled_entry, sheet_assembled_entry])
+
+        self.assertEqual(
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_app',
+            dimension_tag.fields['app_entry'].string_value)
+
     def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
         app_id = 'test_app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
 
-        sheet_id = 'test_app'
+        sheet_id = 'test_sheet'
         sheet_entry = self.__make_fake_entry(sheet_id, 'sheet')
         string_fields = ('id', sheet_id), ('app_id', app_id)
         sheet_tag = self.__make_fake_tag(string_fields=string_fields)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -205,6 +205,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         scraper.scrape_all_apps.return_value = \
             [self.__make_fake_published_app()]
         scraper.scrape_sheets.return_value = []
+        scraper.scrape_dimensions.return_value = []
 
         self.__synchronizer.run()
 
@@ -218,6 +219,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                     'id': 'test_stream'
                 },
                 'sheets': [],
+                'dimensions': [],
             }]
         }
 
@@ -267,6 +269,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         scraper.scrape_sheets.return_value = [
             self.__make_fake_published_sheet()
         ]
+        scraper.scrape_dimensions.return_value = []
 
         self.__synchronizer.run()
 
@@ -274,10 +277,8 @@ class MetadataSynchronizerTest(unittest.TestCase):
             'id':
                 'test_stream',
             'apps': [{
-                'id':
-                    'test_app',
-                'published':
-                    True,
+                'id': 'test_app',
+                'published': True,
                 'stream': {
                     'id': 'test_stream'
                 },
@@ -293,6 +294,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                         'name': None
                     },
                 }],
+                'dimensions': [],
             }]
         }
 
@@ -313,6 +315,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
         scraper.scrape_all_apps.return_value = \
             [self.__make_fake_published_app()]
         scraper.scrape_sheets.return_value = [self.__make_fake_wip_sheet()]
+        scraper.scrape_dimensions.return_value = []
 
         self.__synchronizer.run()
 
@@ -326,6 +329,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                     'id': 'test_stream'
                 },
                 'sheets': [],
+                'dimensions': [],
             }]
         }
 

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -96,6 +96,9 @@ def __delete_tag_templates(project_id, location_id):
             'qlik_custom_property_definition_metadata'))
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_dimension_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'qlik_sheet_metadata'))
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(


### PR DESCRIPTION
**- What I did**
Added support for ingesting Dimensions metadata.

**- How I did it**
1. Added Dimension-related methods to the Qlik connector's Entry, Tag Template, and Tag factories.
2. Added Dimension-related code to the Qlik connector's metadata synchronizer.
3. Added unit tests to fully cover the above changes.
4. Updated the cleanup script in order to delete the Tag Template identified by `qlik_dimension_metadata`.
5. Added `Master Items: Dimension` to the assets list in the `README.md` file.

**- How to verify it**
Run the unit tests and, preferably, the connector in an integrated environment.

**- Description for the changelog**
Added support for ingesting Dimensions metadata.
