### PR TITLE
Scrape Sisense Dashboards metadata

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -28,6 +28,18 @@ class MetadataScraper:
         self.__api_helper = rest_api_helper.RESTAPIHelper(
             server_address, api_version, username, password)
 
+    def scrape_all_dashboards(self) -> List[Dict[str, Any]]:
+        self.__log_scrape_start('Scraping all Dashboards...')
+        dashboards = self.__api_helper.get_all_dashboards()
+
+        logging.info('')
+        logging.info('  %s Dashboards found:', len(dashboards))
+        for dashboard in dashboards:
+            logging.info('    - %s [%s]', dashboard.get('title'),
+                         dashboard.get('oid'))
+
+        return dashboards
+
     def scrape_all_folders(self) -> List[Dict[str, Any]]:
         self.__log_scrape_start('Scraping all Folders...')
         folders = self.__api_helper.get_all_folders()
@@ -36,7 +48,7 @@ class MetadataScraper:
         logging.info('  %s Folders found:', len(folders))
         for folder in folders:
             logging.info('    - %s [%s]', folder.get('name'),
-                         folder.get('_id'))
+                         folder.get('oid'))
 
         return folders
 
@@ -46,7 +58,7 @@ class MetadataScraper:
 
         logging.info('')
         logging.info('  User found: %s %s', user.get('firstName'),
-                     user.get('lastName'))
+                     user.get('lastName') or '')
 
         return user
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -58,13 +58,16 @@ class RESTAPIHelper:
         # ``GET /dashboards`` currently does not support pagination.
         all_dashboards = self.__get_response_body_or_raise(response)
 
-        # ``GET /dashboards`` returns summary objects for dashboards that
-        # are shared with the current user and we need to perform subsequent
-        # API calls to get their detailed metadata.
+        # ``GET /dashboards`` returns an array containing a mix of summary
+        # objects for dashboards that are shared with the current user and full
+        # objects for dashboards that are owned by the user. Such summary
+        # objects contain only the ``oid`` and ``lastPublish`` fields.
         #
-        # Summary objects currently contain only the ``oid`` and
-        # ``lastPublish`` fields, so we check for the presence of ``_id`` to
-        # determine whether an object refers to a shared dashboard or not.
+        # So, we check the presence of ``_id`` to determine whether an object
+        # refers to a shared dashboard or not. If ``_id`` is absent, we need to
+        # perform extra API calls to ``GET dashboards/{id}``, passing ``oid``
+        # as parameter, in order to get detailed metadata for each shared
+        # dashboard.
         shared_dashboards = [
             dashboard for dashboard in all_dashboards
             if not dashboard.get('_id')

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -38,9 +38,23 @@ class MetadataScraperTest(unittest.TestCase):
         self.assertEqual(self.__mock_api_helper,
                          attrs['_MetadataScraper__api_helper'])
 
+    def test_scrape_all_dashboards_should_delegate_to_api_helper(self):
+        dashboards_metadata = [{
+            'oid': 'dashboard-id',
+        }]
+
+        api_helper = self.__mock_api_helper
+        api_helper.get_all_dashboards.return_value = dashboards_metadata
+
+        dashboards = self.__scraper.scrape_all_dashboards()
+
+        self.assertEqual(1, len(dashboards))
+        self.assertEqual('dashboard-id', dashboards[0]['oid'])
+        api_helper.get_all_dashboards.assert_called_once()
+
     def test_scrape_all_folders_should_delegate_to_api_helper(self):
         folders_metadata = [{
-            '_id': 'folder-id',
+            'oid': 'folder-id',
         }]
 
         api_helper = self.__mock_api_helper
@@ -49,7 +63,7 @@ class MetadataScraperTest(unittest.TestCase):
         folders = self.__scraper.scrape_all_folders()
 
         self.assertEqual(1, len(folders))
-        self.assertEqual('folder-id', folders[0]['_id'])
+        self.assertEqual('folder-id', folders[0]['oid'])
         api_helper.get_all_folders.assert_called_once()
 
     def test_scrape_user_should_delegate_to_api_helper(self):

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
@@ -52,17 +52,65 @@ class RESTAPIHelperTest(unittest.TestCase):
         attrs = self.__helper.__dict__
         self.assertIsNone(attrs['_RESTAPIHelper__auth_credentials'])
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_response_body_or_raise')
+    @mock.patch(f'{__HELPER_MODULE}.requests', mock.MagicMock())
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_all_dashboards_should_return_list_on_success(
+            self, mock_get_response_body_or_raise):
+
+        mock_get_response_body_or_raise.return_value = [{
+            '_id': 'dashboard-id'
+        }]
+
+        dashboards = self.__helper.get_all_dashboards()
+
+        self.assertEqual(1, len(dashboards))
+        self.assertEqual('dashboard-id', dashboards[0]['_id'])
+
+    @mock.patch(f'{__HELPER_CLASS}.get_dashboard')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_response_body_or_raise')
+    @mock.patch(f'{__HELPER_MODULE}.requests', mock.MagicMock())
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_all_dashboards_should_get_detail_of_shared_dashboards(
+            self, mock_get_response_body_or_raise, mock_get_dashboard):
+
+        mock_get_response_body_or_raise.return_value = [{
+            'oid': 'dashboard-oid'
+        }]
+
+        mock_get_dashboard.return_value = {'_id': 'dashboard-id'}
+
+        dashboards = self.__helper.get_all_dashboards()
+
+        self.assertEqual(1, len(dashboards))
+        self.assertEqual('dashboard-id', dashboards[0]['_id'])
+        mock_get_dashboard.assert_called_once_with('dashboard-oid')
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_response_body_or_raise')
+    @mock.patch(f'{__HELPER_MODULE}.requests', mock.MagicMock())
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_dashboard_should_return_object_on_success(
+            self, mock_get_response_body_or_raise):
+
+        mock_get_response_body_or_raise.return_value = {
+            'oid': 'dashboard-id',
+        }
+
+        dashboard = self.__helper.get_dashboard('dashboard-id')
+
+        self.assertEqual('dashboard-id', dashboard['oid'])
+
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_list_using_pagination')
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
     def test_get_all_folders_should_return_list_on_success(
             self, mock_get_list_using_pagination):
 
-        mock_get_list_using_pagination.return_value = [{'_id': 'folder-id'}]
+        mock_get_list_using_pagination.return_value = [{'oid': 'folder-id'}]
 
         folders = self.__helper.get_all_folders()
 
         self.assertEqual(1, len(folders))
-        self.assertEqual('folder-id', folders[0]['_id'])
+        self.assertEqual('folder-id', folders[0]['oid'])
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_list_using_pagination')
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
@@ -83,14 +131,12 @@ class RESTAPIHelperTest(unittest.TestCase):
             self, mock_get_response_body_or_raise):
 
         mock_get_response_body_or_raise.return_value = {
-            '_id': 'user-id',
-            'firstName': 'Jane',
-            'lastName': 'Doe'
+            'oid': 'user-id',
         }
 
         user = self.__helper.get_user('user-id')
 
