### PR TITLE
Improve the exception handling

### DIFF
--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,9 +34,12 @@ class EngineAPIDimensionsHelper(base_engine_api_helper.BaseEngineAPIHelper):
         try:
             return self._run_until_complete(
                 self.__get_dimensions(app_id, timeout))
-        except Exception:
+        except Exception as e:
             logging.warning("error on get_dimensions:", exc_info=True)
-            return []
+            if isinstance(e, asyncio.TimeoutError):
+                return []
+            else:
+                raise
 
     async def __get_dimensions(self, app_id, timeout):
         async with self._connect_websocket(app_id) as websocket:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper.py
@@ -34,9 +34,12 @@ class EngineAPIMeasuresHelper(base_engine_api_helper.BaseEngineAPIHelper):
         try:
             return self._run_until_complete(
                 self.__get_measures(app_id, timeout))
-        except Exception:
+        except Exception as e:
             logging.warning("error on get_measures:", exc_info=True)
-            return []
+            if isinstance(e, asyncio.TimeoutError):
+                return []
+            else:
+                raise
 
     async def __get_measures(self, app_id, timeout):
         async with self._connect_websocket(app_id) as websocket:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,9 +29,12 @@ class EngineAPISheetsHelper(base_engine_api_helper.BaseEngineAPIHelper):
     def get_sheets(self, app_id, timeout=60):
         try:
             return self._run_until_complete(self.__get_sheets(app_id, timeout))
-        except Exception:
+        except Exception as e:
             logging.warning("error on get_sheets:", exc_info=True)
-            return []
+            if isinstance(e, asyncio.TimeoutError):
+                return []
+            else:
+                raise
 
     async def __get_sheets(self, app_id, timeout):
         async with self._connect_websocket(app_id) as websocket:

--- a/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper.py
+++ b/google-datacatalog-qlik-connector/src/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper.py
@@ -34,9 +34,12 @@ class EngineAPIVisualizationsHelper(base_helper.BaseEngineAPIHelper):
         try:
             return self._run_until_complete(
                 self.__get_visualizations(app_id, timeout))
-        except Exception:
+        except Exception as e:
             logging.warning("error on get_visualizations:", exc_info=True)
-            return []
+            if isinstance(e, asyncio.TimeoutError):
+                return []
+            else:
+                raise
 
     async def __get_visualizations(self, app_id, timeout):
         async with self._connect_websocket(app_id) as websocket:

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_dimensions_helper_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,10 +38,19 @@ class EngineAPIDimensionsHelperTest(unittest.TestCase):
     @mock.patch(f'{__HELPER_CLASS}._EngineAPIDimensionsHelper__get_dimensions',
                 lambda *args: None)
     @mock.patch(f'{__BASE_CLASS}._run_until_complete')
