### PR TITLE
Prepare the Folder tags

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
@@ -15,5 +15,6 @@
 # limitations under the License.
 
 from .assembled_entry_factory import AssembledEntryFactory
+from .datacatalog_tag_template_factory import DataCatalogTagTemplateFactory
 
-__all__ = ('AssembledEntryFactory',)
+__all__ = ('AssembledEntryFactory', 'DataCatalogTagTemplateFactory')

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/__init__.py
@@ -16,5 +16,7 @@
 
 from .assembled_entry_factory import AssembledEntryFactory
 from .datacatalog_tag_template_factory import DataCatalogTagTemplateFactory
+from .entry_relationship_mapper import EntryRelationshipMapper
 
-__all__ = ('AssembledEntryFactory', 'DataCatalogTagTemplateFactory')
+__all__ = ('AssembledEntryFactory', 'DataCatalogTagTemplateFactory',
+           'EntryRelationshipMapper')

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -56,8 +56,8 @@ class AssembledEntryFactory:
             self, folder_metadata: Dict[str, Any],
             tag_templates: Dict[str, TagTemplate]) -> List[AssembledEntryData]:
 
-        folder_tag_template = self.__get_tag_template(
-            constants.TAG_TEMPLATE_ID_FOLDER, tag_templates)
+        folder_tag_template = tag_templates.get(
+            constants.TAG_TEMPLATE_ID_FOLDER)
 
         assembled_entries = [
             self.__make_assembled_entry_for_folder(folder_metadata,
@@ -88,11 +88,3 @@ class AssembledEntryFactory:
         return prepare.AssembledEntryData(entry_id=entry_id,
                                           entry=entry,
                                           tags=tags)
-
-    @classmethod
-    def __get_tag_template(
-            cls, tag_template_id: str,
-            tag_templates: Dict[str, TagTemplate]) -> TagTemplate:
-
-        return tag_templates[tag_template_id] \
-            if tag_template_id in tag_templates else None

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -65,9 +65,9 @@ class AssembledEntryFactory:
         ]
 
         for child_folder in folder_metadata.get('folders') or []:
-            assembled_entries.append(
-                self.__make_assembled_entry_for_folder(child_folder,
-                                                       folder_tag_template))
+            assembled_entries.extend(
+                self.__make_assembled_entries_for_folder(
+                    child_folder, tag_templates))
 
         return assembled_entries
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -52,14 +52,6 @@ class AssembledEntryFactory:
 
         return assembled_entries
 
-    @classmethod
-    def __get_tag_template(
-            cls, tag_template_id: str,
-            tag_templates: Dict[str, TagTemplate]) -> TagTemplate:
-
-        return tag_templates[tag_template_id] \
-            if tag_template_id in tag_templates else None
-
     def __make_assembled_entries_for_folder(
             self, folder_metadata: Dict[str, Any],
             tag_templates: Dict[str, TagTemplate]) -> List[AssembledEntryData]:
@@ -72,7 +64,7 @@ class AssembledEntryFactory:
                                                    folder_tag_template)
         ]
 
-        for child_folder in folder_metadata['folders']:
+        for child_folder in folder_metadata.get('folders') or []:
             assembled_entries.append(
                 self.__make_assembled_entry_for_folder(child_folder,
                                                        folder_tag_template))
@@ -96,3 +88,11 @@ class AssembledEntryFactory:
         return prepare.AssembledEntryData(entry_id=entry_id,
                                           entry=entry,
                                           tags=tags)
+
+    @classmethod
+    def __get_tag_template(
+            cls, tag_template_id: str,
+            tag_templates: Dict[str, TagTemplate]) -> TagTemplate:
+
+        return tag_templates[tag_template_id] \
+            if tag_template_id in tag_templates else None

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -20,6 +20,9 @@ ENTRY_ID_PREFIX = 'sss_'
 # ENTRY_ID_PREFIX when generating Sisense Entry IDs.
 ENTRY_ID_PART_FOLDER = 'fd_'
 
