### PR TITLE
Prepare the Folder entries

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
@@ -13,3 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .assembled_entry_factory import AssembledEntryFactory
+
+__all__ = ('AssembledEntryFactory',)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.datacatalog_connectors.commons import prepare
+
+from google.datacatalog_connectors.sisense.prepare import \
+    datacatalog_entry_factory
+from google.datacatalog_connectors.sisense.prepare.datacatalog_entry_factory \
+    import DataCatalogEntryFactory
+
+
+class AssembledEntryFactory:
+    __datacatalog_entry_factory: DataCatalogEntryFactory
+
+    def __init__(self, project_id, location_id, entry_group_id,
+                 user_specified_system, server_address):
+
+        self.__datacatalog_entry_factory = datacatalog_entry_factory \
+            .DataCatalogEntryFactory(
+                project_id, location_id, entry_group_id, user_specified_system,
+                server_address)
+
+    def make_assembled_entries_for_folder(self, folder_metadata):
+        assembled_entries = [
+            self.__make_assembled_entry_for_folder(folder_metadata)
+        ]
+
+        return assembled_entries
+
+    def __make_assembled_entry_for_folder(self, folder_metadata):
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_folder(
+                folder_metadata)
+
+        tags = []
+
+        return prepare.AssembledEntryData(entry_id, entry, tags)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -52,6 +52,6 @@ class AssembledEntryFactory:
             self.__datacatalog_entry_factory.make_entry_for_folder(
                 folder_metadata)
 
-        tags = []
-
-        return prepare.AssembledEntryData(entry_id, entry, tags)
+        return prepare.AssembledEntryData(entry_id=entry_id,
+                                          entry=entry,
+                                          tags=[])

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Dict, List
+
 from google.datacatalog_connectors.commons import prepare
+from google.datacatalog_connectors.commons.prepare import AssembledEntryData
 
 from google.datacatalog_connectors.sisense.prepare import \
     datacatalog_entry_factory
@@ -25,22 +28,26 @@ from google.datacatalog_connectors.sisense.prepare.datacatalog_entry_factory \
 class AssembledEntryFactory:
     __datacatalog_entry_factory: DataCatalogEntryFactory
 
-    def __init__(self, project_id, location_id, entry_group_id,
-                 user_specified_system, server_address):
+    def __init__(self, project_id: str, location_id: str, entry_group_id: str,
+                 user_specified_system: str, server_address: str):
 
         self.__datacatalog_entry_factory = datacatalog_entry_factory \
             .DataCatalogEntryFactory(
                 project_id, location_id, entry_group_id, user_specified_system,
                 server_address)
 
-    def make_assembled_entries_for_folder(self, folder_metadata):
+    def make_assembled_entries_for_folder(
+            self, folder_metadata: Dict[str, Any]) -> List[AssembledEntryData]:
+
         assembled_entries = [
             self.__make_assembled_entry_for_folder(folder_metadata)
         ]
 
         return assembled_entries
 
-    def __make_assembled_entry_for_folder(self, folder_metadata):
+    def __make_assembled_entry_for_folder(
+            self, folder_metadata: Dict[str, Any]) -> AssembledEntryData:
+
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_folder(
                 folder_metadata)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the common prefix for all Sisense Entries.
+ENTRY_ID_PREFIX = 'sss_'
+# The below asset type specific strings are appended to the standard
+# ENTRY_ID_PREFIX when generating Sisense Entry IDs.
+ENTRY_ID_PART_FOLDER = 'fd_'
+
+# The user specified type of Folder-related Entries.
+USER_SPECIFIED_TYPE_FOLDER = 'folder'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -29,16 +29,16 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
     def __init__(self, project_id: str, location_id: str, entry_group_id: str,
-                 user_specified_system: str, instance_url: str):
+                 user_specified_system: str, __server_address: str):
 
         self.__project_id = project_id
         self.__location_id = location_id
         self.__entry_group_id = entry_group_id
         self.__user_specified_system = user_specified_system
-        self.__instance_url = instance_url
+        self.__server_address = __server_address
 
         # Strip schema (http | https) and slashes from the server url.
-        self.__server_id = instance_url[instance_url.find('//') + 2:]
+        self.__server_id = __server_address[__server_address.find('//') + 2:]
 
     def make_entry_for_folder(
             self, folder_metadata: Dict[str, Any]) -> Tuple[str, Entry]:
