### PR TITLE
Add support for ingesting Visualizations metadata

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -6,13 +6,11 @@ currently supporting below asset types:
 - Stream
 - App (only the published ones)
 - Master Items: Dimension  
-- Master Items: Measure  
+- Master Items: Measure
+- Master Items: Visualization
 - Sheet (only the published ones)
 
 **Disclaimer: This is not an officially supported Google product.**
-
-> **WORK IN PROGRESS**: This connector is under active development and breaking
-> changes are expected in the coming weeks!
 
 <!--
   ⚠️ DO NOT UPDATE THE TABLE OF CONTENTS MANUALLY ️️⚠️

--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -16,7 +16,7 @@
 
 import setuptools
 
-release_status = 'Development Status :: 3 - Alpha'
+release_status = 'Development Status :: 4 - Beta'
 
 with open('README.md') as readme_file:
     readme = readme_file.read()

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory.py
@@ -109,6 +109,10 @@ class AssembledEntryFactory:
                     app_metadata.get('measures'), tag_templates_dict))
 
             assembled_entries.extend(
+                self.__make_assembled_entries_for_visualizations(
+                    app_metadata.get('visualizations'), tag_templates_dict))
+
+            assembled_entries.extend(
                 self.__make_assembled_entries_for_sheets(
                     app_metadata.get('sheets'), tag_templates_dict))
 
@@ -210,5 +214,33 @@ class AssembledEntryFactory:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_sheet(
                     tag_template, sheet_metadata))
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)
+
+    def __make_assembled_entries_for_visualizations(self,
+                                                    visualizations_metadata,
+                                                    tag_templates_dict):
+
+        return [
+            self.__make_assembled_entry_for_visualization(
+                visualization_metadata, tag_templates_dict)
+            for visualization_metadata in visualizations_metadata
+        ] if visualizations_metadata else []
+
+    def __make_assembled_entry_for_visualization(self, visualization_metadata,
+                                                 tag_templates_dict):
+
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_visualization(
+                visualization_metadata)
+
+        tag_template = tag_templates_dict.get(
+            constants.TAG_TEMPLATE_ID_VISUALIZATION)
+
+        tags = []
+        if tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.make_tag_for_visualization(
+                    tag_template, visualization_metadata))
 
         return prepare.AssembledEntryData(entry_id, entry, tags)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/constants.py
@@ -24,6 +24,7 @@ ENTRY_ID_PART_DIMENSION = 'dim_'
 ENTRY_ID_PART_MEASURE = 'msr_'
 ENTRY_ID_PART_SHEET = 'sht_'
 ENTRY_ID_PART_STREAM = 'str_'
+ENTRY_ID_PART_VISUALIZATION = 'viz_'
 # This is the common prefix for all Qlik Entries.
 ENTRY_ID_PREFIX = 'qlik_'
 # This constant represents the max length a generated Entry ID can have before
@@ -54,6 +55,9 @@ TAG_TEMPLATE_ID_SHEET = 'qlik_sheet_metadata'
 # The ID of the Tag Template created to store additional metadata for the
 # Stream-related Entries.
 TAG_TEMPLATE_ID_STREAM = 'qlik_stream_metadata'
+# The ID of the Tag Template created to store additional metadata for the
+# Visualization-related Entries.
+TAG_TEMPLATE_ID_VISUALIZATION = 'qlik_visualization_metadata'
 
 # The user specified type of the App-related Entries.
 USER_SPECIFIED_TYPE_APP = 'app'
@@ -67,6 +71,8 @@ USER_SPECIFIED_TYPE_MEASURE = 'measure'
 USER_SPECIFIED_TYPE_SHEET = 'sheet'
 # The user specified type of the Stream-related Entries.
 USER_SPECIFIED_TYPE_STREAM = 'stream'
+# The user specified type of the Visualization-related Entries.
+USER_SPECIFIED_TYPE_VISUALIZATION = 'visualization'
 
 # The value of the Tag Field that represents a 'Drill down' Dimension.
 DIMENSION_GROUPING_DRILL_DOWN_TAG_FIELD = 'Drill down'

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory.py
@@ -253,6 +253,40 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return generated_id, entry
 