+# The Sisense type for Folder assets.
+SISENSE_ASSET_TYPE_FOLDER = 'folder'
+
 # The ID of the Tag Template created to store additional metadata for
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -20,5 +20,9 @@ ENTRY_ID_PREFIX = 'sss_'
 # ENTRY_ID_PREFIX when generating Sisense Entry IDs.
 ENTRY_ID_PART_FOLDER = 'fd_'
 
+# The ID of the Tag Template created to store additional metadata for
+# Folder-related Entries.
+TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
+
 # The user specified type of Folder-related Entries.
 USER_SPECIFIED_TYPE_FOLDER = 'folder'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -45,8 +45,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         entry = datacatalog.Entry()
 
-        # The root folder does not have an ``_id`` field.
-        folder_id = folder_metadata.get('_id') or folder_metadata.get('name')
+        # The root folder's ``oid`` field is not fulfilled.
+        folder_id = folder_metadata.get('oid') or folder_metadata.get('name')
 
         generated_id = self.__format_id(constants.ENTRY_ID_PART_FOLDER,
                                         folder_id)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -46,8 +46,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         entry = datacatalog.Entry()
 
         # The root folder does not have an ``_id`` field.
-        folder_id = folder_metadata['_id'] if folder_metadata.get(
-            '_id') else folder_metadata.get('name')
+        folder_id = folder_metadata.get('_id') or folder_metadata.get('name')
 
         generated_id = self.__format_id(constants.ENTRY_ID_PART_FOLDER,
                                         folder_id)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -30,7 +30,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
     def __init__(self, server_address: str):
         self.__server_address = server_address
 