@@ -48,6 +48,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         # The root folder does not have an ``_id`` field.
         folder_id = folder_metadata['_id'] if folder_metadata.get(
             '_id') else folder_metadata.get('name')
+
         generated_id = self.__format_id(constants.ENTRY_ID_PART_FOLDER,
                                         folder_id)
         entry.name = datacatalog.DataCatalogClient.entry_path(
@@ -60,7 +61,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.display_name = self._format_display_name(
             folder_metadata.get('name'))
 
-        entry.linked_resource = f'{self.__instance_url}/app/main#/home/' \
+        entry.linked_resource = f'{self.__server_address}/app/main#/home/' \
                                 f'{folder_metadata.get("oid")}'
 
         created_datetime = datetime.strptime(

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -61,8 +61,10 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.display_name = self._format_display_name(
             folder_metadata.get('name'))
 
-        entry.linked_resource = f'{self.__server_address}/app/main#/home/' \
-                                f'{folder_metadata.get("oid")}'
+        if folder_metadata.get('oid'):
+            entry.linked_resource = f'{self.__server_address}' \
+                                    f'/app/main#/home' \
+                                    f'/{folder_metadata.get("oid")}'
 
         if folder_metadata.get('created'):
             created_datetime = datetime.strptime(

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from typing import Any, Dict, Tuple
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import Entry
+from google.protobuf import timestamp_pb2
+from google.datacatalog_connectors.commons import prepare
+
+from google.datacatalog_connectors.sisense.prepare import constants
+
+
+class DataCatalogEntryFactory(prepare.BaseEntryFactory):
+    __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+    def __init__(self, project_id: str, location_id: str, entry_group_id: str,
+                 user_specified_system: str, instance_url: str):
+
+        self.__project_id = project_id
+        self.__location_id = location_id
+        self.__entry_group_id = entry_group_id
+        self.__user_specified_system = user_specified_system
+        self.__instance_url = instance_url
+
+        # Strip schema (http | https) and slashes from the server url.
+        self.__server_id = instance_url[instance_url.find('//') + 2:]
+
+    def make_entry_for_folder(
+            self, folder_metadata: Dict[str, Any]) -> Tuple[str, Entry]:
+
+        entry = datacatalog.Entry()
+
+        # The root folder does not have an ``_id`` field.
+        folder_id = folder_metadata['_id'] if folder_metadata.get(
+            '_id') else folder_metadata.get('name')
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_FOLDER,
+                                        folder_id)
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_FOLDER
+
+        entry.display_name = self._format_display_name(
+            folder_metadata.get('name'))
+
+        entry.linked_resource = f'{self.__instance_url}/app/main#/home/' \
+                                f'{folder_metadata.get("oid")}'
+
+        created_datetime = datetime.strptime(
+            folder_metadata.get('created'),
+            self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        create_timestamp = timestamp_pb2.Timestamp()
+        create_timestamp.FromDatetime(created_datetime)
+        entry.source_system_timestamps.create_time = create_timestamp
+
+        modified_date = folder_metadata.get('lastUpdated')
+        resolved_modified_date = modified_date or folder_metadata.get(
+            'created')
+        modified_datetime = datetime.strptime(
+            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+        update_timestamp = timestamp_pb2.Timestamp()
+        update_timestamp.FromDatetime(modified_datetime)
+        entry.source_system_timestamps.update_time = update_timestamp
+
+        return generated_id, entry
+
+    def __format_id(self, source_type_identifier, source_id):
+        prefixed_id = f'{constants.ENTRY_ID_PREFIX}' \
+                      f'{self.__server_id}_' \
+                      f'{source_type_identifier}{source_id}'
+        return self._format_id(prefixed_id)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -64,21 +64,22 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry.linked_resource = f'{self.__server_address}/app/main#/home/' \
                                 f'{folder_metadata.get("oid")}'
 
-        created_datetime = datetime.strptime(
-            folder_metadata.get('created'),
-            self.__INCOMING_TIMESTAMP_UTC_FORMAT)
-        create_timestamp = timestamp_pb2.Timestamp()
-        create_timestamp.FromDatetime(created_datetime)
-        entry.source_system_timestamps.create_time = create_timestamp
+        if folder_metadata.get('created'):
+            created_datetime = datetime.strptime(
+                folder_metadata.get('created'),
+                self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+            create_timestamp = timestamp_pb2.Timestamp()
+            create_timestamp.FromDatetime(created_datetime)
+            entry.source_system_timestamps.create_time = create_timestamp
 
-        modified_date = folder_metadata.get('lastUpdated')
-        resolved_modified_date = modified_date or folder_metadata.get(
-            'created')
-        modified_datetime = datetime.strptime(
-            resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
-        update_timestamp = timestamp_pb2.Timestamp()
-        update_timestamp.FromDatetime(modified_datetime)
-        entry.source_system_timestamps.update_time = update_timestamp
+            modified_date = folder_metadata.get('lastUpdated')
+            resolved_modified_date = modified_date or folder_metadata.get(
+                'created')
+            modified_datetime = datetime.strptime(
+                resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+            update_timestamp = timestamp_pb2.Timestamp()
+            update_timestamp.FromDatetime(modified_datetime)
+            entry.source_system_timestamps.update_time = update_timestamp
 
         return generated_id, entry
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -29,16 +29,16 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
     def __init__(self, project_id: str, location_id: str, entry_group_id: str,
-                 user_specified_system: str, __server_address: str):
+                 user_specified_system: str, server_address: str):
 
         self.__project_id = project_id
         self.__location_id = location_id
         self.__entry_group_id = entry_group_id
         self.__user_specified_system = user_specified_system
-        self.__server_address = __server_address
+        self.__server_address = server_address
 
         # Strip schema (http | https) and slashes from the server url.
-        self.__server_id = __server_address[__server_address.find('//') + 2:]
+        self.__server_id = server_address[server_address.find('//') + 2:]
 
     def make_entry_for_folder(
             self, folder_metadata: Dict[str, Any]) -> Tuple[str, Entry]:

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/__init__.py
@@ -16,4 +16,4 @@
 
 from .metadata_scraper import MetadataScraper
 
-__all__ = ['MetadataScraper']
+__all__ = ('MetadataScraper',)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.sisense import prepare
+
+
+class AssembledEntryFactoryTest(unittest.TestCase):
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
+    __FACTORY_MODULE = f'{__PREPARE_PACKAGE}.assembled_entry_factory'
+    __FACTORY_CLASS = f'{__FACTORY_MODULE}.AssembledEntryFactory'
+    __PRIVATE_METHOD_PREFIX = f'{__FACTORY_CLASS}._AssembledEntryFactory'
+
+    @mock.patch(f'{__FACTORY_MODULE}.datacatalog_entry_factory'
+                f'.DataCatalogEntryFactory')
+    def setUp(self, mock_entry_factory):
+        self.__factory = prepare.AssembledEntryFactory(
+            project_id='test-project',
+            location_id='test-location',
+            entry_group_id='test-entry-group',
+            user_specified_system='test-system',
+            server_address='https://test.server.com')
+
+        self.__entry_factory = mock_entry_factory.return_value
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__factory.__dict__
+
+        self.assertEqual(
+            self.__entry_factory,
+            attrs['_AssembledEntryFactory__datacatalog_entry_factory'])
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
+    def test_make_assembled_entries_for_folder_should_process_folder(
+            self, make_assembled_entry_for_folder):
+
+        make_assembled_entry_for_folder.return_value = ('id', {})
+
+        assembled_entries = \
+            self.__factory.make_assembled_entries_for_folder(
+                self.__make_fake_folder())
+
+        self.assertEqual(1, len(assembled_entries))
+        make_assembled_entry_for_folder.assert_called_once()
+
+    def test_make_assembled_entry_for_folder_should_process_folder(self):
+        fake_entry = ('id', {})
+
+        entry_factory = self.__entry_factory
+        entry_factory.make_entry_for_folder.return_value = fake_entry
+
+        assembled_entry = self.__factory\
+            ._AssembledEntryFactory__make_assembled_entry_for_folder(
+                self.__make_fake_folder())
+
+        self.assertEqual('id', assembled_entry.entry_id)
+        entry_factory.make_entry_for_folder.assert_called_once()
+
+    @classmethod
+    def __make_fake_folder(cls):
+        return {
+            '_id': 'test-folder',
+            'name': 'Test folder',
+        }

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+import unittest
+
+from google.datacatalog_connectors.sisense.prepare import \
+    datacatalog_entry_factory
+
+
+class DataCatalogEntryFactoryTest(unittest.TestCase):
+    __DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
+
+    def setUp(self):
+        self.__factory = datacatalog_entry_factory.DataCatalogEntryFactory(
+            project_id='test-project',
+            location_id='test-location',
+            entry_group_id='test-entry-group',
+            user_specified_system='test-system',
+            server_address='https://test.server.com')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__factory.__dict__
+
+        self.assertEqual('test-project',
+                         attrs['_DataCatalogEntryFactory__project_id'])
+        self.assertEqual('test-location',
+                         attrs['_DataCatalogEntryFactory__location_id'])
+        self.assertEqual('test-entry-group',
+                         attrs['_DataCatalogEntryFactory__entry_group_id'])
+        self.assertEqual(
+            'test-system',
+            attrs['_DataCatalogEntryFactory__user_specified_system'])
+        self.assertEqual('https://test.server.com',
+                         attrs['_DataCatalogEntryFactory__server_address'])
+
+    def test_make_entry_for_folder_should_set_all_available_fields(self):
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'name': 'Test folder',
+            'created': '2019-09-12T16:30:00.005Z',
+            'lastUpdated': '2019-09-12T16:31:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_folder(metadata)
+
+        self.assertEqual('sss_test_server_com_fd_a123_b456', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'sss_test_server_com_fd_a123_b456', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('folder', entry.user_specified_type)
+        self.assertEqual('Test folder', entry.display_name)
+        self.assertEqual('https://test.server.com/app/main#/home/a123-b457',
+                         entry.linked_resource)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_folder_should_succeed_on_missing_oid(self):
+        metadata = {
+            '_id': 'a123-b456',
+            'name': 'Test folder',
+            'created': '2019-09-12T16:30:00.005Z',
+            'lastUpdated': '2019-09-12T16:31:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_folder(metadata)
+
+        self.assertEqual('', entry.linked_resource)
+
+    def test_make_entry_for_folder_should_succeed_on_missing_created_date(
+            self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'name': 'Test folder',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_folder(metadata)
+
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+
+    def test_make_entry_for_folder_should_use_created_on_missing_updated_date(
+            self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'name': 'Test folder',
+            'created': '2019-09-12T16:30:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_folder(metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -31,18 +31,19 @@ class MetadataScraperTest(unittest.TestCase):
                                                 username='test-username',
                                                 password='test-password')
 
+        self.__api_helper = mock_rest_api_helper.return_value
+
     def test_constructor_should_set_instance_attributes(self):
         attrs = self.__scraper.__dict__
-        self.assertIsNotNone(attrs['_MetadataScraper__api_helper'])
+        self.assertEqual(self.__api_helper,
+                         attrs['_MetadataScraper__api_helper'])
 
     def test_scrape_all_folders_should_delegate_to_api_helper(self):
-        attrs = self.__scraper.__dict__
-        api_helper = attrs['_MetadataScraper__api_helper']
-
         folders_metadata = [{
             '_id': 'folder-id',
         }]
 
+        api_helper = self.__api_helper
         api_helper.get_all_folders.return_value = folders_metadata
 
         folders = self.__scraper.scrape_all_folders()
@@ -52,15 +53,13 @@ class MetadataScraperTest(unittest.TestCase):
         api_helper.get_all_folders.assert_called_once()
 
     def test_scrape_user_should_delegate_to_api_helper(self):
-        attrs = self.__scraper.__dict__
-        api_helper = attrs['_MetadataScraper__api_helper']
-
         user_metadata = {
             '_id': 'user-id',
             'firstName': 'Jane',
             'lastName': 'Doe'
         }
 
+        api_helper = self.__api_helper
         api_helper.get_user.return_value = user_metadata
 
         user = self.__scraper.scrape_user('user-id')


### PR DESCRIPTION
**- What I did**
Added the feature that allows Sisense Connector to prepare Folder entries.
The tags will be tackled in the next PR.

**- How I did it**
Added the `prepare.AssembledEntryFactory` and `prepare.DataCatalogEntryFactory` classes, and their unit tests as well.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added the feature that allows Sisense Connector to prepare Folder entries.

PS: This PR is part of the effort to implement #70.