+    def make_entry_for_visualization(self, visualization_metadata):
+        entry = datacatalog.Entry()
+
+        viz_id = visualization_metadata.get('qInfo').get('qId')
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_VISUALIZATION,
+                                        viz_id)
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_VISUALIZATION
+
+        q_meta_def = visualization_metadata.get('qMetaDef')
+
+        entry.display_name = self._format_display_name(q_meta_def.get('title'))
+        entry.description = q_meta_def.get('description')
+
+        # The linked_resource field is not fulfilled because Data Catalog
+        # currently does not accept ``?`` and ``=`` in the field value.
+        # The below statements can be uncommented once
+        # https://issuetracker.google.com/issues/176912978
+        # has been fixed.
+        #
+        # app_id = visualization_metadata.get('app').get('id')
+        # entry.linked_resource = f'{self.__site_url}/sense/single' \
+        #                         f'?appid={app_id}' \
+        #                         f'&obj={viz_id}'
+
+        # The create_time and update_time fields are not fulfilled because
+        # there is no such info in the Visualization metadata.
+
+        return generated_id, entry
+
     @classmethod
     def __format_id(cls, source_type_identifier, source_id):
         no_prefix_fmt_id = cls._format_id(

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory.py
@@ -328,6 +328,35 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         return tag
 
+    def make_tag_for_visualization(self, tag_template, visualization_metadata):
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        self._set_string_field(tag, 'id',
+                               visualization_metadata.get('qInfo').get('qId'))
+
+        self._set_string_field(tag, 'title',
+                               visualization_metadata.get('title'))
+        self._set_string_field(tag, 'subtitle',
+                               visualization_metadata.get('subtitle'))
+        self._set_string_field(tag, 'footnote',
+                               visualization_metadata.get('footnote'))
+        self._set_string_field(tag, 'type',
+                               visualization_metadata.get('visualization'))
+
+        q_meta_def = visualization_metadata.get('qMetaDef')
+        self._set_string_field(tag, 'tags', ', '.join(q_meta_def.get('tags')))
+
+        app_metadata = visualization_metadata.get('app')
+        if app_metadata:
+            self._set_string_field(tag, 'app_id', app_metadata.get('id'))
+            self._set_string_field(tag, 'app_name', app_metadata.get('name'))
+
+        self._set_string_field(tag, 'site_url', self.__site_url)
+
+        return tag
+
     @classmethod
     def __get_human_readable_size_value(cls, size_bytes):
         """

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory.py
@@ -213,7 +213,7 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        self.__STRING_TYPE, 'Field labels')
 
         self._add_primitive_type_field(tag_template, 'tags',
-                                       self.__STRING_TYPE, 'Qlik Tags')
+                                       self.__STRING_TYPE, 'Qlik tags')
 
         self._add_primitive_type_field(tag_template, 'app_id',
                                        self.__STRING_TYPE, 'App Id')
@@ -254,7 +254,7 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        self.__BOOL_TYPE, 'Is custom formatted')
 
         self._add_primitive_type_field(tag_template, 'tags',
-                                       self.__STRING_TYPE, 'Qlik Tags')
+                                       self.__STRING_TYPE, 'Qlik tags')
 
         self._add_primitive_type_field(tag_template, 'app_id',
                                        self.__STRING_TYPE, 'App Id')
@@ -344,6 +344,50 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self._add_primitive_type_field(tag_template, 'modified_by_username',
                                        self.__STRING_TYPE,
                                        'Username who modified it')
+
+        self._add_primitive_type_field(tag_template, 'site_url',
+                                       self.__STRING_TYPE,
+                                       'Qlik Sense site url')
+
+        return tag_template
+
+    def make_tag_template_for_visualization(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_VISUALIZATION)
+
+        tag_template.display_name = 'Qlik Visualization Metadata'
+
+        self._add_primitive_type_field(tag_template, 'id', self.__STRING_TYPE,
+                                       'Unique Id')
+
+        self._add_primitive_type_field(tag_template, 'title',
+                                       self.__STRING_TYPE, 'Title')
+
+        self._add_primitive_type_field(tag_template, 'subtitle',
+                                       self.__STRING_TYPE, 'Subtitle')
+
+        self._add_primitive_type_field(tag_template, 'footnote',
+                                       self.__STRING_TYPE, 'Footnote')
+
+        self._add_primitive_type_field(tag_template, 'type',
+                                       self.__STRING_TYPE, 'Type')
+
+        self._add_primitive_type_field(tag_template, 'tags',
+                                       self.__STRING_TYPE, 'Qlik tags')
+
+        self._add_primitive_type_field(tag_template, 'app_id',
+                                       self.__STRING_TYPE, 'App Id')
+
+        self._add_primitive_type_field(tag_template, 'app_name',
+                                       self.__STRING_TYPE, 'App name')
+
+        self._add_primitive_type_field(tag_template, 'app_entry',
+                                       self.__STRING_TYPE,
+                                       'Data Catalog Entry for the App')
 
         self._add_primitive_type_field(tag_template, 'site_url',
                                        self.__STRING_TYPE,

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper.py
@@ -25,6 +25,7 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
         constants.USER_SPECIFIED_TYPE_CUSTOM_PROPERTY_DEFINITION
     __DIMENSION = constants.USER_SPECIFIED_TYPE_DIMENSION
     __MEASURE = constants.USER_SPECIFIED_TYPE_MEASURE
+    __VISUALIZATION = constants.USER_SPECIFIED_TYPE_VISUALIZATION
     __SHEET = constants.USER_SPECIFIED_TYPE_SHEET
     __STREAM = constants.USER_SPECIFIED_TYPE_STREAM
 
@@ -35,6 +36,7 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
             self.__resolve_measure_mappings,
             self.__resolve_sheet_mappings,
             self.__resolve_stream_mappings,
+            self.__resolve_visualization_mappings,
         )
 
         self._fulfill_tag_fields(assembled_entries, resolvers)
@@ -94,3 +96,15 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
                                    cls.__CUSTOM_PROPERTY_DEFINITION,
                                    'property_definition_id',
                                    'property_definition_entry', id_name_pairs)
+
+    @classmethod
+    def __resolve_visualization_mappings(cls, assembled_entries,
+                                         id_name_pairs):
+
+        viz_assembled_entries = [
+            assembled_entry for assembled_entry in assembled_entries
+            if assembled_entry.entry.user_specified_type == cls.__VISUALIZATION
+        ]
+        for assembled_entry in viz_assembled_entries:
+            cls._map_related_entry(assembled_entry, cls.__APP, 'app_id',
+                                   'app_entry', id_name_pairs)

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/sync/metadata_synchronizer.py
@@ -131,6 +131,7 @@ class MetadataSynchronizer:
             # to turn further processing more efficient.
             app['dimensions'] = self.__scrape_dimensions(app)
             app['measures'] = self.__scrape_measures(app)
+            app['visualizations'] = self.__scrape_visualizations(app)
             app['sheets'] = self.__scrape_published_sheets(app)
 
         self.__assemble_streams_metadata_from_flat_lists(
@@ -160,7 +161,7 @@ class MetadataSynchronizer:
         """Scrapes metadata from the Measures the current user has access to
         within the given App.
 
-        :return: A ``list`` of dimension metadata.
+        :return: A ``list`` of measure metadata.
         """
         measures = self.__metadata_scraper.scrape_measures(app)
         # The 'app' field is not available in the scrape measures API
@@ -173,6 +174,24 @@ class MetadataSynchronizer:
             }
 
         return measures
+
+    def __scrape_visualizations(self, app):
+        """Scrapes metadata from the Visualizations the current user has access
+        to within the given App.
+
+        :return: A ``list`` of visualization metadata.
+        """
+        visualizations = self.__metadata_scraper.scrape_visualizations(app)
+        # The 'app' field is not available in the scrape visualizations API
+        # response, so it is injected into the returned metadata object to turn
+        # further processing more efficient.
+        for visualization in visualizations:
+            visualization['app'] = {
+                'id': app.get('id'),
+                'name': app.get('name'),
+            }
+
+        return visualizations
 
     def __scrape_published_sheets(self, app):
         """Scrapes metadata from all the published Sheets the current user has
@@ -237,6 +256,9 @@ class MetadataSynchronizer:
         self.__add_template_to_dict(
             templates_dict,
             self.__tag_template_factory.make_tag_template_for_measure())
+        self.__add_template_to_dict(
+            templates_dict,
+            self.__tag_template_factory.make_tag_template_for_visualization())
         self.__add_template_to_dict(
             templates_dict,
             self.__tag_template_factory.make_tag_template_for_sheet())

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/assembled_entry_factory_test.py
@@ -208,6 +208,37 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(tags))
         self.__tag_factory.make_tag_for_sheet.assert_called_once()
 