-    def make_tag_for_stream(self, tag_template: TagTemplate,
+    def make_tag_for_folder(self, tag_template: TagTemplate,
                             folder_metadata: Dict[str, Any]) -> Tag:
 
         tag = datacatalog.Tag()

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -56,10 +56,14 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         children = folder_metadata.get('children')
         child_count = len(children) if children else 0
         self._set_bool_field(tag, 'has_children', child_count > 0)
+        if child_count:
+            self._set_double_field(tag, 'child_count', child_count)
 
         dashboards = folder_metadata.get('dashboards')
         dashboard_count = len(dashboards) if dashboards else 0
         self._set_bool_field(tag, 'has_dashboards', dashboard_count > 0)
+        if dashboard_count:
+            self._set_double_field(tag, 'dashboard_count', dashboard_count)
 
         self._set_string_field(tag, 'server_url', self.__server_address)
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from typing import Any, Dict
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import Tag, TagTemplate
+from google.datacatalog_connectors.commons import prepare
+
+from google.datacatalog_connectors.sisense.prepare import constants
+
+
+class DataCatalogTagFactory(prepare.BaseTagFactory):
+    __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+    def __init__(self, server_address: str):
+        self.__server_address = server_address
+
+    def make_tag_for_stream(self, tag_template: TagTemplate,
+                            folder_metadata: Dict[str, Any]) -> Tag:
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        # The root folder does not have an ``_id`` field.
+        folder_id = folder_metadata.get('_id') or folder_metadata.get('name')
+        self._set_string_field(tag, 'id', folder_id)
+
+        self._set_string_field(tag, 'name', folder_metadata.get('name'))
+
+        owner = folder_metadata.get('owner')
+        if owner:
+            self._set_string_field(tag, 'owner_username',
+                                   owner.get('userName'))
+
+            first_name = owner.get('firstName') or ''
+            last_name = owner.get('lastName') or ''
+            self._set_string_field(tag, 'owner_name',
+                                   f'{first_name} {last_name}')
+
+        self._set_bool_field(tag, 'has_children', False)
+
+        self._set_bool_field(tag, 'has_dashboards', False)
+
+        self._set_string_field(tag, 'server_url', self.__server_address)
+
+        return tag

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -37,13 +37,15 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         tag.template = tag_template.name
 
-        # The root folder does not have an ``_id`` field.
-        folder_id = folder_metadata.get('_id') or folder_metadata.get('name')
+        # The root folder's ``oid`` field is not fulfilled.
+        folder_id = folder_metadata.get('oid') or folder_metadata.get('name')
         self._set_string_field(tag, 'id', folder_id)
 
         self._set_string_field(tag, 'name', folder_metadata.get('name'))
+        self._set_string_field(tag, 'parent_id',
+                               folder_metadata.get('parentId'))
 
-        owner = folder_metadata.get('owner')
+        owner = folder_metadata.get('ownerData')
         if owner:
             self._set_string_field(tag, 'owner_username',
                                    owner.get('userName'))
@@ -53,8 +55,8 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             self._set_string_field(tag, 'owner_name',
                                    f'{first_name} {last_name}')
 
-        children = folder_metadata.get('children')
-        child_count = len(children) if children else 0
+        child_folders = folder_metadata.get('folders')
+        child_count = len(child_folders) if child_folders else 0
         self._set_bool_field(tag, 'has_children', child_count > 0)
         if child_count:
             self._set_double_field(tag, 'child_count', child_count)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -53,9 +53,13 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             self._set_string_field(tag, 'owner_name',
                                    f'{first_name} {last_name}')
 
-        self._set_bool_field(tag, 'has_children', False)
+        children = folder_metadata.get('children')
+        child_count = len(children) if children else 0
+        self._set_bool_field(tag, 'has_children', child_count > 0)
 
-        self._set_bool_field(tag, 'has_dashboards', False)
+        dashboards = folder_metadata.get('dashboards')
+        dashboard_count = len(dashboards) if dashboards else 0
+        self._set_bool_field(tag, 'has_dashboards', dashboard_count > 0)
 
         self._set_string_field(tag, 'server_url', self.__server_address)
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -14,14 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
 from typing import Any, Dict
 
 from google.cloud import datacatalog
 from google.cloud.datacatalog import Tag, TagTemplate
 from google.datacatalog_connectors.commons import prepare
-
-from google.datacatalog_connectors.sisense.prepare import constants
 
 
 class DataCatalogTagFactory(prepare.BaseTagFactory):

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud import datacatalog
+from google.datacatalog_connectors.commons import prepare
+
+from google.datacatalog_connectors.sisense.prepare import constants
+
+
+class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
+
+    def __init__(self, project_id, location_id):
+        self.__project_id = project_id
+        self.__location_id = location_id
+
+    def make_tag_template_for_folder(self):
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_FOLDER)
+
+        tag_template.display_name = 'Sisense Folder Metadata'
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Id',
+                                       is_required=True,
+                                       order=11)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Name',
+                                       is_required=True,
+                                       order=10)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_username',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner username',
+                                       order=9)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner name',
+                                       order=8)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='has_children',
+                                       field_type=self.__BOOL_TYPE,
+                                       display_name='Has children',
+                                       is_required=True,
+                                       order=7)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='children_count',
+                                       field_type=self.__DOUBLE_TYPE,
+                                       display_name='Children count',
+                                       order=6)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='parent_id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Id of Parent',
+                                       order=5)
+
+        self._add_primitive_type_field(
+            tag_template=tag_template,
+            field_id='parent_entry',
+            field_type=self.__STRING_TYPE,
+            display_name='Data Catalog Entry for the parent Folder',
+            order=4)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='has_dashboards',
+                                       field_type=self.__BOOL_TYPE,
+                                       display_name='Has dashboards',
+                                       is_required=True,
+                                       order=3)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='dashboards_count',
+                                       field_type=self.__DOUBLE_TYPE,
+                                       display_name='Dashboards count',
+                                       order=2)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='server_url',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Sisense Server Url',
+                                       is_required=True,
+                                       order=1)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -101,9 +101,9 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        order=3)
 
         self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='dashboards_count',
+                                       field_id='dashboard_count',
                                        field_type=self.__DOUBLE_TYPE,
-                                       display_name='Dashboards count',
+                                       display_name='Dashboard count',
                                        order=2)
 
         self._add_primitive_type_field(tag_template=tag_template,

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from google.cloud import datacatalog
+from google.cloud.datacatalog import TagTemplate
 from google.datacatalog_connectors.commons import prepare
 
 from google.datacatalog_connectors.sisense.prepare import constants
@@ -26,11 +27,11 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
     __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
     __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
 
-    def __init__(self, project_id, location_id):
+    def __init__(self, project_id: str, location_id: str):
         self.__project_id = project_id
         self.__location_id = location_id
 
-    def make_tag_template_for_folder(self):
+    def make_tag_template_for_folder(self) -> TagTemplate:
         tag_template = datacatalog.TagTemplate()
 
         tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
@@ -111,3 +112,5 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        display_name='Sisense Server Url',
                                        is_required=True,
                                        order=1)