-    def test_get_dimensions_should_return_empty_list_on_exception(
+    def test_get_dimensions_should_raise_unknown_exception(
             self, mock_run_until_complete):
 
         mock_run_until_complete.side_effect = Exception
+        self.assertRaises(Exception, self.__helper.get_dimensions, 'app_id')
+
+    @mock.patch(f'{__HELPER_CLASS}._EngineAPIDimensionsHelper__get_dimensions',
+                lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_dimensions_should_return_empty_list_on_timeout(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = asyncio.TimeoutError
         dimensions = self.__helper.get_dimensions('app-id')
         self.assertEqual(0, len(dimensions))
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_measures_helper_test.py
@@ -38,10 +38,19 @@ class EngineAPIMeasuresHelperTest(unittest.TestCase):
     @mock.patch(f'{__HELPER_CLASS}._EngineAPIMeasuresHelper__get_measures',
                 lambda *args: None)
     @mock.patch(f'{__BASE_CLASS}._run_until_complete')
-    def test_get_measures_should_return_empty_list_on_exception(
+    def test_get_measures_should_raise_unknown_exception(
             self, mock_run_until_complete):
 
         mock_run_until_complete.side_effect = Exception
+        self.assertRaises(Exception, self.__helper.get_measures, 'app_id')
+
+    @mock.patch(f'{__HELPER_CLASS}._EngineAPIMeasuresHelper__get_measures',
+                lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_measures_should_return_empty_list_on_timeout(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = asyncio.TimeoutError
         measures = self.__helper.get_measures('app-id')
         self.assertEqual(0, len(measures))
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_scraper_test.py
@@ -23,15 +23,11 @@ from google.datacatalog_connectors.qlik.scrape import \
 
 from . import scrape_ops_mocks
 
-_SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
-_SCRAPER_MODULE = f'{_SCRAPE_PACKAGE}.engine_api_scraper'
 
-
-@mock.patch(f'{_SCRAPER_MODULE}'
-            f'.engine_api_sheets_helper.EngineAPISheetsHelper.get_sheets',
-            lambda *args: None)
 class EngineAPIScraperTest(unittest.TestCase):
-    __SCRAPER_CLASS = f'{_SCRAPER_MODULE}.EngineAPIScraper'
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.qlik.scrape'
+    __SCRAPER_MODULE = f'{__SCRAPE_PACKAGE}.engine_api_scraper'
+    __SCRAPER_CLASS = f'{__SCRAPER_MODULE}.EngineAPIScraper'
 
     def setUp(self):
         self.__scraper = engine_api_scraper.EngineAPIScraper(
@@ -57,6 +53,9 @@ class EngineAPIScraperTest(unittest.TestCase):
         attrs = self.__scraper.__dict__
         self.assertIsNone(attrs['_EngineAPIScraper__auth_cookie'])
 
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_dimensions_helper'
+                f'.EngineAPIDimensionsHelper.get_dimensions',
+                lambda *args: None)
     @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
     def test_get_dimensions_should_authenticate_user_beforehand(
             self, mock_set_up_cookie):
@@ -64,6 +63,8 @@ class EngineAPIScraperTest(unittest.TestCase):
         self.__scraper.get_dimensions('app-id')
         mock_set_up_cookie.assert_called_once()
 
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_measures_helper'
+                f'.EngineAPIMeasuresHelper.get_measures', lambda *args: None)
     @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
     def test_get_measures_should_authenticate_user_beforehand(
             self, mock_set_up_cookie):
@@ -71,6 +72,8 @@ class EngineAPIScraperTest(unittest.TestCase):
         self.__scraper.get_measures('app-id')
         mock_set_up_cookie.assert_called_once()
 
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_sheets_helper'
+                f'.EngineAPISheetsHelper.get_sheets', lambda *args: None)
     @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
     def test_get_sheets_should_authenticate_user_beforehand(
             self, mock_set_up_cookie):
@@ -78,6 +81,9 @@ class EngineAPIScraperTest(unittest.TestCase):
         self.__scraper.get_sheets('app-id')
         mock_set_up_cookie.assert_called_once()
 
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_visualizations_helper'
+                f'.EngineAPIVisualizationsHelper.get_visualizations',
+                lambda *args: None)
     @mock.patch(f'{__SCRAPER_CLASS}._EngineAPIScraper__set_up_auth_cookie')
     def test_get_visualizations_should_authenticate_user_beforehand(
             self, mock_set_up_cookie):
@@ -85,7 +91,9 @@ class EngineAPIScraperTest(unittest.TestCase):
         self.__scraper.get_visualizations('app-id')
         mock_set_up_cookie.assert_called_once()
 
-    @mock.patch(f'{_SCRAPER_MODULE}.authenticator.Authenticator'
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_sheets_helper'
+                f'.EngineAPISheetsHelper.get_sheets', lambda *args: None)
+    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator'
                 f'.get_qps_session_cookie_windows_auth')
     @mock.patch(f'{__SCRAPER_CLASS}'
                 f'._EngineAPIScraper__get_windows_authentication_url')
@@ -105,7 +113,9 @@ class EngineAPIScraperTest(unittest.TestCase):
         attrs = self.__scraper.__dict__
         self.assertEqual(fake_cookie, attrs['_EngineAPIScraper__auth_cookie'])
 
-    @mock.patch(f'{_SCRAPER_MODULE}.authenticator.Authenticator'
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_sheets_helper'
+                f'.EngineAPISheetsHelper.get_sheets', lambda *args: None)
+    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator'
                 f'.get_qps_session_cookie_windows_auth')
     @mock.patch(f'{__SCRAPER_CLASS}'
                 f'._EngineAPIScraper__get_windows_authentication_url')
@@ -123,10 +133,12 @@ class EngineAPIScraperTest(unittest.TestCase):
 
         mock_get_qps_session_cookie.assert_not_called()
 
-    @mock.patch(f'{_SCRAPER_MODULE}.authenticator.Authenticator'
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_sheets_helper'
+                f'.EngineAPISheetsHelper.get_sheets', lambda *args: None)
+    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator'
                 f'.get_qps_session_cookie_windows_auth',
                 lambda *args, **kwargs: None)