+    def test_make_assembled_entries_for_stream_should_process_visualizations(
+            self):
+
+        entry_factory = self.__entry_factory
+        entry_factory.make_entry_for_stream.return_value = ('id', {})
+        entry_factory.make_entry_for_app.return_value = ('id', {})
+        entry_factory.make_entry_for_visualization.return_value = ('id', {})
+
+        tag_templates_dict = {
+            'qlik_visualization_metadata': {
+                'name': 'tagTemplates/qlik_visualization_metadata',
+            }
+        }
+
+        fake_stream = self.__make_fake_stream()
+        fake_app = self.__make_fake_app()
+        fake_app['visualizations'].append(self.__make_fake_visualization())
+        fake_stream['apps'].append(fake_app)
+        assembled_entries = \
+            self.__factory.make_assembled_entries_for_stream(
+                fake_stream, tag_templates_dict)
+
+        self.assertEqual(3, len(assembled_entries))
+        entry_factory.make_entry_for_visualization.assert_called_once()
+
+        measure_assembled_entry = assembled_entries[2]
+        tags = measure_assembled_entry.tags
+
+        self.assertEqual(1, len(tags))
+        self.__tag_factory.make_tag_for_visualization.assert_called_once()
+
     @classmethod
     def __make_fake_stream(cls):
         return {
@@ -223,6 +254,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             'name': 'Test app',
             'dimensions': [],
             'measures': [],
+            'visualizations': [],
             'sheets': [],
         }
 