+
+        return tag_template

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -68,30 +68,30 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        order=8)
 
         self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='has_children',
-                                       field_type=self.__BOOL_TYPE,
-                                       display_name='Has children',
-                                       is_required=True,
-                                       order=7)
-
-        self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='children_count',
-                                       field_type=self.__DOUBLE_TYPE,
-                                       display_name='Children count',
-                                       order=6)
-
-        self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='parent_id',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Id of Parent',
-                                       order=5)
+                                       order=7)
 
         self._add_primitive_type_field(
             tag_template=tag_template,
             field_id='parent_entry',
             field_type=self.__STRING_TYPE,
             display_name='Data Catalog Entry for the parent Folder',
-            order=4)
+            order=6)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='has_children',
+                                       field_type=self.__BOOL_TYPE,
+                                       display_name='Has children',
+                                       is_required=True,
+                                       order=5)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='child_count',
+                                       field_type=self.__DOUBLE_TYPE,
+                                       display_name='Child count',
+                                       order=4)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='has_dashboards',

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -75,7 +75,7 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         self._add_primitive_type_field(
             tag_template=tag_template,
-            field_id='parent_entry',
+            field_id='parent_folder_entry',
             field_type=self.__STRING_TYPE,
             display_name='Data Catalog Entry for the parent Folder',
             order=6)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
@@ -35,4 +35,5 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
                 continue
 
             cls._map_related_entry(assembled_entry_data, cls.__FOLDER,
-                                   'parent_id', 'parent_entry', id_name_pairs)
+                                   'parent_id', 'parent_folder_entry',
+                                   id_name_pairs)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.datacatalog_connectors.commons import prepare
+
+from google.datacatalog_connectors.sisense.prepare import constants
+
+
+class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
+    __FOLDER = constants.USER_SPECIFIED_TYPE_FOLDER
+
+    def fulfill_tag_fields(self, assembled_entries_data):
+        resolvers = (self.__resolve_folder_mappings,)
+
+        self._fulfill_tag_fields(assembled_entries_data, resolvers)
+
+    @classmethod
+    def __resolve_folder_mappings(cls, assembled_entries_data, id_name_pairs):
+        for assembled_entry_data in assembled_entries_data:
+            entry = assembled_entry_data.entry
+            if not entry.user_specified_type == cls.__FOLDER:
+                continue
+
+            cls._map_related_entry(assembled_entry_data, cls.__FOLDER,
+                                   'parent_id', 'parent_entry', id_name_pairs)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -54,7 +54,8 @@ class RESTAPIHelper:
         self.__set_up_auth()
 
         # Sisense can return the folders in flat (default) or tree structures.
-        # We decided for flat because it simplifies further processing.
+        # We decided for flat because it supports standard pagination handling
+        # (paginating a tree structure would require extra programming effort).
         url = f'{self.__base_api_endpoint}/folders?structure=flat'
         return self.__get_list_using_pagination(base_url=url,
                                                 results_per_page=50)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -17,6 +17,9 @@
 import unittest
 from unittest import mock
 
+from google.cloud import datacatalog
+from google.datacatalog_connectors.commons import prepare as commons_prepare
+
 from google.datacatalog_connectors.sisense import prepare
 
 
@@ -26,9 +29,11 @@ class AssembledEntryFactoryTest(unittest.TestCase):
     __FACTORY_CLASS = f'{__FACTORY_MODULE}.AssembledEntryFactory'
     __PRIVATE_METHOD_PREFIX = f'{__FACTORY_CLASS}._AssembledEntryFactory'
 
+    @mock.patch(f'{__PREPARE_PACKAGE}.datacatalog_tag_factory'
+                f'.DataCatalogTagFactory')
     @mock.patch(f'{__FACTORY_MODULE}.datacatalog_entry_factory'
                 f'.DataCatalogEntryFactory')
