### PR TITLE
Add support for scraping Visualizations metadata

### DIFF
--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     },
     include_package_data=True,
     install_requires=(
-        'google-datacatalog-connectors-commons ~= 0.6.6',
+        'google-datacatalog-connectors-commons ~= 0.6.7',
         'jmespath ~= 0.10.0',
         'requests_ntlm ~= 1.1.0',
         'websockets ~= 8.1',

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_scraper.py
@@ -23,7 +23,8 @@ import websockets
 
 from google.datacatalog_connectors.qlik.scrape import \
     authenticator, constants, engine_api_dimensions_helper, \
-    engine_api_measures_helper, engine_api_sheets_helper
+    engine_api_measures_helper, engine_api_sheets_helper, \
+    engine_api_visualizations_helper
 
 
 class EngineAPIScraper:
@@ -92,6 +93,17 @@ class EngineAPIScraper:
         self.__set_up_auth_cookie()
         return engine_api_sheets_helper.EngineAPISheetsHelper(
             self.__server_address, self.__auth_cookie).get_sheets(app_id)
+
+    def get_visualizations(self, app_id):
+        """Gets the Visualizations (Master Items) set up to a given App.
+
+        Returns:
+            A list of [GenericObjectProperties](https://help.qlik.com/en-US/sense-developer/September2020/APIs/EngineAPI/definitions-GenericObjectProperties.html).  # noqa E501
+        """
+        self.__set_up_auth_cookie()
+        return engine_api_visualizations_helper.EngineAPIVisualizationsHelper(
+            self.__server_address,
+            self.__auth_cookie).get_visualizations(app_id)
 
     def __set_up_auth_cookie(self):
         if self.__auth_cookie:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import logging
+
+from google.datacatalog_connectors.qlik.scrape import \
+    base_engine_api_helper as base_helper, websocket_responses_manager
+
+
+class EngineAPIVisualizationsHelper(base_helper.BaseEngineAPIHelper):
+    # Keys used to identify the handles.
+    __DOC_HANDLE = 'doc-handle'
+
+    # Methods to be used in the requests.
+    __GET_OBJECT = 'GetObject'
+    __GET_PROPERTIES = 'GetProperties'
+
+    def get_visualizations(self, app_id, timeout=60):
+        try:
+            return self._run_until_complete(
+                self.__get_visualizations(app_id, timeout))
+        except Exception:
+            logging.warning("error on get_visualizations:", exc_info=True)
+            return []
+
+    async def __get_visualizations(self, app_id, timeout):
+        async with self._connect_websocket(app_id) as websocket:
+            responses_manager = \
+                websocket_responses_manager.WebsocketResponsesManager()
+
+            await self._start_websocket_communication(websocket, app_id,
+                                                      responses_manager)
+
+            consumer = self.__consume_get_visualizations_msg
+            producer = self.__produce_get_visualizations_msg
+            return await asyncio.wait_for(
+                self._handle_websocket_communication(
+                    consumer(websocket, responses_manager),
+                    producer(websocket, responses_manager)), timeout)
+
+    async def __consume_get_visualizations_msg(self, websocket,
+                                               responses_manager):
+        return await self._consume_messages(websocket, responses_manager,
+                                            self.__GET_PROPERTIES,
+                                            'result.qProp')
+
+    async def __produce_get_visualizations_msg(self, websocket,
+                                               responses_manager):
+        return await self._produce_messages(
+            websocket, responses_manager,
+            self.__send_follow_up_msg_get_visualizations)
+
+    async def __send_follow_up_msg_get_visualizations(self, websocket,
+                                                      responses_manager,
+                                                      response):
+
+        response_id = response.get('id')
+        if responses_manager.is_method(response_id, self._OPEN_DOC):
+            await self.__handle_open_doc_response(websocket, responses_manager,
+                                                  response)
+            responses_manager.remove_unhandled(response)
+        elif responses_manager.is_method(response_id, self._GET_ALL_INFOS):
+            await self.__handle_get_all_infos_response(websocket,
+                                                       responses_manager,
+                                                       response)
+            responses_manager.remove_unhandled(response)
+        elif responses_manager.is_method(response_id, self.__GET_OBJECT):
+            await self.__handle_get_object_response(websocket,
+                                                    responses_manager,
+                                                    response)
+            responses_manager.remove_unhandled(response)
+
+    async def __handle_open_doc_response(self, websocket, responses_manager,
+                                         response):
+
+        doc_handle = response.get('result').get('qReturn').get('qHandle')
+        responses_manager.set_handle(doc_handle, self.__DOC_HANDLE)
+        follow_up_req_id = await self._send_get_all_infos_request(
+            websocket, doc_handle)
+        responses_manager.add_pending_id(follow_up_req_id, self._GET_ALL_INFOS)
+
+    async def __handle_get_all_infos_response(self, websocket,
+                                              responses_manager, response):
+
+        all_infos = response.get('result').get('qInfos')
+        doc_handle = responses_manager.get_handle(self.__DOC_HANDLE)
+        master_obj_ids = [
+            info.get('qId')
+            for info in all_infos
+            if 'masterobject' == info.get('qType')
+        ]
+        follow_up_req_ids = await asyncio.gather(*[
+            self.__send_get_object_request(websocket, doc_handle,
+                                           master_obj_id)
+            for master_obj_id in master_obj_ids
+        ])
+        responses_manager.add_pending_ids(follow_up_req_ids, self.__GET_OBJECT)
+
+    async def __handle_get_object_response(self, websocket, responses_manager,
+                                           response):
+
+        object_handle = response.get('result').get('qReturn').get('qHandle')
+        follow_up_req_id = await self.__send_get_properties_request(
+            websocket, object_handle)
+        responses_manager.add_pending_id(follow_up_req_id,
+                                         self.__GET_PROPERTIES)
+
+    async def __send_get_object_request(self, websocket, doc_handle,
+                                        object_id):
+        """Sends a Get Object Interface request.
+
+        Returns:
+            The request id.
+        """
+        request_id = self._generate_request_id()
+        await websocket.send(
+            json.dumps({
+                'handle': doc_handle,
+                'method': self.__GET_OBJECT,
+                'params': {
+                    'qId': object_id,
+                },
+                'id': request_id,
+            }))
+
+        logging.debug('Get Object Interface request sent: %d', request_id)
+        return request_id
+
+    async def __send_get_properties_request(self, websocket, object_handle):
+        """Sends a Get Object Properties request.
+
+        Returns:
+            The request id.
+        """
+        request_id = self._generate_request_id()
+        await websocket.send(
+            json.dumps({
+                'handle': object_handle,
+                'method': self.__GET_PROPERTIES,
+                'params': {},
+                'id': request_id,
+            }))
+
+        logging.debug('Get Object Properties request sent: %d', request_id)
+        return request_id

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/metadata_scraper.py
@@ -114,6 +114,21 @@ class MetadataScraper:
 
         return sheets
 
+    def scrape_visualizations(self, app_metadata):
+        self.__log_scrape_start(
+            'Scraping Visualizations (Master Items) from the'
+            ' "%s" App...', app_metadata.get('name'))
+        visualizations = self.__engine_api_scraper.get_visualizations(
+            app_metadata.get('id')) or []
+
+        logging.info('  %s Visualizations found:', len(visualizations))
+        for visualization in visualizations:
+            q_meta_def = visualization.get('qMetaDef')
+            logging.info('    - %s [%s]', q_meta_def.get('title'),
+                         visualization.get('qInfo').get('qId'))
+
+        return visualizations
+
     @classmethod
     def __log_scrape_start(cls, message, *args):
         logging.info('')

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
@@ -78,6 +78,13 @@ class EngineAPIScraperTest(unittest.TestCase):
         self.__scraper.get_sheets('app-id')
         mock_set_up_cookie.assert_called_once()
 
+    @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
+    def test_get_visualizations_should_authenticate_user_beforehand(
+            self, mock_set_up_cookie):
+
+        self.__scraper.get_visualizations('app-id')
+        mock_set_up_cookie.assert_called_once()
+
     @mock.patch(f'{_SCRAPER_MODULE}.authenticator.Authenticator'
                 f'.get_qps_session_cookie_windows_auth')
     @mock.patch(f'{__SCRAPER_CLASS}'

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper_test.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.qlik.scrape import \
+    engine_api_visualizations_helper
+
+from . import scrape_ops_mocks
+
+
+class EngineAPIVisualizationsHelperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
+    __BASE_CLASS = f'{__SCRAPE_PACKAGE}.base_engine_api_helper' \
+                   f'.BaseEngineAPIHelper'
+    __HELPER_CLASS = f'{__SCRAPE_PACKAGE}.engine_api_visualizations_helper' \
+                     f'.EngineAPIVisualizationsHelper'
+
+    def setUp(self):
+        self.__helper = \
+            engine_api_visualizations_helper.EngineAPIVisualizationsHelper(
+                server_address='https://test-server',
+                auth_cookie=mock.MagicMock())
+
+    @mock.patch(
+        f'{__HELPER_CLASS}._EngineAPIVisualizationsHelper__get_visualizations',
+        lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_visualizations_should_return_empty_list_on_exception(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = Exception
+        visualizations = self.__helper.get_visualizations('app-id')
+        self.assertEqual(0, len(visualizations))
+
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with Visualizations. Maybe
+    # it's worth refactoring it in the future to mock that method, and the
+    # private async ones from EngineAPIVisualizationsHelper as well, thus
+    # testing in a more granular way.
+    @mock.patch(f'{__BASE_CLASS}._generate_request_id')
+    @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
+    @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
+    @mock.patch(f'{__BASE_CLASS}._connect_websocket',
+                new_callable=scrape_ops_mocks.AsyncContextManager)
+    def test_get_visualizations_should_return_list_on_success(
+            self, mock_websocket, mock_send_open_doc, mock_send_get_all_infos,
+            mock_generate_request_id):
+
+        mock_send_open_doc.return_value = asyncio.sleep(delay=0, result=1)
+        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0, result=2)
+        mock_generate_request_id.side_effect = [3, 4]
+
+        websocket_ctx = mock_websocket.return_value.__enter__.return_value
+        websocket_ctx.set_itr_break(0.25)
+        websocket_ctx.set_data([
+            {
+                'id': 1,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1,
+                    },
+                },
+            },
+            {
+                'id': 2,
+                'result': {
+                    'qInfos': [{
+                        'qId': 'visualization-id',
+                        'qType': 'masterobject'
+                    }],
+                },
+            },
+            {
+                'id': 3,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 2,
+                    },
+                },
+            },
+            {
+                'id': 4,
+                'result': {
+                    'qProp': [{
+                        'qInfo': {
+                            'qId': 'visualization-id',
+                        },
+                    }],
+                },
+            },
+        ])
+
+        visualizations = self.__helper.get_visualizations('app-id')
+
+        self.assertEqual(1, len(visualizations))
+        self.assertEqual('visualization-id',
+                         visualizations[0].get('qInfo').get('qId'))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()
+
+    # BaseEngineAPIHelper._handle_websocket_communication is purposefully not
+    # mocked in this test case in order to simulate a full produce/consume
+    # scenario with responses that represent an App with no Visualizations.
+    # Maybe it's worth refactoring it in the future to mock that method, and
+    # the private async ones from EngineAPIVisualizationsHelper as well, thus
+    # testing in a more granular way.
+    @mock.patch(f'{__BASE_CLASS}._send_get_all_infos_request')
+    @mock.patch(f'{__BASE_CLASS}._BaseEngineAPIHelper__send_open_doc_request')
+    @mock.patch(f'{__BASE_CLASS}._connect_websocket',
+                new_callable=scrape_ops_mocks.AsyncContextManager)
+    def test_get_visualizations_should_return_empty_list_on_none_available(
+            self, mock_websocket, mock_send_open_doc, mock_send_get_all_infos):
+
+        mock_send_open_doc.return_value = asyncio.sleep(delay=0, result=1)
+        mock_send_get_all_infos.return_value = asyncio.sleep(delay=0, result=2)
+
+        websocket_ctx = mock_websocket.return_value.__enter__.return_value
+        websocket_ctx.set_itr_break(0.25)
+        websocket_ctx.set_data([
+            {
+                'id': 1,
+                'result': {
+                    'qReturn': {
+                        'qHandle': 1,
+                    },
+                },
+            },
+            {
+                'id': 2,
+                'result': {
+                    'qInfos': [],
+                },
+            },
+        ])
+
+        visualizations = self.__helper.get_visualizations('app-id')
+
+        self.assertEqual(0, len(visualizations))
+        mock_send_open_doc.assert_called_once()
+        mock_send_get_all_infos.assert_called_once()

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/metadata_scraper_test.py
@@ -193,3 +193,39 @@ class MetadataScraperTest(unittest.TestCase):
 
         self.assertEqual(0, len(sheets))
         engine_api_scraper.get_sheets.assert_called_once()