@@ -256,5 +288,16 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             },
             'qMeta': {
                 'title': 'Test sheet',
+            },
+        }
+
+    @classmethod
+    def __make_fake_visualization(cls):
+        return {
+            'qInfo': {
+                'qId': 'test-visualization',
+            },
+            'qMetaDef': {
+                'title': 'Test visualization',
             },
         }

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_entry_factory_test.py
@@ -319,6 +319,40 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+    def test_make_entry_for_visualization_should_set_all_available_fields(
+            self):
+
+        metadata = {
+            'qInfo': {
+                'qId': 'a123-b456',
+            },
+            'qMetaDef': {
+                'title': 'Test visualization',
+                'description': 'Description of the Test visualization',
+            },
+            'app': {
+                'id': 'app-id'
+            },
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_visualization(metadata)
+
+        self.assertEqual('qlik_viz_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'qlik_viz_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('visualization', entry.user_specified_type)
+        self.assertEqual('Test visualization', entry.display_name)
+        self.assertEqual('Description of the Test visualization',
+                         entry.description)
+
+        self.assertEqual('', entry.linked_resource)
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+        self.assertIsNone(entry.source_system_timestamps.update_time)
+
     def test_make_entry_long_id_should_limit_result_id_length(self):
         metadata = {
             'id': '12345678901234567890123456789012'

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_factory_test.py
@@ -459,3 +459,43 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('https://test.server.com',
                          tag.fields['site_url'].string_value)
+
+    def test_make_tag_for_visualization_should_set_all_available_fields(self):
+        tag_template = \
+            self.__tag_template_factory.make_tag_template_for_visualization()
+
+        metadata = {
+            'qInfo': {
+                'qId': 'c987-d654',
+            },
+            'qMetaDef': {
+                'tags': [
+                    'tag 1',
+                    'tag 2',
+                ],
+            },
+            'title': 'Test title',
+            'subtitle': 'Test subtitle',
+            'footnote': 'Test footnote',
+            'visualization': 'test-type',
+            'app': {
+                'id': 'a123-b456',
+                'name': 'Test app',
+            },
+        }
+
+        tag = self.__factory.make_tag_for_visualization(tag_template, metadata)
+
+        self.assertEqual('c987-d654', tag.fields['id'].string_value)
+
+        self.assertEqual('Test title', tag.fields['title'].string_value)
+        self.assertEqual('Test subtitle', tag.fields['subtitle'].string_value)
+        self.assertEqual('Test footnote', tag.fields['footnote'].string_value)
+        self.assertEqual('test-type', tag.fields['type'].string_value)
+        self.assertEqual('tag 1, tag 2', tag.fields['tags'].string_value)
+
+        self.assertEqual('a123-b456', tag.fields['app_id'].string_value)
+        self.assertEqual('Test app', tag.fields['app_name'].string_value)
+
+        self.assertEqual('https://test.server.com',
+                         tag.fields['site_url'].string_value)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/datacatalog_tag_template_factory_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -264,6 +264,113 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual('Qlik Sense site url',
                          tag_template.fields['site_url'].display_name)
 
+    def test_make_tag_template_for_dimension(self):
+        tag_template = self.__factory.make_tag_template_for_dimension()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/qlik_dimension_metadata', tag_template.name)
+
+        self.assertEqual('Qlik Dimension Metadata', tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        grouping_values = tag_template.fields[
+            'grouping'].type.enum_type.allowed_values
+        self.assertEqual('Single', grouping_values[0].display_name)
+        self.assertEqual('Drill down', grouping_values[1].display_name)
+        self.assertEqual('Grouping',
+                         tag_template.fields['grouping'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['fields'].type.primitive_type)
+        self.assertEqual('Fields', tag_template.fields['fields'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['field_labels'].type.primitive_type)
+        self.assertEqual('Field labels',
+                         tag_template.fields['field_labels'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['tags'].type.primitive_type)
+        self.assertEqual('Qlik tags', tag_template.fields['tags'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_id'].type.primitive_type)
+        self.assertEqual('App Id', tag_template.fields['app_id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_name'].type.primitive_type)
+        self.assertEqual('App name',
+                         tag_template.fields['app_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the App',
+                         tag_template.fields['app_entry'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
+    def test_make_tag_template_for_measure(self):
+        tag_template = self.__factory.make_tag_template_for_measure()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/qlik_measure_metadata', tag_template.name)
+
+        self.assertEqual('Qlik Measure Metadata', tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['expression'].type.primitive_type)
+        self.assertEqual('Expression',
+                         tag_template.fields['expression'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['label_expression'].type.primitive_type)
+        self.assertEqual('Label expression',
+                         tag_template.fields['label_expression'].display_name)
+
+        self.assertEqual(
+            self.__BOOL_TYPE,
+            tag_template.fields['is_custom_formatted'].type.primitive_type)
+        self.assertEqual(
+            'Is custom formatted',
+            tag_template.fields['is_custom_formatted'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['tags'].type.primitive_type)
+        self.assertEqual('Qlik tags', tag_template.fields['tags'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_id'].type.primitive_type)
+        self.assertEqual('App Id', tag_template.fields['app_id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_name'].type.primitive_type)
+        self.assertEqual('App name',
+                         tag_template.fields['app_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the App',
+                         tag_template.fields['app_entry'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
     def test_make_tag_template_for_sheet(self):
         tag_template = self.__factory.make_tag_template_for_sheet()
 
@@ -365,6 +472,61 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual(
             'Username who modified it',
             tag_template.fields['modified_by_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['site_url'].type.primitive_type)
+        self.assertEqual('Qlik Sense site url',
+                         tag_template.fields['site_url'].display_name)
+
+    def test_make_tag_template_for_visualization(self):
+        tag_template = self.__factory.make_tag_template_for_visualization()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/qlik_visualization_metadata', tag_template.name)
+
+        self.assertEqual('Qlik Visualization Metadata',
+                         tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Unique Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['title'].type.primitive_type)
+        self.assertEqual('Title', tag_template.fields['title'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['subtitle'].type.primitive_type)
+        self.assertEqual('Subtitle',
+                         tag_template.fields['subtitle'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['footnote'].type.primitive_type)
+        self.assertEqual('Footnote',
+                         tag_template.fields['footnote'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['type'].type.primitive_type)
+        self.assertEqual('Type', tag_template.fields['type'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['tags'].type.primitive_type)
+        self.assertEqual('Qlik tags', tag_template.fields['tags'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_id'].type.primitive_type)
+        self.assertEqual('App Id', tag_template.fields['app_id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_name'].type.primitive_type)
+        self.assertEqual('App name',
+                         tag_template.fields['app_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['app_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the App',
+                         tag_template.fields['app_entry'].display_name)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['site_url'].type.primitive_type)

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/prepare/entry_relationship_mapper_test.py
@@ -28,13 +28,13 @@ class EntryRelationshipMapperTest(unittest.TestCase):
     def test_fulfill_tag_fields_should_resolve_app_custom_prop_def_mapping(
             self):
 
-        definition_id = 'test_definition'
+        definition_id = 'test-definition'
         definition_entry = self.__make_fake_entry(
             definition_id, 'custom_property_definition')
         definition_tag = self.__make_fake_tag(string_fields=(('id',
                                                               definition_id),))
 
-        app_id = 'test_app'
+        app_id = 'test-app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         string_fields = ('id', app_id), ('property_definition_id',
                                          definition_id)
@@ -50,15 +50,15 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_definition',
+            'fake_entries/test-definition',
             app_tag.fields['property_definition_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_app_stream_mapping(self):
-        stream_id = 'test_stream'
+        stream_id = 'test-stream'
         stream_entry = self.__make_fake_entry(stream_id, 'stream')
         stream_tag = self.__make_fake_tag(string_fields=(('id', stream_id),))
 
-        app_id = 'test_app'
+        app_id = 'test-app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         string_fields = ('id', app_id), ('stream_id', stream_id)
         app_tag = self.__make_fake_tag(string_fields=string_fields)
@@ -73,15 +73,15 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_stream',
+            'fake_entries/test-stream',
             app_tag.fields['stream_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_dimension_app_mapping(self):
-        app_id = 'test_app'
+        app_id = 'test-app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
 
-        dimension_id = 'test_dimension'
+        dimension_id = 'test-dimension'
         dimension_entry = self.__make_fake_entry(dimension_id, 'dimension')
         string_fields = ('id', dimension_id), ('app_id', app_id)
         dimension_tag = self.__make_fake_tag(string_fields=string_fields)
@@ -96,15 +96,15 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_app',
+            'fake_entries/test-app',
             dimension_tag.fields['app_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_measure_app_mapping(self):
-        app_id = 'test_app'
+        app_id = 'test-app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
 
-        measure_id = 'test_measure'
+        measure_id = 'test-measure'
         measure_entry = self.__make_fake_entry(measure_id, 'measure')
         string_fields = ('id', measure_id), ('app_id', app_id)
         measure_tag = self.__make_fake_tag(string_fields=string_fields)
@@ -119,15 +119,15 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_app',
+            'fake_entries/test-app',
             measure_tag.fields['app_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_sheet_app_mapping(self):
-        app_id = 'test_app'
+        app_id = 'test-app'
         app_entry = self.__make_fake_entry(app_id, 'app')
         app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
 
-        sheet_id = 'test_sheet'
+        sheet_id = 'test-sheet'
         sheet_entry = self.__make_fake_entry(sheet_id, 'sheet')
         string_fields = ('id', sheet_id), ('app_id', app_id)
         sheet_tag = self.__make_fake_tag(string_fields=string_fields)
@@ -142,19 +142,19 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_app',
+            'fake_entries/test-app',
             sheet_tag.fields['app_entry'].string_value)
 
     def test_fulfill_tag_fields_should_resolve_stream_custom_prop_def_mapping(
             self):
 
-        definition_id = 'test_definition'
+        definition_id = 'test-definition'
         definition_entry = self.__make_fake_entry(
             definition_id, 'custom_property_definition')
         definition_tag = self.__make_fake_tag(string_fields=(('id',
                                                               definition_id),))
 
-        stream_id = 'test_stream'
+        stream_id = 'test-stream'
         stream_entry = self.__make_fake_entry(stream_id, 'stream')
         string_fields = ('id', stream_id), ('property_definition_id',
                                             definition_id)
@@ -170,8 +170,32 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         self.assertEqual(
             'https://console.cloud.google.com/datacatalog/'
-            'fake_entries/test_definition',
+            'fake_entries/test-definition',
             stream_tag.fields['property_definition_entry'].string_value)
+
+    def test_fulfill_tag_fields_should_resolve_visualization_app_mapping(self):
+        app_id = 'test-app'
+        app_entry = self.__make_fake_entry(app_id, 'app')
+        app_tag = self.__make_fake_tag(string_fields=(('id', app_id),))
+
+        visualization_id = 'test-measure'
+        visualization_entry = self.__make_fake_entry(visualization_id,
+                                                     'visualization')
+        string_fields = ('id', visualization_id), ('app_id', app_id)
+        visualization_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        app_assembled_entry = commons_prepare.AssembledEntryData(
+            app_id, app_entry, [app_tag])
+        measure_assembled_entry = commons_prepare.AssembledEntryData(
+            visualization_id, visualization_entry, [visualization_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [app_assembled_entry, measure_assembled_entry])
+
+        self.assertEqual(
+            'https://console.cloud.google.com/datacatalog/'
+            'fake_entries/test-app',
+            visualization_tag.fields['app_entry'].string_value)
 
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/sync/metadata_synchronizer_test.py
@@ -226,6 +226,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
             [self.__make_fake_published_app()]
         scraper.scrape_dimensions.return_value = []
         scraper.scrape_measures.return_value = []
+        scraper.scrape_visualizations.return_value = []
         scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
@@ -241,6 +242,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                 },
                 'dimensions': [],
                 'measures': [],
+                'visualizations': [],
                 'sheets': [],
             }]
         }
@@ -298,6 +300,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
             [self.__make_fake_published_app()]
         scraper.scrape_dimensions.return_value = [self.__make_fake_dimension()]
         scraper.scrape_measures.return_value = []
+        scraper.scrape_visualizations.return_value = []
         scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
@@ -323,6 +326,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                     },
                 }],
                 'measures': [],
+                'visualizations': [],
                 'sheets': [],
             }]
         }
@@ -349,6 +353,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
             [self.__make_fake_published_app()]
         scraper.scrape_dimensions.return_value = []
         scraper.scrape_measures.return_value = [self.__make_fake_measure()]
+        scraper.scrape_visualizations.return_value = []
         scraper.scrape_sheets.return_value = []
 
         self.__synchronizer.run()
@@ -368,6 +373,61 @@ class MetadataSynchronizerTest(unittest.TestCase):
                         'qId': 'test-measure',
                     },
                     'qMeasure': {},
+                    'qMetaDef': {},
+                    'app': {
+                        'id': 'test-app',
+                        'name': None
+                    },
+                }],
+                'visualizations': [],
+                'sheets': [],
+            }]
+        }
+
+        actual_call_args = assembled_entry_factory\
+            .make_assembled_entries_for_stream.call_args[0]
+        self.assertEqual(expected_make_assembled_entries_call_arg,
+                         actual_call_args[0])
+
+    @mock.patch(f'{__SYNCR_MODULE}.ingest.DataCatalogMetadataIngestor',
+                lambda *args: mock.MagicMock())
+    @mock.patch(f'{__SYNCR_MODULE}.cleanup.DataCatalogMetadataCleaner',
+                lambda *args: mock.MagicMock())
+    @mock.patch(f'{__SYNCR_MODULE}.prepare.EntryRelationshipMapper',
+                lambda *args: mock.MagicMock())
+    def test_run_visualization_should_properly_ask_assembled_entries(self):
+        attrs = self.__synchronizer.__dict__
+        scraper = attrs['_MetadataSynchronizer__metadata_scraper']
+        assembled_entry_factory = attrs[
+            '_MetadataSynchronizer__assembled_entry_factory']
+
+        scraper.scrape_all_streams.return_value = [self.__make_fake_stream()]
+        scraper.scrape_all_apps.return_value = \
+            [self.__make_fake_published_app()]
+        scraper.scrape_dimensions.return_value = []
+        scraper.scrape_measures.return_value = []
+        scraper.scrape_visualizations.return_value = [
+            self.__make_fake_visualization()
+        ]
+        scraper.scrape_sheets.return_value = []
+
+        self.__synchronizer.run()
+
+        expected_make_assembled_entries_call_arg = {
+            'id':
+                'test-stream',
+            'apps': [{
+                'id': 'test-app',
+                'published': True,
+                'stream': {
+                    'id': 'test-stream'
+                },
+                'dimensions': [],
+                'measures': [],
+                'visualizations': [{
+                    'qInfo': {
+                        'qId': 'test-visualization',
+                    },
                     'qMetaDef': {},
                     'app': {
                         'id': 'test-app',
@@ -400,6 +460,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
             [self.__make_fake_published_app()]
         scraper.scrape_dimensions.return_value = []
         scraper.scrape_measures.return_value = []
+        scraper.scrape_visualizations.return_value = []
         scraper.scrape_sheets.return_value = [
             self.__make_fake_published_sheet()
         ]
@@ -419,6 +480,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                 },
                 'dimensions': [],
                 'measures': [],
+                'visualizations': [],
                 'sheets': [{
                     'qInfo': {
                         'qId': 'test-sheet',
@@ -458,6 +520,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
             [self.__make_fake_published_app()]
         scraper.scrape_dimensions.return_value = []
         scraper.scrape_measures.return_value = []
+        scraper.scrape_visualizations.return_value = []
         scraper.scrape_sheets.return_value = [self.__make_fake_wip_sheet()]
 
         self.__synchronizer.run()
@@ -473,6 +536,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
                 },
                 'dimensions': [],
                 'measures': [],
+                'visualizations': [],
                 'sheets': [],
             }]
         }
@@ -520,6 +584,15 @@ class MetadataSynchronizerTest(unittest.TestCase):
                 'qId': 'test-measure',
             },
             'qMeasure': {},
+            'qMetaDef': {},
+        }
+
+    @classmethod
+    def __make_fake_visualization(cls):
+        return {
+            'qInfo': {
+                'qId': 'test-visualization',
+            },
             'qMetaDef': {},
         }
 

--- a/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-qlik-connector/tools/scripts/cleanup_datacatalog.py
@@ -102,6 +102,9 @@ def __delete_tag_templates(project_id, location_id):
             project_id, location_id, 'qlik_measure_metadata'))
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'qlik_visualization_metadata'))
+    template_names.append(
+        datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'qlik_sheet_metadata'))
     template_names.append(
         datacatalog.DataCatalogClient.tag_template_path(


### PR DESCRIPTION
**- What I did**
Added support for ingesting Visualizations metadata.

**- How I did it**
1. Added Visualization-related methods to the Qlik connector's Entry, Tag Template, and Tag factories.
2. Added Visualization-related code to the Qlik connector's metadata synchronizer.
3. Added unit tests to fully cover the above changes.
4. Updated the cleanup script in order to delete the Tag Template identified by qlik_visualization_metadata.
5. Added `Master Items: Visualization` to the assets list in the `README.md` file.

**- How to verify it**
Run the unit tests and, preferably, the connector in an integrated environment.

**- Description for the changelog**
Added support for ingesting Visualizations metadata.

Closes #34.