-    def setUp(self, mock_entry_factory):
+    def setUp(self, mock_entry_factory, mock_tag_factory):
         self.__factory = prepare.AssembledEntryFactory(
             project_id='test-project',
             location_id='test-location',
@@ -37,6 +42,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             server_address='https://test.server.com')
 
         self.__entry_factory = mock_entry_factory.return_value
+        self.__tag_factory = mock_tag_factory.return_value
 
     def test_constructor_should_set_instance_attributes(self):
         attrs = self.__factory.__dict__
@@ -46,34 +52,57 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             attrs['_AssembledEntryFactory__datacatalog_entry_factory'])
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_tag_template')
     def test_make_assembled_entries_for_folder_should_process_folder(
-            self, make_assembled_entry_for_folder):
+            self, mock_get_tag_template, mock_make_assembled_entry_for_folder):
 
-        make_assembled_entry_for_folder.return_value = ('id', {})
+        folder = self.__make_fake_folder()
+
+        tag_template = datacatalog.TagTemplate()
+        mock_get_tag_template.return_value = tag_template
+
+        mock_make_assembled_entry_for_folder.return_value = \
+            commons_prepare.AssembledEntryData('test-folder', {})
 
         assembled_entries = self.__factory\
             ._AssembledEntryFactory__make_assembled_entries_for_folder(
-                self.__make_fake_folder())
+                folder, {})
 
         self.assertEqual(1, len(assembled_entries))
-        make_assembled_entry_for_folder.assert_called_once()
+        mock_make_assembled_entry_for_folder.assert_called_once_with(
+            folder, tag_template)
 
-    def test_make_assembled_entry_for_folder_should_process_folder(self):
-        fake_entry = ('id', {})
+    def test_make_assembled_entry_for_folder_should_make_entry_and_tags(self):
+        folder = self.__make_fake_folder()
+        tag_template = datacatalog.TagTemplate()
 
+        fake_entry = ('test-folder', {})
         entry_factory = self.__entry_factory
         entry_factory.make_entry_for_folder.return_value = fake_entry
 
+        fake_tag = datacatalog.Tag()
+        fake_tag.template = 'tagTemplates/sisense_folder_metadata'
+        tag_factory = self.__tag_factory
+        tag_factory.make_tag_for_folder.return_value = fake_tag
+
         assembled_entry = self.__factory\
             ._AssembledEntryFactory__make_assembled_entry_for_folder(
-                self.__make_fake_folder())
+                folder, tag_template)
 
-        self.assertEqual('id', assembled_entry.entry_id)
-        entry_factory.make_entry_for_folder.assert_called_once()
+        self.assertEqual('test-folder', assembled_entry.entry_id)
+        self.assertEqual({}, assembled_entry.entry)
+        entry_factory.make_entry_for_folder.assert_called_once_with(folder)
+
+        tags = assembled_entry.tags
+        self.assertEqual(1, len(tags))
+        self.assertEqual('tagTemplates/sisense_folder_metadata',
+                         tags[0].template)
+        tag_factory.make_tag_for_folder.assert_called_once_with(
+            tag_template, folder)
 
     @classmethod
     def __make_fake_folder(cls):
         return {
-            '_id': 'test-folder',
+            'oid': 'test-folder',
             'name': 'Test folder',
         }

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -68,35 +68,33 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         mock_make_assembled_entries_for_folder.assert_called_once()
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_tag_template')
     def test_make_assembled_entries_for_folder_should_process_folder(
-            self, mock_get_tag_template, mock_make_assembled_entry_for_folder):
+            self, mock_make_assembled_entry_for_folder):
 
         folder = self.__make_fake_folder()
 
         tag_template = datacatalog.TagTemplate()