-        self.assertEqual('user-id', user['_id'])
+        self.assertEqual('user-id', user['oid'])
 
     @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
     def test_set_up_auth_should_set_credentials_if_not_authenticated(
@@ -131,15 +177,15 @@ class RESTAPIHelperTest(unittest.TestCase):
             self, mock_requests, mock_get_response_body_or_raise):
 
         mock_get_response_body_or_raise.side_effect = [[{
-            '_id': 'object-id-1'
+            'oid': 'object-id-1'
         }, {
-            '_id': 'object-id-2'
+            'oid': 'object-id-2'
         }], [{
-            '_id': 'object-id-3'
+            'oid': 'object-id-3'
         }, {
-            '_id': 'object-id-4'
+            'oid': 'object-id-4'
         }], [{
-            '_id': 'object-id-5'
+            'oid': 'object-id-5'
         }]]
 
         results = self.__helper._RESTAPIHelper__get_list_using_pagination(
@@ -169,11 +215,11 @@ class RESTAPIHelperTest(unittest.TestCase):
             self, mock_get_response_body_or_raise):
 
         mock_get_response_body_or_raise.side_effect = [[{
-            '_id': 'object-id-1'
+            'oid': 'object-id-1'
         }, {
-            '_id': 'object-id-2'
+            'oid': 'object-id-2'
         }], [{
-            '_id': 'object-id-2'
+            'oid': 'object-id-2'
         }]]
 
         results = self.__helper._RESTAPIHelper__get_list_using_pagination(
@@ -185,10 +231,10 @@ class RESTAPIHelperTest(unittest.TestCase):
     def test_get_response_body_or_raise_should_get_on_success(self):
         body = rest_api_helper.RESTAPIHelper\
             ._RESTAPIHelper__get_response_body_or_raise(
-                metadata_scraper_mocks.FakeResponse({'_id': 'object-id'}))
+                metadata_scraper_mocks.FakeResponse({'oid': 'object-id'}))
 
         self.assertIsNotNone(body)
-        self.assertEqual('object-id', body['_id'])
+        self.assertEqual('object-id', body['oid'])
 
     def test_get_response_body_or_raise_should_raise_on_api_error(self):
         self.assertRaises(


### PR DESCRIPTION
**- What I did**
1. Added support for Sisense Dashboards metadata scraping.
2. I've also changed the REST API results pagination/deduping logic because I found a minor bug while working on the present feature (in a nutshell: `tuple()` does not work seamlessly with dicts that contain _complex_ values such as lists). I realized that pagination is not supported by `GET /dashboards` yet, but it was a bit late, so I decided to keep the fix to avoid trouble with the coming objects to be scraped.

**- How I did it**
The main change comprises 3 new methods and their unit tests:
1. `MetadataScraper.scrape_all_dashboards()`
2. `RESTAPIHelper.get_all_dashboards()`
3. `RESTAPIHelper.get_dashboard()`

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added support for Sisense Dashboards metadata scraping.

PS: This PR is part of the effort to deliver feature #70.