### PR TITLE
Scrape Sisense Folders metadata

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
@@ -13,3 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .metadata_scraper import MetadataScraper
+
+__all__ = ['MetadataScraper']

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/authenticator.py
@@ -16,6 +16,7 @@
 
 import logging
 import requests
+from typing import Dict, Optional
 
 from google.datacatalog_connectors.sisense.scrape import constants
 
@@ -23,7 +24,9 @@ from google.datacatalog_connectors.sisense.scrape import constants
 class Authenticator:
 
     @classmethod
-    def authenticate(cls, server_address, api_version, username, password):
+    def authenticate(cls, server_address: str, api_version: str, username: str,
+                     password: str) -> Optional[Dict]:
+
         url = f'{server_address}/api/{api_version}/authentication/login'
 
         headers = {

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/constants.py
@@ -14,5 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Authentication and authorization
+AUTHORIZATION_HEADER_NAME = 'Authorization'
+BEARER_TOKEN_PREFIX = 'Bearer'
+
+# Content types
 JSON_CONTENT_TYPE = 'application/json'
 X_WWW_FORM_URLENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, List
+
+from google.datacatalog_connectors.sisense.scrape import rest_api_helper
+
+
+class MetadataScraper:
+
+    def __init__(self, server_address: str, api_version: str, username: str,
+                 password: str):
+
+        self.__api_helper = rest_api_helper.RESTAPIHelper(
+            server_address, api_version, username, password)
+
+    def scrape_all_folders(self) -> List[Dict]:
+        self.__log_scrape_start('Scraping all Folders...')
+        folders = self.__api_helper.get_all_folders()
+
+        logging.info('  %s Folders found:', len(folders))
+        for folder in folders:
+            logging.info('    - %s [%s]', folder.get('name'),
+                         folder.get('_id'))
+
+        return folders
+
+    @classmethod
+    def __log_scrape_start(cls, message: str, *args: Any) -> None:
+        logging.info('')
+        logging.info(message, *args)
+        logging.info('-------------------------------------------------')

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -46,6 +46,9 @@ class RESTAPIHelper:
             A ``list``.
         """
         self.__set_up_auth()
+
+        # Sisense can return the folders in flat (default) or tree structures.
+        # We decided for flat because it simplifies further processing.
         url = f'{self.__base_api_endpoint}/folders?structure=flat'
         return requests.get(url=url, headers=self.__common_headers).json()
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+from typing import Dict, List
+
+from google.datacatalog_connectors.sisense.scrape import \
+    authenticator, constants
+
+
+class RESTAPIHelper:
+
+    def __init__(self, server_address: str, api_version: str, username: str,
+                 password: str):
+
+        self.__server_address = server_address
+        self.__api_version = api_version
+        self.__username = username
+        self.__password = password
+
+        self.__base_api_endpoint = f'{server_address}/api/{api_version}'
+        self.__common_headers = {
+            'Content-Type': constants.JSON_CONTENT_TYPE,
+            'Accept': constants.JSON_CONTENT_TYPE
+        }
+
+        self.__auth_credentials = None
+
+    def get_all_folders(self) -> List[Dict]:
+        """Get all Folders the user has access to on a given server.
+
+        Returns:
+            A ``list``.
+        """
+        self.__set_up_auth()
+        url = f'{self.__base_api_endpoint}/folders?structure=flat'
+        return requests.get(url=url, headers=self.__common_headers).json()
+
+    def __set_up_auth(self) -> None:
+        if self.__auth_credentials:
+            return
+
+        self.__auth_credentials = \
+            authenticator.Authenticator.authenticate(
+                self.__server_address,
+                self.__api_version,
+                self.__username,
+                self.__password)
+
+        self.__common_headers[constants.AUTHORIZATION_HEADER_NAME] = \
+            f'{constants.BEARER_TOKEN_PREFIX}' \
+            f' {self.__auth_credentials["access_token"]}'

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/authenticator_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/authenticator_test.py
@@ -30,11 +30,10 @@ class AuthenticatorTest(unittest.TestCase):
     def test_authenticate_should_return_credentials_on_success(
             self, mock_post):
 
-        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
-            {
-                'success': True,
-                'access_token': 'TEST-TOKEN',
-            }, 200)
+        mock_post.return_value = metadata_scraper_mocks.FakeResponse({
+            'success': True,
+            'access_token': 'TEST-TOKEN',
+        })
 
         credentials = authenticator.Authenticator.authenticate(
             'https://test-server.com', 'test-api', 'test-username',
@@ -43,7 +42,7 @@ class AuthenticatorTest(unittest.TestCase):
         self.assertEqual('TEST-TOKEN', credentials['access_token'])
 
     def test_authenticate_should_return_none_on_failure(self, mock_post):
-        mock_post.return_value = metadata_scraper_mocks.make_fake_response(
+        mock_post.return_value = metadata_scraper_mocks.FakeResponse(
             {'error': {}}, 401)
 
         credentials = authenticator.Authenticator.authenticate(

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -13,3 +13,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.sisense import scrape
+
+
+class MetadataScraperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.sisense.scrape'
+    __SCRAPER_MODULE = f'{__SCRAPE_PACKAGE}.metadata_scraper'
+
+    @mock.patch(f'{__SCRAPER_MODULE}.rest_api_helper.RESTAPIHelper')
+    def setUp(self, mock_rest_api_helper):
+        self.__scraper = scrape.MetadataScraper(server_address='test-server',
+                                                api_version='test-version',
+                                                username='test-username',
+                                                password='test-password')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__scraper.__dict__
+        self.assertIsNotNone(attrs['_MetadataScraper__api_helper'])
+
+    def test_scrape_all_folders_should_delegate_to_api_helper(self):
+        attrs = self.__scraper.__dict__
+        api_helper = attrs['_MetadataScraper__api_helper']
+
+        folders_metadata = [{
+            '_id': 'folder-id',
+        }]
+
+        api_helper.get_all_folders.return_value = folders_metadata
+
+        folders = self.__scraper.scrape_all_folders()
+
+        self.assertEqual(1, len(folders))
+        self.assertEqual('folder-id', folders[0]['_id'])
+        api_helper.get_all_folders.assert_called_once()

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -13,15 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Any
-
-
-class FakeResponse:
-
-    def __init__(self, json_data: Any, status_code=200):
-        self.__json_data = json_data
-        self.__status_code = status_code
-
-    def json(self) -> Any:
-        return self.__json_data

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.sisense.scrape import rest_api_helper
+
+from . import metadata_scraper_mocks
+
+
+class RESTAPIHelperTest(unittest.TestCase):
+    __SCRAPE_PACKAGE = 'google.datacatalog_connectors.sisense.scrape'
+    __HELPER_MODULE = f'{__SCRAPE_PACKAGE}.rest_api_helper'
+    __HELPER_CLASS = f'{__HELPER_MODULE}.RESTAPIHelper'
+    __PRIVATE_METHOD_PREFIX = f'{__HELPER_CLASS}._RESTAPIHelper'
+
+    def setUp(self):
+        self.__helper = rest_api_helper.RESTAPIHelper(
+            server_address='test-server',
+            api_version='test-version',
+            username='test-username',
+            password='test-password')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__helper.__dict__
+
+        self.assertEqual('test-server',
+                         attrs['_RESTAPIHelper__server_address'])
+        self.assertEqual('test-version', attrs['_RESTAPIHelper__api_version'])
+        self.assertEqual('test-username', attrs['_RESTAPIHelper__username'])
+        self.assertEqual('test-password', attrs['_RESTAPIHelper__password'])
+
+        self.assertEqual('test-server/api/test-version',
+                         attrs['_RESTAPIHelper__base_api_endpoint'])
+        self.assertIsNotNone(attrs['_RESTAPIHelper__common_headers'])
+
+    def test_constructor_should_not_set_auth_related_attributes(self):
+        attrs = self.__helper.__dict__
+        self.assertIsNone(attrs['_RESTAPIHelper__auth_credentials'])
+
+    @mock.patch(f'{__HELPER_MODULE}.requests')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_all_folders_should_return_list_on_success(
+            self, mock_requests):
+
+        mock_requests.get.return_value = metadata_scraper_mocks.FakeResponse([{
+            '_id': 'folder-id'
+        }])
+
+        folders = self.__helper.get_all_folders()
+
+        self.assertEqual(1, len(folders))
+        self.assertEqual('folder-id', folders[0]['_id'])
+
+        attrs = self.__helper.__dict__
+        mock_requests.get.assert_called_once_with(
+            url='test-server/api/test-version/folders?structure=flat',
+            headers=attrs['_RESTAPIHelper__common_headers'],
+        )
+
+    @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
+    def test_set_up_auth_should_set_credentials_if_not_authenticated(
+            self, mock_authenticate):
+        mock_authenticate.return_value = {'access_token': 'test-token'}
+
+        self.__helper._RESTAPIHelper__set_up_auth()
+
+        attrs = self.__helper.__dict__
+        self.assertEqual({'access_token': 'test-token'},
+                         attrs['_RESTAPIHelper__auth_credentials'])
+        self.assertEqual(
+            'Bearer test-token',
+            attrs['_RESTAPIHelper__common_headers']['Authorization'])
+
+    @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
+    def test_set_up_auth_should_skip_if_already_authenticated(
+            self, mock_authenticate):
+
+        attrs = self.__helper.__dict__
+        attrs['_RESTAPIHelper__auth_credentials'] = {
+            'access_token': 'test-token'
+        }
+
+        self.__helper._RESTAPIHelper__set_up_auth()
+
+        mock_authenticate.assert_not_called()


### PR DESCRIPTION
**- What I did**
Added the features that allow the Sisense Connector to scrape folders' metadata.

**- How I did it**
Created the `scrape.RESTAPIHelper` and `scrape.MetadataScraper` classes, and their unit tests as well.

**- How to verify it**
Run the unit tests

**- Description for the changelog**
Added the features that allow the Sisense Connector to scrape folders' metadata.

PS: This PR is part of the effort to implement #70.