-        mock_get_tag_template.return_value = tag_template
+        tag_templates_dict = {'sisense_folder_metadata': tag_template}
 
         mock_make_assembled_entry_for_folder.return_value = \
             commons_prepare.AssembledEntryData('test-folder', {})
 
         assembled_entries = self.__factory\
             ._AssembledEntryFactory__make_assembled_entries_for_folder(
-                folder, {})
+                folder, tag_templates_dict)
 
         self.assertEqual(1, len(assembled_entries))
         mock_make_assembled_entry_for_folder.assert_called_once_with(
             folder, tag_template)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_tag_template')
     def test_make_assembled_entries_for_folder_should_process_child_folders(
-            self, mock_get_tag_template, mock_make_assembled_entry_for_folder):
+            self, mock_make_assembled_entry_for_folder):
 
         folder = self.__make_fake_folder_with_children()
 
         tag_template = datacatalog.TagTemplate()
-        mock_get_tag_template.return_value = tag_template
+        tag_templates_dict = {'sisense_folder_metadata': tag_template}
 
         mock_make_assembled_entry_for_folder.side_effect = [
             commons_prepare.AssembledEntryData('test-parent-folder', {}),
@@ -105,7 +103,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
         assembled_entries = self.__factory\
             ._AssembledEntryFactory__make_assembled_entries_for_folder(
-                folder, {})
+                folder, tag_templates_dict)
 
         self.assertEqual(2, len(assembled_entries))
         self.assertEqual(2, mock_make_assembled_entry_for_folder.call_count)
@@ -138,30 +136,6 @@ class AssembledEntryFactoryTest(unittest.TestCase):
                          tags[0].template)
         tag_factory.make_tag_for_folder.assert_called_once_with(
             tag_template, folder)
-
-    def test_get_tag_template_should_return_provided_template(self):
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/metadata_template'
-
-        tag_templates_dict = {'metadata_template': tag_template}
-
-        metadata_template = self.__factory\
-            ._AssembledEntryFactory__get_tag_template(
-                'metadata_template', tag_templates_dict)
-
-        self.assertEqual(tag_template, metadata_template)
-
-    def test_get_tag_template_should_return_none_if_not_available(self):
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/metadata_template'
-
-        tag_templates_dict = {'other_metadata_template': tag_template}
-
-        metadata_template = self.__factory\
-            ._AssembledEntryFactory__get_tag_template(
-                'metadata_template', tag_templates_dict)
-
-        self.assertIsNone(metadata_template)
 
     @classmethod
     def __make_fake_folder(cls):

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -51,8 +51,8 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
         make_assembled_entry_for_folder.return_value = ('id', {})
 
-        assembled_entries = \
-            self.__factory.make_assembled_entries_for_folder(
+        assembled_entries = self.__factory\
+            ._AssembledEntryFactory__make_assembled_entries_for_folder(
                 self.__make_fake_folder())
 
         self.assertEqual(1, len(assembled_entries))

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -58,12 +58,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         entry_id, entry = self.__factory.make_entry_for_folder(metadata)
 
-        self.assertEqual('sss_test_server_com_fd_a123_b456', entry_id)
+        self.assertEqual('sss_test_server_com_fd_a123_b457', entry_id)
 
         self.assertEqual(
             'projects/test-project/locations/test-location/'
             'entryGroups/test-entry-group/entries/'
-            'sss_test_server_com_fd_a123_b456', entry.name)
+            'sss_test_server_com_fd_a123_b457', entry.name)
         self.assertEqual('test-system', entry.user_specified_system)
         self.assertEqual('folder', entry.user_specified_type)
         self.assertEqual('Test folder', entry.display_name)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -33,7 +33,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.com',
                          attrs['_DataCatalogTagFactory__server_address'])
 
