### PR TITLE
Standardize the design decisions documentation

### DIFF
--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -38,16 +38,14 @@ currently supporting below asset types:
 - [3. Running the connector](#3-running-the-connector)
   * [3.1. Python entry point](#31-python-entry-point)
   * [3.2. Docker entry point](#32-docker-entry-point)
-- [4. Design decisions](#4-design-decisions)
-  * [4.1. Tag Templates for Custom Property Choice Values](#41-tag-templates-for-custom-property-choice-values)
-- [5. Developer environment](#5-developer-environment)
-  * [5.1. Install and run Yapf formatter](#51-install-and-run-yapf-formatter)
-  * [5.2. Install and run Flake8 linter](#52-install-and-run-flake8-linter)
-  * [5.3. Run Tests](#53-run-tests)
-  * [5.4. Additional resources](#54-additional-resources)
-- [6. Troubleshooting](#6-troubleshooting)
-  * [6.1. Qlik APIs compatibility](#61-qlik-apis-compatibility)
-  * [6.2. Data Catalog quota](#62-data-catalog-quota)
+- [4. Developer environment](#4-developer-environment)
+  * [4.1. Install and run the YAPF formatter](#41-install-and-run-the-yapf-formatter)
+  * [4.2. Install and run the Flake8 linter](#42-install-and-run-the-flake8-linter)
+  * [4.3. Run Tests](#43-run-tests)
+  * [4.4. Additional resources](#44-additional-resources)
+- [5. Troubleshooting](#5-troubleshooting)
+  * [5.1. Qlik APIs compatibility](#51-qlik-apis-compatibility)
+  * [5.2. Data Catalog quota](#52-data-catalog-quota)
 
 <!-- tocstop -->
 
@@ -174,29 +172,9 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   [--datacatalog-location-id $QLIK2DC_DATACATALOG_LOCATION_ID]
 ```
 
-## 4. Design decisions
+## 4. Developer environment
 
-### 4.1. Tag Templates for Custom Property Choice Values
-
-The current implementation creates a Tag Template for each Custom Property 
-Choice Value assigned to Streams or Apps in the provided Qlik Sense site. The
-rationale behind this decision comprises allowing the connector to synchronize
-all metadata scraped from each Custom Property, at the same time it enables
-Qlik assets to be easily found by their custom properties — using query strings
-such as `tag:property_name:"<PROPERTY-NAME>"` and `tag:value:"<SOME-VALUE>"`.
-
-Data Catalog accepts attaching only one Tag per Template to a given Entry, so
-there could be metadata loss if the Tag Templates were created in different
-ways, e.g. on a Custom Property Definition basis.
-
-Lastly, this approach may lead to the creation of several Tag Templates if
-there are many Custom Property Values in use in your Qlik Sense site. In case
-you would like to suggest a different approach to tackle this problem, please
-[file a feature request][3]. We will be happy to discuss alternative solutions! 
-
-## 5. Developer environment
-
-### 5.1. Install and run Yapf formatter
+### 4.1. Install and run the YAPF formatter
 
 ```shell script
 pip install --upgrade yapf
@@ -214,27 +192,27 @@ chmod a+x pre-commit.sh
 mv pre-commit.sh .git/hooks/pre-commit
 ```
 
-### 5.2. Install and run Flake8 linter
+### 4.2. Install and run the Flake8 linter
 
 ```shell script
 pip install --upgrade flake8
 flake8 src tests
 ```
 
-### 5.3. Run Tests
+### 4.3. Run Tests
 
 ```shell script
 python setup.py test
 ```
 
-### 5.4. Additional resources
+### 4.4. Additional resources
 
 Please refer to the [Developer Resources
 documentation](docs/developer-resources).
 
-## 6. Troubleshooting
+## 5. Troubleshooting
 
-### 6.1. Qlik APIs compatibility
+### 5.1. Qlik APIs compatibility
 
 The connector may fail during the scrape stage if the Qlik APIs do not return
 metadata in the expected format. As a reference, the below versions were
@@ -252,7 +230,7 @@ already validated:
 | ------------------------ | :-----: |
 | 12.763.4 (September2020) | SUCCESS |
 
-### 6.2. Data Catalog quota
+### 5.2. Data Catalog quota
 
 In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed
@@ -265,9 +243,8 @@ debug_error_string =
 "{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
 ```
 
-For more information on Data Catalog quota, please refer to: [Data Catalog
-quota docs][2].
+For more information on Data Catalog quota, please refer to the [product
+documentation][2].
 
 [1]: https://virtualenv.pypa.io/en/latest/
 [2]: https://cloud.google.com/data-catalog/docs/resources/quotas
-[3]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues

--- a/google-datacatalog-qlik-connector/docs/README.md
+++ b/google-datacatalog-qlik-connector/docs/README.md
@@ -2,7 +2,8 @@
 
 This directory contains additional documentation on the connector.
 
-- [Developer Resources](developer-resources)
+- [Design decisions](design-decisions.md)
+- [Developer resources](developer-resources)
 
 ---
 

--- a/google-datacatalog-qlik-connector/docs/design-decisions.md
+++ b/google-datacatalog-qlik-connector/docs/design-decisions.md
@@ -1,0 +1,25 @@
+# Design decisions
+
+## Tag Templates for Custom Property Choice Values
+
+The current implementation creates a Tag Template for each Custom Property 
+Choice Value assigned to Streams or Apps in the provided Qlik Sense site. The
+rationale behind this decision comprises allowing the connector to synchronize
+all metadata scraped from each Custom Property, at the same time it enables
+Qlik assets to be easily found by their custom properties — using query strings
+such as `tag:property_name:"<PROPERTY-NAME>"` and `tag:value:"<SOME-VALUE>"`.
+
+Data Catalog accepts attaching only one Tag per Template to a given Entry, so
+there could be metadata loss if the Tag Templates were created in different
+ways, e.g. on a Custom Property Definition basis.
+
+Lastly, this approach may lead to the creation of several Tag Templates if
+there are many Custom Property Values in use in your Qlik Sense site. In case
+you would like to suggest a different approach to tackle this problem, please
+[file a feature
+request](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues).
+We will be happy to discuss alternative solutions! 
+
+---
+
+Back to the [Documentation index](README.md)


### PR DESCRIPTION
**- What I did**
Moved the Qlik connector's design decisions documentation to the `docs` folder to keep it consistent with the file structure that has been used in the Sisense connector. The proposed structure is clearer as it promotes specific content in the `docs` folder instead of adding sections to the main `README.md` file.

**- How I did it**
1. Created and fulfilled the `docs/design-decisions.md` file.
2. Deleted the design decisions section of Qlik connector's main `README.md`.

**- Description for the changelog**
Moved the Qlik connector's design decisions documentation to the `docs` folder.
