### PR TITLE
Prepare the Dashboard tags

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -25,6 +25,9 @@ ENTRY_ID_PART_FOLDER = 'fd_'
 SISENSE_ASSET_TYPE_FOLDER = 'folder'
 
 # The ID of the Tag Template created to store additional metadata for
+# Dashboard-related Entries.
+TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
+# The ID of the Tag Template created to store additional metadata for
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -31,6 +31,76 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
         self.__project_id = project_id
         self.__location_id = location_id
 
+    def make_tag_template_for_dashboard(self) -> TagTemplate:
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_DASHBOARD)
+
+        tag_template.display_name = 'Sisense Dashboard Metadata'
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Id',
+                                       is_required=True,
+                                       order=9)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_username',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner username',
+                                       is_required=True,
+                                       order=8)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner name',
+                                       order=7)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='folder_id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Folder Id',
+                                       order=6)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='folder_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Folder Name',
+                                       order=5)
+
+        self._add_primitive_type_field(
+            tag_template=tag_template,
+            field_id='folder_entry',
+            field_type=self.__STRING_TYPE,
+            display_name='Data Catalog Entry for the Folder',
+            order=4)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='datasource',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Data Source',
+                                       order=3)
+
+        self._add_primitive_type_field(
+            tag_template=tag_template,
+            field_id='last_publish',
+            field_type=self.__TIMESTAMP_TYPE,
+            display_name='Time it was last published',
+            order=2)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='last_opened',
+                                       field_type=self.__TIMESTAMP_TYPE,
+                                       display_name='Time it was last opened',
+                                       order=1)
+
+        return tag_template
+
     def make_tag_template_for_folder(self) -> TagTemplate:
         tag_template = datacatalog.TagTemplate()
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -46,57 +46,64 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        field_type=self.__STRING_TYPE,
                                        display_name='Id',
                                        is_required=True,
-                                       order=9)
+                                       order=10)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='owner_username',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Owner username',
                                        is_required=True,
-                                       order=8)
+                                       order=9)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='owner_name',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Owner name',
-                                       order=7)
+                                       order=8)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='folder_id',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Folder Id',
-                                       order=6)
+                                       order=7)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='folder_name',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Folder Name',
-                                       order=5)
+                                       order=6)
 
         self._add_primitive_type_field(
             tag_template=tag_template,
             field_id='folder_entry',
             field_type=self.__STRING_TYPE,
             display_name='Data Catalog Entry for the Folder',
-            order=4)
+            order=5)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='datasource',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Data Source',
-                                       order=3)
+                                       order=4)
 
         self._add_primitive_type_field(
             tag_template=tag_template,
             field_id='last_publish',
             field_type=self.__TIMESTAMP_TYPE,
             display_name='Time it was last published',
-            order=2)
+            order=3)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='last_opened',
                                        field_type=self.__TIMESTAMP_TYPE,
                                        display_name='Time it was last opened',
+                                       order=2)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='server_url',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Sisense Server Url',
+                                       is_required=True,
                                        order=1)
 
         return tag_template

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
@@ -20,12 +20,25 @@ from google.datacatalog_connectors.sisense.prepare import constants
 
 
 class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
+    __DASHBOARD = constants.USER_SPECIFIED_TYPE_DASHBOARD
     __FOLDER = constants.USER_SPECIFIED_TYPE_FOLDER
 
     def fulfill_tag_fields(self, assembled_entries_data):
-        resolvers = (self.__resolve_folder_mappings,)
+        resolvers = (self.__resolve_dashboard_mappings,
+                     self.__resolve_folder_mappings)
 
         self._fulfill_tag_fields(assembled_entries_data, resolvers)
+
+    @classmethod
+    def __resolve_dashboard_mappings(cls, assembled_entries_data,
+                                     id_name_pairs):
+        for assembled_entry_data in assembled_entries_data:
+            entry = assembled_entry_data.entry
+            if not entry.user_specified_type == cls.__DASHBOARD:
+                continue
+
+            cls._map_related_entry(assembled_entry_data, cls.__FOLDER,
+                                   'folder_id', 'folder_entry', id_name_pairs)
 
     @classmethod
     def __resolve_folder_mappings(cls, assembled_entries_data, id_name_pairs):

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -102,6 +102,11 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual('Time it was last opened',
                          tag_template.fields['last_opened'].display_name)
 
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['server_url'].type.primitive_type)
+        self.assertEqual('Sisense Server Url',
+                         tag_template.fields['server_url'].display_name)
+
     def test_make_tag_template_for_folder(self):
         tag_template = self.__factory.make_tag_template_for_folder()
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -43,6 +43,65 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual('test-location',
                          attrs['_DataCatalogTagTemplateFactory__location_id'])
 
