### PR TITLE
Add the Docker-related files

### DIFF
--- a/google-datacatalog-sisense-connector/.dockerignore
+++ b/google-datacatalog-sisense-connector/.dockerignore
@@ -1,0 +1,119 @@
+# Git
+.git
+.gitignore
+
+# Docker
+.dockerignore
+Dockerfile
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# PyCharm
+.DS_Store
+.idea
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Application logs
+log/

--- a/google-datacatalog-sisense-connector/Dockerfile
+++ b/google-datacatalog-sisense-connector/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.6 as builder
+
+# Set the GOOGLE_APPLICATION_CREDENTIALS environment variable.
+# At run time, /data must be binded to a volume containing a valid Service
+# Account credentials file named sisense2dc-datacatalog-credentials.json.
+ENV GOOGLE_APPLICATION_CREDENTIALS=/data/sisense2dc-datacatalog-credentials.json
+
+WORKDIR /app
+
+# Copy project files (see .dockerignore).
+COPY . .
+
+# QUALITY ASSURANCE
+FROM builder as qa
+
+# Run static code checks.
+RUN pip install flake8 yapf
+RUN yapf --diff --recursive src tests
+RUN flake8 src tests
+
+# Run the unit tests.
+RUN python setup.py test
+# END OF QUALITY ASSURANCE STEPS
+
+# RESUME THE IMAGE BUILD PROCESS
+FROM builder as run
+
+# Install the connector from source files.
+RUN pip install .
+
+ENTRYPOINT ["google-datacatalog-sisense-connector"]


### PR DESCRIPTION
**- What I did**
Added files that make it easier for users to run the connector using Docker.

**- How I did it**
Added the `Dockerfile` and `.dockerignore` files.

**- How to verify it**
Build a Docker image and run the connector using it:
```shell script
docker build --rm --tag sisense2datacatalog .
docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
  sisense2datacatalog \
  --sisense-server $SISENSE2DC_SISENSE_SERVER \
  --sisense-username $SISENSE2DC_SISENSE_USERNAME \
  --sisense-password $SISENSE2DC_SISENSE_PASSWORD \
  --datacatalog-project-id $SISENSE2DC_DATACATALOG_PROJECT_ID \
  [--datacatalog-location-id $SISENSE2DC_DATACATALOG_LOCATION_ID]
```
> More docs on how to run the connector are coming soon.

**- Description for the changelog**
Added files that make it easier for users to run the connector using Docker.

PS: This PR is part of the effort to deliver feature #70.