+
+    def test_scrape_visualizations_should_return_list_on_success(self):
+        attrs = self.__scraper.__dict__
+        engine_api_scraper = attrs['_MetadataScraper__engine_api_scraper']
+
+        visualizations_metadata = [
+            {
+                'qInfo': {
+                    'qId': 'visualization-id',
+                },
+                'qMetaDef': {},
+            },
+        ]
+
+        engine_api_scraper.get_visualizations.return_value = \
+            visualizations_metadata
+
+        visualizations = self.__scraper.scrape_visualizations({'id': 'app-id'})
+
+        self.assertEqual(1, len(visualizations))
+        self.assertEqual('visualization-id',
+                         visualizations[0].get('qInfo').get('qId'))
+        engine_api_scraper.get_visualizations.assert_called_once()
+
+    def test_scrape_visualizations_should_return_empty_list_on_no_server_response(  # noqa E510
+            self):
+
+        attrs = self.__scraper.__dict__
+        engine_api_scraper = attrs['_MetadataScraper__engine_api_scraper']
+
+        engine_api_scraper.get_visualizations.return_value = None
+
+        visualizations = self.__scraper.scrape_visualizations({'id': 'app-id'})
+
+        self.assertEqual(0, len(visualizations))
+        engine_api_scraper.get_visualizations.assert_called_once()


### PR DESCRIPTION
**- What I did**
Added support for scraping Visualizations (Master Items) metadata.

**- How I did it**
1. Added the `EngineAPIVisualizationsHelper` class, which is very similar to `EngineAPIDimensionsHelper`.
2. Added the `get_visualizations()` method to the `EngineAPIScraper`.
3. Added the `scrape_visualizations()` method to the `MetadataScraper`.
4. Added unit tests to cover all the changes listed above.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added support for scraping Visualizations (Master Items) metadata.