### PR TITLE
Add support for scraping Measures metadata

### DIFF
--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
-        'google-datacatalog-connectors-commons ~= 0.6.5',
+        'google-datacatalog-connectors-commons ~= 0.6.6',
         'jmespath ~= 0.10.0',
         'requests_ntlm ~= 1.1.0',
         'websockets ~= 8.1',

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import logging
+
+from google.datacatalog_connectors.qlik.scrape import \
+    base_engine_api_helper, websocket_responses_manager
+
+
+class EngineAPIMeasuresHelper(base_engine_api_helper.BaseEngineAPIHelper):
+    # Keys used to identify the handles.
+    __DOC_HANDLE = 'doc-handle'
+
+    # Methods to be used in the requests.
+    __GET_MEASURE = 'GetMeasure'
+    __GET_PROPERTIES = 'GetProperties'
+
+    def get_measures(self, app_id, timeout=60):
+        try:
+            return self._run_until_complete(
+                self.__get_measures(app_id, timeout))
+        except Exception:
+            logging.warning("error on get_measure:", exc_info=True)
+            return []
+
+    async def __get_measures(self, app_id, timeout):
+        async with self._connect_websocket(app_id) as websocket:
+            responses_manager = \
+                websocket_responses_manager.WebsocketResponsesManager()
+
+            await self._start_websocket_communication(websocket, app_id,
+                                                      responses_manager)
+
+            consumer = self.__consume_get_measures_msg
+            producer = self.__produce_get_measures_msg
+            return await asyncio.wait_for(
+                self._handle_websocket_communication(
+                    consumer(websocket, responses_manager),
+                    producer(websocket, responses_manager)), timeout)
+
+    async def __consume_get_measures_msg(self, websocket, responses_manager):
+        return await self._consume_messages(websocket, responses_manager,
+                                            self.__GET_PROPERTIES,
+                                            'result.qProp')
+
+    async def __produce_get_measures_msg(self, websocket, responses_manager):
+        return await self._produce_messages(
+            websocket, responses_manager,
+            self.__send_follow_up_msg_get_measures)
+
+    async def __send_follow_up_msg_get_measures(self, websocket,
+                                                responses_manager, response):
+
+        response_id = response.get('id')
+        if responses_manager.is_method(response_id, self._OPEN_DOC):
+            await self.__handle_open_doc_response(websocket, responses_manager,
+                                                  response)
+            responses_manager.remove_unhandled(response)
+        elif responses_manager.is_method(response_id, self._GET_ALL_INFOS):
+            await self.__handle_get_all_infos_response(websocket,
+                                                       responses_manager,
+                                                       response)
+            responses_manager.remove_unhandled(response)
+        elif responses_manager.is_method(response_id, self.__GET_MEASURE):
+            await self.__handle_get_measure_response(websocket,
+                                                     responses_manager,
+                                                     response)
+            responses_manager.remove_unhandled(response)
+
+    async def __handle_open_doc_response(self, websocket, responses_manager,
+                                         response):
+
+        doc_handle = response.get('result').get('qReturn').get('qHandle')
+        responses_manager.set_handle(doc_handle, self.__DOC_HANDLE)
+        follow_up_req_id = await self._send_get_all_infos_request(
+            websocket, doc_handle)
+        responses_manager.add_pending_id(follow_up_req_id, self._GET_ALL_INFOS)
+
+    async def __handle_get_all_infos_response(self, websocket,
+                                              responses_manager, response):
+
+        all_infos = response.get('result').get('qInfos')
+        doc_handle = responses_manager.get_handle(self.__DOC_HANDLE)
+        measure_ids = [
+            info.get('qId')
+            for info in all_infos
+            if 'measure' == info.get('qType')
+        ]
+        follow_up_req_ids = await asyncio.gather(*[
+            self.__send_get_measure_request(websocket, doc_handle, measure_id)
+            for measure_id in measure_ids
+        ])
+        responses_manager.add_pending_ids(follow_up_req_ids,
+                                          self.__GET_MEASURE)
+
+    async def __handle_get_measure_response(self, websocket, responses_manager,
+                                            response):
+
+        measure_handle = response.get('result').get('qReturn').get('qHandle')
+        follow_up_req_id = await self.__send_get_properties_request(
+            websocket, measure_handle)
+        responses_manager.add_pending_id(follow_up_req_id,
+                                         self.__GET_PROPERTIES)
+
+    async def __send_get_measure_request(self, websocket, doc_handle,
+                                         measure_id):
+        """Sends a Get Measure Interface request.
+
+        Returns:
+            The request id.
+        """
+        request_id = self._generate_request_id()
+        await websocket.send(
+            json.dumps({
+                'handle': doc_handle,
+                'method': self.__GET_MEASURE,
+                'params': {
+                    'qId': measure_id,
+                },
+                'id': request_id,
+            }))
+
+        logging.debug('Get Measure Interface request sent: %d', request_id)
+        return request_id
+
+    async def __send_get_properties_request(self, websocket, measure_handle):
+        """Sends a Get Measure Properties request.
+
+        Returns:
+            The request id.
+        """
+        request_id = self._generate_request_id()
+        await websocket.send(
+            json.dumps({
+                'handle': measure_handle,
+                'method': self.__GET_PROPERTIES,
+                'params': {},
+                'id': request_id,
+            }))
+
+        logging.debug('Get Measure Properties request sent: %d', request_id)
+        return request_id

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_scraper.py
@@ -23,7 +23,7 @@ import websockets
 
 from google.datacatalog_connectors.qlik.scrape import \
     authenticator, constants, engine_api_dimensions_helper, \
