### PR TITLE
Set up the Sisense Connector package structure

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,6 +17,7 @@ jobs:
         build-dir:
           [
             "./google-datacatalog-qlik-connector",
+            "./google-datacatalog-sisense-connector",
             "./google-datacatalog-tableau-connector",
           ]
         python-version: [3.6]
@@ -54,6 +55,7 @@ jobs:
           [
             "./google-datacatalog-looker-connector",
             "./google-datacatalog-qlik-connector",
+            "./google-datacatalog-sisense-connector",
             "./google-datacatalog-tableau-connector",
           ]
         python-version: [3.7]
@@ -89,6 +91,7 @@ jobs:
       matrix:
         build-dir:
           [
+            "./google-datacatalog-sisense-connector",
             "./google-datacatalog-tableau-connector",
           ]
         python-version: [3.8]

--- a/google-datacatalog-sisense-connector/.coveragerc
+++ b/google-datacatalog-sisense-connector/.coveragerc
@@ -1,0 +1,6 @@
+# .coveragerc to control coverage.py
+[run]
+omit =
+    */__init__.py
+source =
+    src

--- a/google-datacatalog-sisense-connector/.gitignore
+++ b/google-datacatalog-sisense-connector/.gitignore
@@ -1,0 +1,111 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# PyCharm
+.DS_Store
+.idea
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Application logs
+log/

