### PR TITLE
Add support for ingesting Measures metadata

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -6,6 +6,7 @@ currently supporting below asset types:
 - Stream
 - App (only the published ones)
 - Master Items: Dimension  
+- Master Items: Measure  
 - Sheet (only the published ones)
 
 **Disclaimer: This is not an officially supported Google product.**

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,6 +105,10 @@ class AssembledEntryFactory:
                     app_metadata.get('dimensions'), tag_templates_dict))
 
             assembled_entries.extend(
+                self.__make_assembled_entries_for_measures(
+                    app_metadata.get('measures'), tag_templates_dict))
+
+            assembled_entries.extend(
                 self.__make_assembled_entries_for_sheets(
                     app_metadata.get('sheets'), tag_templates_dict))
 
@@ -153,6 +157,33 @@ class AssembledEntryFactory:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_dimension(
                     tag_template, dimension_metadata))
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)
+
+    def __make_assembled_entries_for_measures(self, measures_metadata,
+                                              tag_templates_dict):
+
+        return [
+            self.__make_assembled_entry_for_measure(measure_metadata,
+                                                    tag_templates_dict)
+            for measure_metadata in measures_metadata
+        ] if measures_metadata else []
+
+    def __make_assembled_entry_for_measure(self, measure_metadata,
+                                           tag_templates_dict):
+
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_measure(
+                measure_metadata)
+
+        tag_template = tag_templates_dict.get(
+            constants.TAG_TEMPLATE_ID_MEASURE)
+
+        tags = []
+        if tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.make_tag_for_measure(
+                    tag_template, measure_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ ENTRY_ID_MAX_LENGTH = 64
 ENTRY_ID_PART_APP = 'app_'
 ENTRY_ID_PART_CUSTOM_PROPERTY_DEFINITION = 'cpd_'
 ENTRY_ID_PART_DIMENSION = 'dim_'
+ENTRY_ID_PART_MEASURE = 'msr_'
 ENTRY_ID_PART_SHEET = 'sht_'
 ENTRY_ID_PART_STREAM = 'str_'
 # This is the common prefix for all Qlik Entries.
@@ -38,12 +39,15 @@ TAG_TEMPLATE_ID_APP = 'qlik_app_metadata'
 # Custom Property Definition related Entries.
 TAG_TEMPLATE_ID_CUSTOM_PROPERTY_DEFINITION = \
     'qlik_custom_property_definition_metadata'
-# The ID of the Tag Template created to store additional metadata for the
-# Dimension-related Entries.
-TAG_TEMPLATE_ID_DIMENSION = 'qlik_dimension_metadata'
 # Prefix for IDs of the Tag Templates created to tag Entries with their
 # Custom Properties.
 TAG_TEMPLATE_ID_PREFIX_CUSTOM_PROPERTY = 'qlik_cp__'
+# The ID of the Tag Template created to store additional metadata for the
+# Dimension-related Entries.
+TAG_TEMPLATE_ID_DIMENSION = 'qlik_dimension_metadata'
+# The ID of the Tag Template created to store additional metadata for the
+# Measure-related Entries.
+TAG_TEMPLATE_ID_MEASURE = 'qlik_measure_metadata'
 # The ID of the Tag Template created to store additional metadata for the
 # Sheet-related Entries.
 TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'
@@ -57,6 +61,8 @@ USER_SPECIFIED_TYPE_APP = 'app'
 USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION = 'custom_property_definition'
 # The user specified type of the Dimension-related Entries.
 USER_SPECIFIED_TYPE_DIMENSION = 'dimension'
+# The user specified type of the Measure-related Entries.
+USER_SPECIFIED_TYPE_MEASURE = 'measure'
 # The user specified type of the Sheet-related Entries.
 USER_SPECIFIED_TYPE_SHEET = 'sheet'
 # The user specified type of the Stream-related Entries.

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -145,7 +145,37 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         # jump directly to a Dimension 'edit' page in Qlik Sense.
 
         # The create_time and update_time fields are not fulfilled because
-        # there is no such info in the Dimension properties.
+        # there is no such info in the Dimension metadata.
+
+        return generated_id, entry
+
+    def make_entry_for_measure(self, measure_metadata):
+        entry = datacatalog.Entry()
+
+        app_metadata = measure_metadata.get('app')
+
+        # The Measure ID is usually a 7 letters string, so the App ID is
+        # prepended to prevent overlaping.
+        generated_id = self.__format_id(
+            constants.ENTRY_ID_PART_MEASURE, f'{app_metadata.get("id")}'
+            f'_{measure_metadata.get("qInfo").get("qId")}')
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_MEASURE
+
+        q_meta_def = measure_metadata.get('qMetaDef')
+
+        entry.display_name = self._format_display_name(q_meta_def.get('title'))
+        entry.description = q_meta_def.get('description')
+
+        # The linked_resource field is not fulfilled because there is no way to
+        # jump directly to a Measure 'edit' page in Qlik Sense.
+
+        # The create_time and update_time fields are not fulfilled because
+        # there is no such info in the Measure metadata.
 
         return generated_id, entry
 

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -125,7 +125,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         app_metadata = dimension_metadata.get('app')
 
         # The Dimension ID is usually a 7 letters string, so the App ID is
-        # prepended to prevent overlaping.
+        # prepended to prevent overlapping.
         generated_id = self.__format_id(
             constants.ENTRY_ID_PART_DIMENSION, f'{app_metadata.get("id")}'
             f'_{dimension_metadata.get("qInfo").get("qId")}')
@@ -155,7 +155,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         app_metadata = measure_metadata.get('app')
 
         # The Measure ID is usually a 7 letters string, so the App ID is
-        # prepended to prevent overlaping.
+        # prepended to prevent overlapping.
         generated_id = self.__format_id(
             constants.ENTRY_ID_PART_MEASURE, f'{app_metadata.get("id")}'
             f'_{measure_metadata.get("qInfo").get("qId")}')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -211,6 +211,47 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         self._add_primitive_type_field(tag_template, 'field_labels',
                                        self.__STRING_TYPE, 'Field labels')
+
+        self._add_primitive_type_field(tag_template, 'tags',
+                                       self.__STRING_TYPE, 'Qlik Tags')
+
+        self._add_primitive_type_field(tag_template, 'app_id',
+                                       self.__STRING_TYPE, 'App Id')
+
+        self._add_primitive_type_field(tag_template, 'app_name',
+                                       self.__STRING_TYPE, 'App name')
+
+        self._add_primitive_type_field(tag_template, 'app_entry',
+                                       self.__STRING_TYPE,
+                                       'Data Catalog Entry for the App')
+
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
+
+        return tag_template
+
+    def make_tag_template_for_measure(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_MEASURE)
+
+        tag_template.display_name = 'Qlik Measure Metadata'
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_primitive_type_field(tag_template, 'expression',
+                                       self.__STRING_TYPE, 'Expression')
+
+        self._add_primitive_type_field(tag_template, 'label_expression',
+                                       self.__STRING_TYPE, 'Label expression')
+
+        self._add_primitive_type_field(tag_template, 'is_custom_formatted',
+                                       self.__BOOL_TYPE, 'Is custom formatted')
 
         self._add_primitive_type_field(tag_template, 'tags',
                                        self.__STRING_TYPE, 'Qlik Tags')

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     __CUSTOM_PROPERTY_DEFINITION = \
         constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
     __DIMENSION = constants.USER_SPECIFIED_TYPE_DIMENSION
+    __MEASURE = constants.USER_SPECIFIED_TYPE_MEASURE
     __SHEET = constants.USER_SPECIFIED_TYPE_SHEET
     __STREAM = constants.USER_SPECIFIED_TYPE_STREAM
 
@@ -31,6 +32,7 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         resolvers = (
             self.__resolve_app_mappings,
             self.__resolve_dimension_mappings,
+            self.__resolve_measure_mappings,
             self.__resolve_sheet_mappings,
             self.__resolve_stream_mappings,
         )
@@ -58,6 +60,16 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
             if assembled_entry.entry.user_specified_type == cls.__DIMENSION
         ]
         for assembled_entry in dimension_assembled_entries:
+            cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
+                                   'app_entry', id_name_pairs)
+
+    @classmethod
+    def __resolve_measure_mappings(cls, assembled_entries, id_name_pairs):
+        measure_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__MEASURE
+        ]
+        for assembled_entry in measure_assembled_entries:
             cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
                                    'app_entry', id_name_pairs)
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -164,6 +164,37 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('Test dimension', entry.display_name)
         self.assertEqual('Description of the Test dimension',
                          entry.description)
+
+        self.assertEqual('', entry.linked_resource)
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+        self.assertIsNone(entry.source_system_timestamps.update_time)
+
+    def test_make_entry_for_measure_should_set_all_available_fields(self):
+        metadata = {
+            'qInfo': {
+                'qId': 'a123-b456',
+            },
+            'qMetaDef': {
+                'title': 'Test measure',
+                'description': 'Description of the Test measure',
+            },
+            'app': {
+                'id': 'app-id'
+            },
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_measure(metadata)
+
+        self.assertEqual('qlik_msr_app_id_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'qlik_msr_app_id_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('measure', entry.user_specified_type)
+        self.assertEqual('Test measure', entry.display_name)
+        self.assertEqual('Description of the Test measure', entry.description)
 
         self.assertEqual('', entry.linked_resource)
         self.assertIsNone(entry.source_system_timestamps.create_time)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -315,6 +315,47 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('FIELD_1, FIELD_2', tag.fields['fields'].string_value)
         self.assertEqual('Field 1, Field 2',
                          tag.fields['field_labels'].string_value)
+        self.assertEqual('tag 1, tag 2', tag.fields['tags'].string_value)
+
+        self.assertEqual('a123-b456', tag.fields['app_id'].string_value)
+        self.assertEqual('Test app', tag.fields['app_name'].string_value)
+
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)
+
+    def test_make_tag_for_measure_should_set_all_available_fields(self):
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_measure()
+
+        metadata = {
+            'qInfo': {
+                'qId': 'c987-d654',
+            },
+            'qMeasure': {
+                'qDef': 'Sum(TEST_FIELD)',
+                'qLabelExpression': 'Test label',
+                'isCustomFormatted': True,
+            },
+            'qMetaDef': {
+                'tags': [
+                    'tag 1',
+                    'tag 2',
+                ],
+            },
+            'app': {
+                'id': 'a123-b456',
+                'name': 'Test app',
+            },
+        }
+
+        tag = self.__factory.make_tag_for_measure(tag_template, metadata)
+
+        self.assertEqual('c987-d654', tag.fields['id'].string_value)
+
+        self.assertEqual('Sum(TEST_FIELD)',
+                         tag.fields['expression'].string_value)
+        self.assertEqual('Test label',
+                         tag.fields['label_expression'].string_value)
         self.assertEqual('tag 1, tag 2', tag.fields['tags'].string_value)
 
         self.assertEqual('a123-b456', tag.fields['app_id'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,16 +88,39 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         app_assembled_entry = commons_prepare.AssembledEntryData(
             app_id, app_entry, [app_tag])
-        sheet_assembled_entry = commons_prepare.AssembledEntryData(
+        dimension_assembled_entry = commons_prepare.AssembledEntryData(
             dimension_id, dimension_entry, [dimension_tag])
 
         prepare.EntryRelationshipMapper().fulfill_tag_fields(
-            [app_assembled_entry, sheet_assembled_entry])
+            [app_assembled_entry, dimension_assembled_entry])
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
             'fake_entries/test_app',
             dimension_tag.fields['app_entry'].string_value)
+
+    def test_fulfill_tag_fields_should_resolve_measure_app_mapping(self):
+        app_id = 'test_app'
+        app_entry = self.__make_fake_entry(app_id, 'app')
+        app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
+
+        measure_id = 'test_measure'
+        measure_entry = self.__make_fake_entry(measure_id, 'measure')
+        string_fields = ('id', measure_id), ('app_id', app_id)
+        measure_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        app_assembled_entry = commons_prepare.AssembledEntryData(
+            app_id, app_entry, [app_tag])
+        measure_assembled_entry = commons_prepare.AssembledEntryData(
+            measure_id, measure_entry, [measure_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [app_assembled_entry, measure_assembled_entry])
+
+        self.assertEqual(
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test_app',
+            measure_tag.fields['app_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
         app_id = 'test_app'

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,6 +97,9 @@ def __delete_tag_templates(project_id, location_id):
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'qlik_dimension_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_measure_metadata'))
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'qlik_sheet_metadata'))


### PR DESCRIPTION
**- What I did**
Added support for ingesting Measures metadata.

**- How I did it**
1. Added Measure-related methods to the Qlik connector's Entry, Tag Template, and Tag factories.
2. Added Measure-related code to the Qlik connector's metadata synchronizer.
3. Added unit tests to fully cover the above changes.
4. Updated the cleanup script in order to delete the Tag Template identified by `qlik_measure_metadata`.
5. Added `Master Items: Measure` to the assets list in the `README.md` file.

**- How to verify it**
Run the unit tests and, preferably, the connector in an integrated environment.

**- Description for the changelog**
Added support for ingesting Measures metadata.