### PR TITLE
Handle pagination in the Sisense API calls

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -28,7 +28,7 @@ class MetadataScraper:
         self.__api_helper = rest_api_helper.RESTAPIHelper(
             server_address, api_version, username, password)
 
-    def scrape_all_folders(self) -> List[Dict]:
+    def scrape_all_folders(self) -> List[Dict[str, Any]]:
         self.__log_scrape_start('Scraping all Folders...')
         folders = self.__api_helper.get_all_folders()
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -32,6 +32,7 @@ class MetadataScraper:
         self.__log_scrape_start('Scraping all Folders...')
         folders = self.__api_helper.get_all_folders()
 
+        logging.info('')
         logging.info('  %s Folders found:', len(folders))
         for folder in folders:
             logging.info('    - %s [%s]', folder.get('name'),

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import requests
 from typing import Dict, List
 
@@ -50,7 +51,7 @@ class RESTAPIHelper:
         # Sisense can return the folders in flat (default) or tree structures.
         # We decided for flat because it simplifies further processing.
         url = f'{self.__base_api_endpoint}/folders?structure=flat'
-        return requests.get(url=url, headers=self.__common_headers).json()
+        return self.__get_using_pagination(base_url=url, results_per_page=50)
 
     def __set_up_auth(self) -> None:
         if self.__auth_credentials:
@@ -66,3 +67,27 @@ class RESTAPIHelper:
         self.__common_headers[constants.AUTHORIZATION_HEADER_NAME] = \
             f'{constants.BEARER_TOKEN_PREFIX}' \
             f' {self.__auth_credentials["access_token"]}'
+
+    def __get_using_pagination(self, base_url: str,
+                               results_per_page: int) -> List[Dict]:
+
+        results = []
+        query_param_prefix = '?' if '?' not in base_url else '&'
+
+        page_count = 0
+        page_results = []
+        while page_count == 0 or len(page_results) >= results_per_page:
+            offset = page_count * results_per_page
+            url = f'{base_url}{query_param_prefix}skip={offset}' \
+                  f'&limit={results_per_page}'
+            page_results = requests.get(url=url,
+                                        headers=self.__common_headers).json()
+            results.extend(page_results)
+            page_count += 1
+            logging.info(f'page {page_count}: {len(page_results)} results')
+
+        logging.info('')
+        logging.info('Removing potential duplicates...')
+        results_set = {tuple(result.items()) for result in results}
+
+        return [dict(result_tuple) for result_tuple in results_set]

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_mocks.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_mocks.py
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, Dict, List, Union
 
 
 class FakeResponse:
 
-    def __init__(self, json_data: Any, status_code=200):
+    def __init__(self,
+                 json_data: Union[Dict[str, Any], List[Dict[str, Any]]],
+                 status_code=200):
+
         self.__json_data = json_data
         self.__status_code = status_code
 


### PR DESCRIPTION
**- What I did**
Added logic to handle pagination in the Sisense API calls.

**- How I did it**
1. Added the `__get_using_pagination()` to the `RESTAPIHelper` class.
2. Changed `get_all_folders()` to call the new method.
3. Added unit tests.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added logic to handle pagination in the Sisense API calls.