--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -1,0 +1,8 @@
+# google-datacatalog-sisense-connector
+
+Package for ingesting [Sisense](https://www.sisense.com/) metadata into Google
+Cloud Data Catalog.
+
+**Disclaimer: This is not an officially supported Google product.**
+
+> This connector is a work in progress!

--- a/google-datacatalog-sisense-connector/docs/README.md
+++ b/google-datacatalog-sisense-connector/docs/README.md
@@ -1,6 +1,6 @@
 # Additional documentation
 
-This directory contains additional documentation on the Connector.
+This directory contains additional documentation on the connector.
 
 - [Developer Resources](developer-resources)
 

--- a/google-datacatalog-sisense-connector/docs/README.md
+++ b/google-datacatalog-sisense-connector/docs/README.md
@@ -1,0 +1,7 @@
+# Additional documentation
+
+This directory contains additional documentation on the Connector.
+
+- [Developer Resources](developer-resources)
+
+Back to [Home](..)

--- a/google-datacatalog-sisense-connector/docs/README.md
+++ b/google-datacatalog-sisense-connector/docs/README.md
@@ -4,4 +4,6 @@ This directory contains additional documentation on the connector.
 
 - [Developer Resources](developer-resources)
 
+---
+
 Back to [Home](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/README.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/README.md
@@ -1,0 +1,9 @@
+# Developer Resources
+
+- Documentation
+  * [Sisense APIs](sisense-apis.md)
+
+- Tools
+  * [Postman](postman.md) 
+
+Back to the [Documentation index](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/README.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/README.md
@@ -6,4 +6,6 @@
 - Tools
   * [Postman](postman.md) 
 
+---
+
 Back to the [Documentation index](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
@@ -19,3 +19,5 @@ v1](https://sisense.dev/reference/rest/v1.html).
    | `PASSWORD`    | Password to authenticate the API calls     |
 
 1. Sample environment file: [tools/postman/sisense-sample-environment.postman_environment.json](../../tools/postman/sisense-sample-environment.postman_environment.json)
+
+Back to the [Developer Resources index](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
@@ -1,0 +1,21 @@
+# Postman
+
+Developers may leverage [Postman](https://www.postman.com/) to validate API
+requests. The available collection covers the [Sisense REST API
+v1](https://sisense.dev/reference/rest/v1.html).
+
+## Collection for the Sisense REST API v1
+
+1. File: [tools/postman/Sisense REST API v1.postman_collection.json](../../tools/postman/Sisense%20REST%20%20API%20v1.postman_collection.json)
+
+1. Postman Environment Variables:
+
+   | NAME          | DESCRIPTION                                |
+   | ------------- | ------------------------------------------ |
+   | `SCHEME`      | The URI scheme: `http` or `https`          |
+   | `SERVER`      | URL of the Sisense server                  |
+   | `API_VERSION` | Version of the Sisense REST API, e.g. `v1` |
+   | `USERNAME`    | Username to authenticate the API calls     |
+   | `PASSWORD`    | Password to authenticate the API calls     |
+
+1. Sample environment file: [tools/postman/sisense-sample-environment.postman_environment.json](../../tools/postman/sisense-sample-environment.postman_environment.json)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/postman.md
@@ -20,4 +20,6 @@ v1](https://sisense.dev/reference/rest/v1.html).
 
 1. Sample environment file: [tools/postman/sisense-sample-environment.postman_environment.json](../../tools/postman/sisense-sample-environment.postman_environment.json)
 
+---
+
 Back to the [Developer Resources index](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
@@ -5,4 +5,6 @@ The below API docs were used as a reference to develop this connector:
 1. [Sisense REST API v1.0 Reference (Sisense V6 and
    higher)](https://sisense.dev/reference/rest/v1.html)
 
+---
+
 Back to the [Developer Resources index](..)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
@@ -1,6 +1,6 @@
 # Sisense APIs
 
-The below API docs were used as a reference to develop this connector:
+The below API docs were used as references to develop this connector:
 
 1. [Sisense REST API v1.0 Reference (Sisense V6 and
    higher)](https://sisense.dev/reference/rest/v1.html)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
@@ -1,0 +1,6 @@
+# Sisense APIs
+
+The below API docs were used as a reference to develop this connector:
+
+1. [Sisense REST API v1.0 Reference (Sisense V6 and
+   higher)](https://sisense.dev/reference/rest/v1.html)

--- a/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
+++ b/google-datacatalog-sisense-connector/docs/developer-resources/sisense-apis.md
@@ -4,3 +4,5 @@ The below API docs were used as a reference to develop this connector:
 
 1. [Sisense REST API v1.0 Reference (Sisense V6 and
    higher)](https://sisense.dev/reference/rest/v1.html)
+
+Back to the [Developer Resources index](..)

--- a/google-datacatalog-sisense-connector/setup.cfg
+++ b/google-datacatalog-sisense-connector/setup.cfg
@@ -1,0 +1,10 @@
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --cov --cov-report html --cov-report term-missing --cov-fail-under 95
+testpaths = tests
+
+[yapf]
+based_on_style = google
+column_limit = 79

--- a/google-datacatalog-sisense-connector/setup.py
+++ b/google-datacatalog-sisense-connector/setup.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools
+
+release_status = 'Development Status :: 4 - Beta'
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+setuptools.setup(
+    name='google-datacatalog-sisense-connector',
+    version='0.1.0',
+    author='Google LLC',
+    description='Package for ingesting Sisense metadata'
+    ' into Google Cloud Data Catalog',
+    platforms='Posix; MacOS X; Windows',
+    packages=setuptools.find_packages(where='./src'),
+    namespace_packages=['google', 'google.datacatalog_connectors'],
+    package_dir={'': 'src'},
+    include_package_data=True,
+    install_requires=('google-datacatalog-connectors-commons ~= 0.6.8',),
+    setup_requires=('pytest-runner',),
+    tests_require=('pytest-cov',),
+    classifiers=[
+        release_status,
+        'Natural Language :: English',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    long_description=readme,
+    long_description_content_type='text/markdown',
+)

--- a/google-datacatalog-sisense-connector/setup.py
+++ b/google-datacatalog-sisense-connector/setup.py
@@ -23,7 +23,7 @@ with open('README.md') as readme_file:
 
 setuptools.setup(
     name='google-datacatalog-sisense-connector',
-    version='0.1.0',
+    version='0.0.1',
     author='Google LLC',
     description='Package for ingesting Sisense metadata'
     ' into Google Cloud Data Catalog',

--- a/google-datacatalog-sisense-connector/src/google/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import pkg_resources
+
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import requests
+
+from google.datacatalog_connectors.sisense.scrape import constants
+
+
+class Authenticator:
+
+    @classmethod
+    def authenticate(cls, server_address, api_version, username, password):
+        url = f'{server_address}/api/{api_version}/authentication/login'
+
+        headers = {
+            'Content-Type': constants.X_WWW_FORM_URLENCODED_CONTENT_TYPE,
+            'Accept': constants.JSON_CONTENT_TYPE
+        }
+
+        credentials = {'username': username, 'password': password}
+
+        response = requests.post(url=url, headers=headers,
+                                 data=credentials).json()
+
+        if not response.get('success'):
+            logging.info(response)
+            return
+
+        return response

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/constants.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+JSON_CONTENT_TYPE = 'application/json'
+X_WWW_FORM_URLENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/__init__.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/authenticator_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/authenticator_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.sisense.scrape import authenticator
+
+from . import metadata_scraper_mocks
+
+__SCRAPE_PACKAGE = 'google.datacatalog_connectors.sisense.scrape'
+
+
+@mock.patch(f'{__SCRAPE_PACKAGE}.authenticator.requests.post')
+class AuthenticatorTest(unittest.TestCase):
+
+    def test_authenticate_should_return_credentials_on_success(
+            self, mock_post):
+
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {
+                'success': True,
+                'access_token': 'TEST-TOKEN',
+            }, 200)
+
+        credentials = authenticator.Authenticator.authenticate(
+            'https://test-server.com', 'test-api', 'test-username',
+            'test-password')
+
+        self.assertEqual('TEST-TOKEN', credentials['access_token'])
+
+    def test_authenticate_should_return_none_on_failure(self, mock_post):
+        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+            {'error': {}}, 401)
+
+        credentials = authenticator.Authenticator.authenticate(
+            'https://test-server.com', 'test-api', 'test-username',
+            'test-password')
+
+        self.assertIsNone(credentials)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_mocks.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_mocks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class __FakeResponse:
+
+    def __init__(self, json_data, status_code):
+        self.__json_data = json_data
+        self.__status_code = status_code
+
+    def json(self):
+        return self.__json_data
+
+
+def make_fake_response(json_data, status_code):
+    return __FakeResponse(json_data, status_code)

--- a/google-datacatalog-sisense-connector/tools/postman/Sisense REST API v1.postman_collection.json
+++ b/google-datacatalog-sisense-connector/tools/postman/Sisense REST API v1.postman_collection.json
@@ -1,0 +1,236 @@
+{
+	"info": {
+		"_postman_id": "973ae1ce-2cc9-41b8-8c07-5e661315673c",
+		"name": "Sisense REST API v1",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "0 Authentication",
+			"item": [
+				{
+					"name": "0.01.01 Login",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									"pm.globals.clear();"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.globals.set(\"access_token\", pm.response.json().access_token);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "username",
+									"value": "{{USERNAME}}",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "{{PASSWORD}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/authentication/login",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"authentication",
+								"login"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "1 REST API",
+			"item": [
+				{
+					"name": "1.01.01 Get Folders",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/folders",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"folders"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "1.02.01 Get Dashboards",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const jsonData = pm.response.json();",
+									"const dashboards = jsonData;",
+									"",
+									"pm.globals.unset(\"dashboardId\");",
+									"",
+									"if (dashboards.length > 0) {",
+									"    pm.globals.set(\"dashboardId\", dashboards[0].oid);",
+									"}",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/dashboards?expand=owner,parentFolder",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"dashboards"
+							],
+							"query": [
+								{
+									"key": "expand",
+									"value": "owner,parentFolder"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "1.02.02 Get Dashboard by id",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/dashboards/{{dashboardId}}?expand=owner",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"dashboards",
+								"{{dashboardId}}"
+							],
+							"query": [
+								{
+									"key": "expand",
+									"value": "owner"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "1.03.01 Get Widgets by dashboard",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{access_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SCHEME}}://{{SERVER}}/api/{{API_VERSION}}/dashboards/{{dashboardId}}/widgets",
+							"protocol": "{{SCHEME}}",
+							"host": [
+								"{{SERVER}}"
+							],
+							"path": [
+								"api",
+								"{{API_VERSION}}",
+								"dashboards",
+								"{{dashboardId}}",
+								"widgets"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}

--- a/google-datacatalog-sisense-connector/tools/postman/sisense-sample-environment.postman_environment.json
+++ b/google-datacatalog-sisense-connector/tools/postman/sisense-sample-environment.postman_environment.json
@@ -1,0 +1,34 @@
+{
+	"id": "cd34f798-833f-4e5b-a3fe-c077f29b16b6",
+	"name": "sisense-sample-environment",
+	"values": [
+		{
+			"key": "SCHEME",
+			"value": "https",
+			"enabled": true
+		},
+		{
+			"key": "SERVER",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "API_VERSION",
+			"value": "v1",
+			"enabled": true
+		},
+		{
+			"key": "USERNAME",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "PASSWORD",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-04-29T15:47:15.465Z",
+	"_postman_exported_using": "Postman/7.36.5"
+}


### PR DESCRIPTION
**- What I did**
Set up the Sisense Connector package structure. 

**- How I did it**
1. Created a Python package with unit test support.
2. Created a `docs` folder with the initial developer resources.
3. Added a Postman collection to demonstrate foundational REST operations such as authentication, get folders, get dashboards and get widgets.

**- How to verify it**
Check the static content, the Postman files, and run the unit tests.

**- Description for the changelog**
Set up the Sisense Connector package structure.

PS: This PR is part of the effort to implement #70.