-    engine_api_sheets_helper
+    engine_api_measures_helper, engine_api_sheets_helper
 
 
 class EngineAPIScraper:
@@ -64,7 +64,7 @@ class EngineAPIScraper:
         self.__auth_cookie = None
 
     def get_dimensions(self, app_id):
-        """Get the Dimensions (Master Items) set up to a given App.
+        """Gets the Dimensions (Master Items) set up to a given App.
 
         Returns:
             A list of [GenericDimensionProperties](https://help.qlik.com/en-US/sense-developer/September2020/APIs/EngineAPI/definitions-GenericDimensionProperties.html).  # noqa E501
@@ -72,6 +72,16 @@ class EngineAPIScraper:
         self.__set_up_auth_cookie()
         return engine_api_dimensions_helper.EngineAPIDimensionsHelper(
             self.__server_address, self.__auth_cookie).get_dimensions(app_id)
+
+    def get_measures(self, app_id):
+        """Gets the Measures (Master Items) set up to a given App.
+
+        Returns:
+            A list of [GenericMeasureProperties](https://help.qlik.com/en-US/sense-developer/September2020/APIs/EngineAPI/definitions-GenericMeasureProperties.html).  # noqa E501
+        """
+        self.__set_up_auth_cookie()
+        return engine_api_measures_helper.EngineAPIMeasuresHelper(
+            self.__server_address, self.__auth_cookie).get_measures(app_id)
 
     def get_sheets(self, app_id):
         """Gets the Sheets that belong to the given App.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -83,6 +83,21 @@ class MetadataScraper:
 
         return dimensions
 
+    def scrape_measures(self, app_metadata):
+        self.__log_scrape_start(
+            'Scraping Measures (Master Items) from the'
+            ' "%s" App...', app_metadata.get('name'))
+        measures = self.__engine_api_scraper.get_measures(
+            app_metadata.get('id')) or []
+
+        logging.info('  %s Measures found:', len(measures))
+        for measure in measures:
+            q_meta_def = measure.get('qMetaDef')
+            logging.info('    - %s [%s]', q_meta_def.get('title'),
+                         measure.get('qInfo').get('qId'))
+
+        return measures
+
     def scrape_sheets(self, app_metadata):
         self.__log_scrape_start('Scraping Sheets from the "%s" App...',
                                 app_metadata.get('name'))

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper_test.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.qlik.scrape import \
+    engine_api_measures_helper
+
+from . import scrape_ops_mocks
+
+
+class EngineAPIMeasuresHelperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
+    __BASE_CLASS = f'{__SCRAPE_PACKAGE}.base_engine_api_helper' \
+                   f'.BaseEngineAPIHelper'
+    __HELPER_CLASS = f'{__SCRAPE_PACKAGE}.engine_api_measures_helper' \
+                     f'.EngineAPIMeasuresHelper'
+
+    def setUp(self):
+        self.__helper = engine_api_measures_helper.EngineAPIMeasuresHelper(
+            server_address='https://test-server', auth_cookie=mock.MagicMock())
+
+    @mock.patch(f'{__HELPER_CLASS}._EngineAPIMeasuresHelper__get_measures',
+                lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_measures_should_return_empty_list_on_exception(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = Exception
+        measures = self.__helper.get_measures('app-id')
+        self.assertEqual(0, len(measures))
+
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with Measures. Maybe it's
+    # worth refactoring it in the future to mock that method, and the private
+    # async ones from EngineAPIMeasuresHelper as well, thus testing in a more
+    # granular way.
+    @mock.patch(f'{__BASE_CLASS}._generate_request_id')
+    @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
+    @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
+    @mock.patch(f'{__BASE_CLASS}._connect_websocket',
+                new_callable=scrape_ops_mocks.AsyncContextManager)
+    def test_get_measures_should_return_list_on_success(
+            self, mock_websocket, mock_send_open_doc, mock_send_get_all_infos,
+            mock_generate_request_id):
+
+        mock_send_open_doc.return_value = asyncio.sleep(delay=0, result=1)
+        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0, result=2)
+        mock_generate_request_id.side_effect = [3, 4]
+
+        websocket_ctx = mock_websocket.return_value.__enter__.return_value
+        websocket_ctx.set_itr_break(0.25)
+        websocket_ctx.set_data([
+            {
+                'id': 1,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1,
+                    },
+                },
+            },
+            {
+                'id': 2,
+                'result': {
+                    'qInfos': [{
+                        'qId': 'measure-id',
+                        'qType': 'measure'
+                    }],
+                },
+            },
+            {
+                'id': 3,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 2,
+                    },
+                },
+            },
+            {
+                'id': 4,
+                'result': {
+                    'qProp': [{
+                        'qInfo': {
+                            'qId': 'measure-id',
+                        },
+                    }],
+                },
+            },
+        ])
+
+        measures = self.__helper.get_measures('app-id')
+
+        self.assertEqual(1, len(measures))
+        self.assertEqual('measure-id', measures[0].get('qInfo').get('qId'))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()
+
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with no Measures. Maybe
+    # it's worth refactoring it in the future to mock that method, and the
+    # private async ones from EngineAPIMeasuresHelper as well, thus testing
+    # in a more granular way.
+    @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
+    @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
+    @mock.patch(f'{__BASE_CLASS}._connect_websocket',
+                new_callable=scrape_ops_mocks.AsyncContextManager)
+    def test_get_measures_should_return_empty_list_on_none_available(
+            self, mock_websocket, mock_send_open_doc, mock_send_get_all_infos):
+
+        mock_send_open_doc.return_value = asyncio.sleep(delay=0, result=1)
+        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0, result=2)
+
+        websocket_ctx = mock_websocket.return_value.__enter__.return_value
+        websocket_ctx.set_itr_break(0.25)
+        websocket_ctx.set_data([
+            {
+                'id': 1,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1,
+                    },
+                },
+            },
+            {
+                'id': 2,
+                'result': {
+                    'qInfos': [],
+                },
+            },
+        ])
+
+        measures = self.__helper.get_measures('app-id')
+
+        self.assertEqual(0, len(measures))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
@@ -65,6 +65,13 @@ class EngineAPIScraperTest(unittest.TestCase):
         mock_set_up_cookie.assert_called_once()
 
     @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
+    def test_get_measures_should_authenticate_user_beforehand(
+            self, mock_set_up_cookie):
+
+        self.__scraper.get_measures('app-id')
+        mock_set_up_cookie.assert_called_once()
+
+    @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
     def test_get_sheets_should_authenticate_user_beforehand(
             self, mock_set_up_cookie):
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -126,6 +126,40 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(0, len(dimensions))
         engine_api_scraper.get_dimensions.assert_called_once()
 
+    def test_scrape_measures_should_return_list_on_success(self):
+        attrs = self.__scraper.__dict__
+        engine_api_scraper = attrs['_MetadataScraper__engine_api_scraper']
+
+        measures_metadata = [
+            {
+                'qInfo': {
+                    'qId': 'measure-id',
+                },
+                'qMetaDef': {},
+            },
+        ]
+
+        engine_api_scraper.get_measures.return_value = measures_metadata
+
+        measures = self.__scraper.scrape_measures({'id': 'app-id'})
+
+        self.assertEqual(1, len(measures))
+        self.assertEqual('measure-id', measures[0].get('qInfo').get('qId'))
+        engine_api_scraper.get_measures.assert_called_once()
+
+    def test_scrape_measures_should_return_empty_list_on_no_server_response(
+            self):
+
+        attrs = self.__scraper.__dict__
+        engine_api_scraper = attrs['_MetadataScraper__engine_api_scraper']
+
+        engine_api_scraper.get_measures.return_value = None
+
+        measures = self.__scraper.scrape_measures({'id': 'app-id'})
+
+        self.assertEqual(0, len(measures))
+        engine_api_scraper.get_measures.assert_called_once()
+
     def test_scrape_sheets_should_return_list_on_success(self):
         attrs = self.__scraper.__dict__
         engine_api_scraper = attrs['_MetadataScraper__engine_api_scraper']


### PR DESCRIPTION
**- What I did**
Added support for scraping Measures metadata.

**- How I did it**
1. Added the `EngineAPIMeasuresHelper` class, which is very similar to `EngineAPIDimensionsHelper`.
2. Added the `get_measures()` method to the `EngineAPIScraper`.
3. Added the `scrape_measures()` methods to the `MetadataScraper`.
4. Added unit tests to cover all the changes listed above.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added support for scraping Measures metadata.