-    def test_make_tag_for_app_should_set_all_available_fields(self):
+    def test_make_tag_for_folder_should_set_all_available_fields(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_folder_metadata'
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.cloud import datacatalog
+
+from google.datacatalog_connectors.sisense.prepare import \
+    datacatalog_tag_factory
+
+
+class DataCatalogEntryFactoryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.__factory = datacatalog_tag_factory.DataCatalogTagFactory(
+            'https://test.com')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__factory.__dict__
+        self.assertEqual('https://test.com',
+                         attrs['_DataCatalogTagFactory__server_address'])
+
+    def test_make_tag_for_app_should_set_all_available_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_folder_metadata'
+
+        metadata = {
+            'oid': 'test-folder',
+            'name': 'Test folder',
+            'parentId': 'parent-folder',
+            'ownerData': {
+                'userName': 'johndoe@test.com',
+                'firstName': 'John',
+                'lastName': 'Doe',
+            },
+            'folders': [{
+                'oid': 'child-folder',
+            }],
+            'dashboards': [{
+                'oid': 'test-dashboard',
+            }],
+        }
+
+        tag = self.__factory.make_tag_for_folder(tag_template, metadata)
+
+        self.assertEqual('test-folder', tag.fields['id'].string_value)
+        self.assertEqual('Test folder', tag.fields['name'].string_value)
+        self.assertEqual('parent-folder', tag.fields['parent_id'].string_value)
+        self.assertEqual('johndoe@test.com',
+                         tag.fields['owner_username'].string_value)
+        self.assertEqual('John Doe', tag.fields['owner_name'].string_value)
+        self.assertEqual(True, tag.fields['has_children'].bool_value)
+        self.assertEqual(1, tag.fields['child_count'].double_value)
+        self.assertEqual(True, tag.fields['has_dashboards'].bool_value)
+        self.assertEqual(1, tag.fields['dashboard_count'].double_value)
+
+        self.assertEqual('https://test.com',
+                         tag.fields['server_url'].string_value)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.cloud import datacatalog
+
+from google.datacatalog_connectors.sisense.prepare import \
+    datacatalog_tag_template_factory
+
+
+class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
+    __FACTORY_MODULE = f'{__PREPARE_PACKAGE}.datacatalog_tag_template_factory'
+
+    __BOOL_TYPE = datacatalog.FieldType.PrimitiveType.BOOL
+    __DOUBLE_TYPE = datacatalog.FieldType.PrimitiveType.DOUBLE
+    __STRING_TYPE = datacatalog.FieldType.PrimitiveType.STRING
+    __TIMESTAMP_TYPE = datacatalog.FieldType.PrimitiveType.TIMESTAMP
+
+    def setUp(self):
+        self.__factory = datacatalog_tag_template_factory.\
+            DataCatalogTagTemplateFactory('test-project', 'test-location')
+
+    def test_constructor_should_set_instance_attributes(self):
+        attrs = self.__factory.__dict__
+
+        self.assertEqual('test-project',
+                         attrs['_DataCatalogTagTemplateFactory__project_id'])
+        self.assertEqual('test-location',
+                         attrs['_DataCatalogTagTemplateFactory__location_id'])
+
+    def test_make_tag_template_for_folder(self):
+        tag_template = self.__factory.make_tag_template_for_folder()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/sisense_folder_metadata', tag_template.name)
+
+        self.assertEqual('Sisense Folder Metadata', tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['name'].type.primitive_type)
+        self.assertEqual('Name', tag_template.fields['name'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['owner_username'].type.primitive_type)
+        self.assertEqual('Owner username',
+                         tag_template.fields['owner_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['owner_name'].type.primitive_type)
+        self.assertEqual('Owner name',
+                         tag_template.fields['owner_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['parent_id'].type.primitive_type)
+        self.assertEqual('Id of Parent',
+                         tag_template.fields['parent_id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['parent_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the parent Folder',
+                         tag_template.fields['parent_entry'].display_name)
+
+        self.assertEqual(
+            self.__BOOL_TYPE,
+            tag_template.fields['has_children'].type.primitive_type)
+        self.assertEqual('Has children',
+                         tag_template.fields['has_children'].display_name)
+
+        self.assertEqual(
+            self.__DOUBLE_TYPE,
+            tag_template.fields['child_count'].type.primitive_type)
+        self.assertEqual('Child count',
+                         tag_template.fields['child_count'].display_name)
+
+        self.assertEqual(
+            self.__BOOL_TYPE,
+            tag_template.fields['has_dashboards'].type.primitive_type)
+        self.assertEqual('Has dashboards',
+                         tag_template.fields['has_dashboards'].display_name)
+
+        self.assertEqual(
+            self.__DOUBLE_TYPE,
+            tag_template.fields['dashboard_count'].type.primitive_type)
+        self.assertEqual('Dashboard count',
+                         tag_template.fields['dashboard_count'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['server_url'].type.primitive_type)
+        self.assertEqual('Sisense Server Url',
+                         tag_template.fields['server_url'].display_name)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -78,9 +78,10 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
 
         self.assertEqual(
             self.__STRING_TYPE,
-            tag_template.fields['parent_entry'].type.primitive_type)
-        self.assertEqual('Data Catalog Entry for the parent Folder',
-                         tag_template.fields['parent_entry'].display_name)
+            tag_template.fields['parent_folder_entry'].type.primitive_type)
+        self.assertEqual(
+            'Data Catalog Entry for the parent Folder',
+            tag_template.fields['parent_folder_entry'].display_name)
 
         self.assertEqual(
             self.__BOOL_TYPE,

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.cloud import datacatalog
+from google.datacatalog_connectors.commons import \
+    prepare as commons_prepare
+
+from google.datacatalog_connectors.sisense import prepare
+
+
+class EntryRelationshipMapperTest(unittest.TestCase):
+    __PREPARE_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
+    __MAPPER_MODULE = f'{__PREPARE_PACKAGE}.entry_relationship_mapper'
+    __MAPPER_CLASS = f'{__MAPPER_MODULE}.EntryRelationshipMapper'
+
+    def test_fulfill_tag_fields_should_resolve_parent_folder_mapping(self):
+        parent_folder_id = 'parent-folder'
+        parent_folder_entry = self.__make_fake_entry(parent_folder_id,
+                                                     'folder')
+        parent_folder_tag = self.__make_fake_tag(
+            string_fields=(('id', parent_folder_id),))
+
+        folder_id = 'test-folder'
+        folder_entry = self.__make_fake_entry(folder_id, 'folder')
+        string_fields = ('id', folder_id), ('parent_id', parent_folder_id)
+        folder_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        parent_folder_assembled_entry = commons_prepare.AssembledEntryData(
+            parent_folder_id, parent_folder_entry, [parent_folder_tag])
+        folder_assembled_entry = commons_prepare.AssembledEntryData(
+            folder_id, folder_entry, [folder_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [parent_folder_assembled_entry, folder_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'{parent_folder_entry.name}',
+            folder_tag.fields['parent_folder_entry'].string_value)
+
+    @mock.patch(f'{__MAPPER_CLASS}._map_related_entry')
+    def test_resolve_folder_mappings_should_skip_non_folder_entries(
+            self, mock_map_related_entry):
+
+        entry_id = 'test'
+        entry = self.__make_fake_entry(entry_id, 'not-a-folder')
+        tag = self.__make_fake_tag(string_fields=(('id', entry_id),))
+
+        assembled_entry = commons_prepare.AssembledEntryData(
+            entry_id, entry, [tag])
+
+        prepare.EntryRelationshipMapper()\
+            ._EntryRelationshipMapper__resolve_folder_mappings(
+                [assembled_entry], {})
+
+        mock_map_related_entry.assert_not_called()
+
+    @classmethod
+    def __make_fake_entry(cls, entry_id, entry_type):
+        entry = datacatalog.Entry()
+        entry.name = f'fake_entries/{entry_id}'
+        entry.user_specified_type = entry_type
+        return entry
+
+    @classmethod
+    def __make_fake_tag(cls, string_fields=None, double_fields=None):
+        tag = datacatalog.Tag()
+
+        if string_fields:
+            for string_field in string_fields:
+                tag_field = datacatalog.TagField()
+                tag_field.string_value = string_field[1]
+                tag.fields[string_field[0]] = tag_field
+
+        if double_fields:
+            for double_field in double_fields:
+                tag_field = datacatalog.TagField()
+                tag_field.double_value = double_field[1]
+                tag.fields[double_field[0]] = tag_field
+
+        return tag


### PR DESCRIPTION
**- What I did**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Folders.

**- How I did it**
Added the `prepare.DataCatalogTagTemplateFactory`, `prepare.DataCatalogTagFactory`, and prepare.EntryRelationshipMapper classes, and their unit tests as well.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Folders.

PS: This PR is part of the effort to implement #70.