-    @mock.patch(f'{_SCRAPE_PACKAGE}.engine_api_scraper.websockets.connect',
+    @mock.patch(f'{__SCRAPE_PACKAGE}.engine_api_scraper.websockets.connect',
                 new_callable=scrape_ops_mocks.AsyncContextManager)
     def test_get_windows_authentication_url_should_pass_appropriate_auth_args(
             self, mock_websocket):
@@ -148,9 +160,11 @@ class EngineAPIScraperTest(unittest.TestCase):
         actual_ws_call_args = mock_websocket.call_args_list[0]
         self.assertEqual(expected_ws_call_args, actual_ws_call_args)
 
-    @mock.patch(f'{_SCRAPER_MODULE}.authenticator.Authenticator'
+    @mock.patch(f'{__SCRAPER_MODULE}.engine_api_sheets_helper'
+                f'.EngineAPISheetsHelper.get_sheets', lambda *args: None)
+    @mock.patch(f'{__SCRAPER_MODULE}.authenticator.Authenticator'
                 f'.get_qps_session_cookie_windows_auth')
-    @mock.patch(f'{_SCRAPE_PACKAGE}.engine_api_scraper.websockets.connect',
+    @mock.patch(f'{__SCRAPE_PACKAGE}.engine_api_scraper.websockets.connect',
                 new_callable=scrape_ops_mocks.AsyncContextManager)
     def test_get_windows_authentication_url_should_return_login_uri(
             self, mock_websocket, mock_get_qps_session_cookie):

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_sheets_helper_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,10 +37,19 @@ class EngineAPISheetsHelperTest(unittest.TestCase):
     @mock.patch(f'{__HELPER_CLASS}._EngineAPISheetsHelper__get_sheets',
                 lambda *args: None)
     @mock.patch(f'{__BASE_CLASS}._run_until_complete')
-    def test_get_sheets_should_return_empty_list_on_exception(
+    def test_get_sheets_should_raise_unknown_exception(
             self, mock_run_until_complete):
 
         mock_run_until_complete.side_effect = Exception
+        self.assertRaises(Exception, self.__helper.get_sheets, 'app_id')
+
+    @mock.patch(f'{__HELPER_CLASS}._EngineAPISheetsHelper__get_sheets',
+                lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_sheets_should_return_empty_list_on_timeout(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = asyncio.TimeoutError
         sheets = self.__helper.get_sheets('app-id')
         self.assertEqual(0, len(sheets))
 

--- a/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper_test.py
+++ b/google-datacatalog-qlik-connector/tests/google/datacatalog_connectors/qlik/scrape/engine_api_visualizations_helper_test.py
@@ -41,10 +41,21 @@ class EngineAPIVisualizationsHelperTest(unittest.TestCase):
         f'{__HELPER_CLASS}._EngineAPIVisualizationsHelper__get_visualizations',
         lambda *args: None)
     @mock.patch(f'{__BASE_CLASS}._run_until_complete')
-    def test_get_visualizations_should_return_empty_list_on_exception(
+    def test_get_visualizations_should_raise_unknown_exception(
             self, mock_run_until_complete):
 
         mock_run_until_complete.side_effect = Exception
+        self.assertRaises(Exception, self.__helper.get_visualizations,
+                          'app_id')
+
+    @mock.patch(
+        f'{__HELPER_CLASS}._EngineAPIVisualizationsHelper__get_visualizations',
+        lambda *args: None)
+    @mock.patch(f'{__BASE_CLASS}._run_until_complete')
+    def test_get_visualizations_should_return_empty_list_on_timeout(
+            self, mock_run_until_complete):
+
+        mock_run_until_complete.side_effect = asyncio.TimeoutError
         visualizations = self.__helper.get_visualizations('app-id')
         self.assertEqual(0, len(visualizations))
 


### PR DESCRIPTION
**- What I did**
Changed `scrape.BaseEngineAPIHelper._run_until_complete()` in order to cancel all tasks running in a given event loop regardless of the type of the exception type that might be raised during the asynchronous code execution.

**- How I did it**
The main change consists of replacing `except asyncio.TimeoutError:` with `except Exception:` in the aforementioned method. All other changes are consequences of it.

Please notice timeouts are now logged and bypassed at the child-class level. Other exceptions are raised, as they used to be before the changes.

```python
if isinstance(e, asyncio.TimeoutError):
    return []
else:
    raise
```

**- How to verify it**
Run the unit tests and preferably the connector in an integrated environment.

**- Description for the changelog**
Improved the exception handling mechanism in order to cancel all tasks running in a given event loop regardless of the type of the exception type that might be raised during the asynchronous code execution.
