### PR TITLE
Prepare the Dashboard entries

### DIFF
--- a/google-datacatalog-sisense-connector/docs/design-decisions.md
+++ b/google-datacatalog-sisense-connector/docs/design-decisions.md
@@ -1,5 +1,23 @@
 # Design decisions
 
+## Assets identification: `_id` vs `oid`
+
+Many Sisense assets have two unique identifiers: `_id` and `oid`. We asked
+Sisense folks about the purpose of these fields concerning folders and
+dashboards, and got the below answer:
+
+> The `oid` is the ID used for tied dashboard entity and folder entity while
+`_id` is just an ID used within our application database as it is required to
+have a unique ID for each record (collection) basically. This said, if you plan
+to use the API you can ignore the `_id` as it is not used for the application
+logic. The dashboards have a parameter called `parentFolder` which gets the
+folder `oid` in it whenever you create a dashboard inside folder.
+
+That being said, we decided to use `oid` and ignore `_id` when both fields are
+available for the same entity (no matter its type). The chosen ID field is used
+to build linked resources (URLs that connect Data Catalog entries to Sisense UI
+elements) and parent-child relationships through Data Catalog tags.
+
 ## Assets' ownership metadata handling
 
 Folders, dashboards, and widgets have an `owner` field, returned in the format

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -18,6 +18,7 @@
 ENTRY_ID_PREFIX = 'sss_'
 # The below asset type specific strings are appended to the standard
 # ENTRY_ID_PREFIX when generating Sisense Entry IDs.
+ENTRY_ID_PART_DASHBOARD = 'db_'
 ENTRY_ID_PART_FOLDER = 'fd_'
 
 # The Sisense type for Folder assets.
@@ -27,5 +28,7 @@ SISENSE_ASSET_TYPE_FOLDER = 'folder'
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 
+# The user specified type of Dashboard-related Entries.
+USER_SPECIFIED_TYPE_DASHBOARD = 'dashboard'
 # The user specified type of Folder-related Entries.
 USER_SPECIFIED_TYPE_FOLDER = 'folder'

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -70,8 +70,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('Test dashboard', entry.display_name)
         self.assertEqual('Test dashboard description', entry.description)
         self.assertEqual(
-            'https://test.server.com/app/main#/dashboards'
-            '/a123-b457', entry.linked_resource)
+            'https://test.server.com/app/main#/dashboards/a123-b457',
+            entry.linked_resource)
 
         created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
                                              self.__DATETIME_FORMAT)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -47,6 +47,75 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.server.com',
                          attrs['_DataCatalogEntryFactory__server_address'])
 
+    def test_make_entry_for_dashboard_should_set_all_available_fields(self):
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test dashboard',
+            'desc': 'Test dashboard description',
+            'created': '2019-09-12T16:30:00.005Z',
+            'lastUpdated': '2019-09-12T16:31:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_dashboard(metadata)
+
+        self.assertEqual('sss_test_server_com_db_a123_b457', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'sss_test_server_com_db_a123_b457', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('dashboard', entry.user_specified_type)
+        self.assertEqual('Test dashboard', entry.display_name)
+        self.assertEqual('Test dashboard description', entry.description)
+        self.assertEqual(
+            'https://test.server.com/app/main#/dashboards'
+            '/a123-b457', entry.linked_resource)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_dashboard_should_succeed_on_missing_created_date(
+            self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test dashboard',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_dashboard(metadata)
+
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+
+    def test_make_entry_for_dashboard_should_use_created_on_no_updated_date(
+            self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test dashboard',
+            'created': '2019-09-12T16:30:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_dashboard(metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
     def test_make_entry_for_folder_should_set_all_available_fields(self):
         metadata = {
             '_id': 'a123-b456',


### PR DESCRIPTION
**- What I did**
Added the feature that allows Sisense Connector to prepare Dashboard entries.
The tags will be tackled in the next PR.

**- How I did it**
Added the `prepare.DataCatalogEntryFactory.make_entry_for_dashboard()` method, and its unit tests.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added the feature that allows Sisense Connector to prepare Dashboard entries.

PS: This PR is part of the effort to deliver feature #70.