+    def test_make_tag_template_for_dashboard(self):
+        tag_template = self.__factory.make_tag_template_for_dashboard()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/sisense_dashboard_metadata', tag_template.name)
+
+        self.assertEqual('Sisense Dashboard Metadata',
+                         tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Id', tag_template.fields['id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['owner_username'].type.primitive_type)
+        self.assertEqual('Owner username',
+                         tag_template.fields['owner_username'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['owner_name'].type.primitive_type)
+        self.assertEqual('Owner name',
+                         tag_template.fields['owner_name'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['folder_id'].type.primitive_type)
+        self.assertEqual('Folder Id',
+                         tag_template.fields['folder_id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['folder_name'].type.primitive_type)
+        self.assertEqual('Folder Name',
+                         tag_template.fields['folder_name'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['folder_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the Folder',
+                         tag_template.fields['folder_entry'].display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['datasource'].type.primitive_type)
+        self.assertEqual('Data Source',
+                         tag_template.fields['datasource'].display_name)
+
+        self.assertEqual(
+            self.__TIMESTAMP_TYPE,
+            tag_template.fields['last_publish'].type.primitive_type)
+        self.assertEqual('Time it was last published',
+                         tag_template.fields['last_publish'].display_name)
+
+        self.assertEqual(
+            self.__TIMESTAMP_TYPE,
+            tag_template.fields['last_opened'].type.primitive_type)
+        self.assertEqual('Time it was last opened',
+                         tag_template.fields['last_opened'].display_name)
+
     def test_make_tag_template_for_folder(self):
         tag_template = self.__factory.make_tag_template_for_folder()
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -30,6 +30,29 @@ class EntryRelationshipMapperTest(unittest.TestCase):
     __MAPPER_MODULE = f'{__PREPARE_PACKAGE}.entry_relationship_mapper'
     __MAPPER_CLASS = f'{__MAPPER_MODULE}.EntryRelationshipMapper'
 
+    def test_fulfill_tag_fields_should_resolve_dashboard_folder_mapping(self):
+        folder_id = 'parent-folder'
+        folder_entry = self.__make_fake_entry(folder_id, 'folder')
+        folder_tag = self.__make_fake_tag(string_fields=(('id', folder_id),))
+
+        dashboard_id = 'test-dashboard'
+        dashboard_entry = self.__make_fake_entry(dashboard_id, 'dashboard')
+        string_fields = ('id', dashboard_id), ('folder_id', folder_id)
+        dashboard_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        folder_assembled_entry = commons_prepare.AssembledEntryData(
+            folder_id, folder_entry, [folder_tag])
+        dashboard_assembled_entry = commons_prepare.AssembledEntryData(
+            dashboard_id, dashboard_entry, [dashboard_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [folder_assembled_entry, dashboard_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'{folder_entry.name}',
+            dashboard_tag.fields['folder_entry'].string_value)
+
     def test_fulfill_tag_fields_should_resolve_parent_folder_mapping(self):
         parent_folder_id = 'parent-folder'
         parent_folder_entry = self.__make_fake_entry(parent_folder_id,

--- a/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
@@ -70,6 +70,9 @@ def __delete_entries_and_groups(project_ids: List[str]) -> None:
 def __delete_tag_templates(project_id: str, location_id: str) -> None:
     __delete_tag_template(
         datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'sisense_dashboard_metadata'))
+    __delete_tag_template(
+        datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'sisense_folder_metadata'))
 
 


### PR DESCRIPTION
**- What I did**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Dashboards.

**- How I did it**
Added the below methods and their unit tests as well:
- `prepare.DataCatalogTagTemplateFactory.make_tag_template_for_dashboard()`
- `prepare.DataCatalogTagFactory.make_tag_for_dashboard()`
- `prepare.EntryRelationshipMapper.__resolve_dashboard_mappings()`

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Dashboards.

PS: This PR is part of the effort to implement #70.