### PR TITLE
Synchronize the Dashboard metadata

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -49,6 +49,11 @@ class AssembledEntryFactory:
             assembled_entries.extend(
                 self.__make_assembled_entries_for_folder(
                     asset_metadata, tag_templates))
+        elif constants.SISENSE_ASSET_TYPE_DASHBOARD == asset_metadata.get(
+                'type'):
+            assembled_entries.append(
+                self.__make_assembled_entry_for_dashboard(
+                    asset_metadata, tag_templates))
 
         return assembled_entries
 
@@ -56,34 +61,55 @@ class AssembledEntryFactory:
             self, folder_metadata: Dict[str, Any],
             tag_templates: Dict[str, TagTemplate]) -> List[AssembledEntryData]:
 
-        folder_tag_template = tag_templates.get(
-            constants.TAG_TEMPLATE_ID_FOLDER)
-
         assembled_entries = [
             self.__make_assembled_entry_for_folder(folder_metadata,
-                                                   folder_tag_template)
+                                                   tag_templates)
         ]
 
         for child_folder in folder_metadata.get('folders') or []:
             assembled_entries.extend(
                 self.__make_assembled_entries_for_folder(
                     child_folder, tag_templates))
+        for dashboard in folder_metadata.get('dashboards') or []:
+            assembled_entries.append(
+                self.__make_assembled_entry_for_dashboard(
+                    dashboard, tag_templates))
 
         return assembled_entries
 
     def __make_assembled_entry_for_folder(
             self, folder_metadata: Dict[str, Any],
-            tag_template: TagTemplate) -> AssembledEntryData:
+            tag_templates: Dict[str, TagTemplate]) -> AssembledEntryData:
 
         entry_id, entry = \
             self.__datacatalog_entry_factory.make_entry_for_folder(
                 folder_metadata)
 
         tags = []
+        tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_FOLDER)
         if tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_folder(
                     tag_template, folder_metadata))
+
+        return prepare.AssembledEntryData(entry_id=entry_id,
+                                          entry=entry,
+                                          tags=tags)
+
+    def __make_assembled_entry_for_dashboard(
+            self, dashboard_metadata: Dict[str, Any],
+            tag_templates: Dict[str, TagTemplate]) -> AssembledEntryData:
+
+        entry_id, entry = \
+            self.__datacatalog_entry_factory.make_entry_for_dashboard(
+                dashboard_metadata)
+
+        tags = []
+        tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_DASHBOARD)
+        if tag_template:
+            tags.append(
+                self.__datacatalog_tag_factory.make_tag_for_dashboard(
+                    tag_template, dashboard_metadata))
 
         return prepare.AssembledEntryData(entry_id=entry_id,
                                           entry=entry,

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -21,6 +21,8 @@ ENTRY_ID_PREFIX = 'sss_'
 ENTRY_ID_PART_DASHBOARD = 'db_'
 ENTRY_ID_PART_FOLDER = 'fd_'
 
+# The Sisense type for Dashboard assets.
+SISENSE_ASSET_TYPE_DASHBOARD = 'dashboard'
 # The Sisense type for Folder assets.
 SISENSE_ASSET_TYPE_FOLDER = 'folder'
 
@@ -32,6 +34,6 @@ TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 
 # The user specified type of Dashboard-related Entries.
-USER_SPECIFIED_TYPE_DASHBOARD = 'dashboard'
+USER_SPECIFIED_TYPE_DASHBOARD = 'Dashboard'
 # The user specified type of Folder-related Entries.
-USER_SPECIFIED_TYPE_FOLDER = 'folder'
+USER_SPECIFIED_TYPE_FOLDER = 'Folder'

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -73,9 +73,9 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             self, mock_make_assembled_entry_for_folder):
 
         folder = self.__make_fake_folder()
-
-        tag_template = datacatalog.TagTemplate()
-        tag_templates_dict = {'sisense_folder_metadata': tag_template}
+        tag_templates_dict = {
+            'sisense_folder_metadata': datacatalog.TagTemplate()
+        }
 
         mock_make_assembled_entry_for_folder.return_value = \
             commons_prepare.AssembledEntryData('test-folder', {})
@@ -86,16 +86,16 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual(1, len(assembled_entries))
         mock_make_assembled_entry_for_folder.assert_called_once_with(
-            folder, tag_template)
+            folder, tag_templates_dict)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
     def test_make_assembled_entries_for_folder_should_process_child_folders(
             self, mock_make_assembled_entry_for_folder):
 
         folder = self.__make_fake_folder_with_children()
-
-        tag_template = datacatalog.TagTemplate()
-        tag_templates_dict = {'sisense_folder_metadata': tag_template}
+        tag_templates_dict = {
+            'sisense_folder_metadata': datacatalog.TagTemplate()
+        }
 
         mock_make_assembled_entry_for_folder.side_effect = [
             commons_prepare.AssembledEntryData('test-parent-folder', {}),
@@ -113,6 +113,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         folder = self.__make_fake_folder()
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_folder_metadata'
+        tag_templates_dict = {'sisense_folder_metadata': tag_template}
 
         fake_entry = ('test-folder', {})
         entry_factory = self.__mock_entry_factory
@@ -125,7 +126,7 @@ class AssembledEntryFactoryTest(unittest.TestCase):
 
         assembled_entry = self.__factory\
             ._AssembledEntryFactory__make_assembled_entry_for_folder(
-                folder, tag_template)
+                folder, tag_templates_dict)
 
         self.assertEqual('test-folder', assembled_entry.entry_id)
         self.assertEqual({}, assembled_entry.entry)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -68,6 +68,22 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(assembled_entries))
         mock_make_assembled_entries_for_folder.assert_called_once()
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}'
+                f'__make_assembled_entry_for_dashboard')
+    def test_make_assembled_entries_list_should_process_dashboards(
+            self, mock_make_assembled_entry_for_dashboard):
+
+        dashboard = self.__make_fake_dashboard()
+
+        mock_make_assembled_entry_for_dashboard.return_value = \
+            commons_prepare.AssembledEntryData('test-dashboard', {})
+
+        assembled_entries = self.__factory.make_assembled_entries_list(
+            dashboard, {})
+
+        self.assertEqual(1, len(assembled_entries))
+        mock_make_assembled_entry_for_dashboard.assert_called_once()
+
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
     def test_make_assembled_entries_for_folder_should_process_folder(
             self, mock_make_assembled_entry_for_folder):
@@ -109,6 +125,32 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         self.assertEqual(2, len(assembled_entries))
         self.assertEqual(2, mock_make_assembled_entry_for_folder.call_count)
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}'
+                f'__make_assembled_entry_for_dashboard')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_assembled_entry_for_folder')
+    def test_make_assembled_entries_for_folder_should_process_nested_dashboards(  # noqa: E501
+            self, mock_make_assembled_entry_for_folder,
+            mock_make_assembled_entry_for_dashboard):
+
+        folder = self.__make_fake_folder_with_nested_dashboard()
+        tag_templates_dict = {
+            'sisense_folder_metadata': datacatalog.TagTemplate()
+        }
+
+        mock_make_assembled_entry_for_folder.return_value = \
+            commons_prepare.AssembledEntryData('test-folder', {})
+
+        mock_make_assembled_entry_for_dashboard.return_value = \
+            commons_prepare.AssembledEntryData('test-dashboard', {})
+
+        assembled_entries = self.__factory\
+            ._AssembledEntryFactory__make_assembled_entries_for_folder(
+                folder, tag_templates_dict)
+
+        self.assertEqual(2, len(assembled_entries))
+        mock_make_assembled_entry_for_folder.assert_called_once()
+        mock_make_assembled_entry_for_dashboard.assert_called_once()
+
     def test_make_assembled_entry_for_folder_should_make_entry_and_tags(self):
         folder = self.__make_fake_folder()
         tag_template = datacatalog.TagTemplate()
@@ -139,6 +181,39 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         tag_factory.make_tag_for_folder.assert_called_once_with(
             tag_template, folder)
 
+    def test_make_assembled_entry_for_dashboard_should_make_entry_and_tags(
+            self):
+
+        dashboard = self.__make_fake_dashboard()
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_dashboard_metadata'
+        tag_templates_dict = {'sisense_dashboard_metadata': tag_template}
+
+        fake_entry = ('test-dashboard', {})
+        entry_factory = self.__mock_entry_factory
+        entry_factory.make_entry_for_dashboard.return_value = fake_entry
+
+        fake_tag = datacatalog.Tag()
+        fake_tag.template = 'tagTemplates/sisense_dashboard_metadata'
+        tag_factory = self.__mock_tag_factory
+        tag_factory.make_tag_for_dashboard.return_value = fake_tag
+
+        assembled_entry = self.__factory\
+            ._AssembledEntryFactory__make_assembled_entry_for_dashboard(
+                dashboard, tag_templates_dict)
+
+        self.assertEqual('test-dashboard', assembled_entry.entry_id)
+        self.assertEqual({}, assembled_entry.entry)
+        entry_factory.make_entry_for_dashboard.assert_called_once_with(
+            dashboard)
+
+        tags = assembled_entry.tags
+        self.assertEqual(1, len(tags))
+        self.assertEqual('tagTemplates/sisense_dashboard_metadata',
+                         tags[0].template)
+        tag_factory.make_tag_for_dashboard.assert_called_once_with(
+            tag_template, dashboard)
+
     @classmethod
     def __make_fake_folder(cls) -> Dict[str, Any]:
         return {
@@ -154,4 +229,21 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             'type': 'folder',
             'name': 'Test parent folder',
             'folders': [cls.__make_fake_folder()]
+        }
+
+    @classmethod
+    def __make_fake_dashboard(cls) -> Dict[str, Any]:
+        return {
+            'oid': 'test-dashboard',
+            'type': 'dashboard',
+            'title': 'Test dashboard',
+        }
+
+    @classmethod
+    def __make_fake_folder_with_nested_dashboard(cls) -> Dict[str, Any]:
+        return {
+            'oid': 'test-folder',
+            'type': 'folder',
+            'name': 'Test folder',
+            'dashboards': [cls.__make_fake_dashboard()]
         }

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -66,7 +66,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'entryGroups/test-entry-group/entries/'
             'sss_test_server_com_db_a123_b457', entry.name)
         self.assertEqual('test-system', entry.user_specified_system)
-        self.assertEqual('dashboard', entry.user_specified_type)
+        self.assertEqual('Dashboard', entry.user_specified_type)
         self.assertEqual('Test dashboard', entry.display_name)
         self.assertEqual('Test dashboard description', entry.description)
         self.assertEqual(
@@ -134,7 +134,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'entryGroups/test-entry-group/entries/'
             'sss_test_server_com_fd_a123_b457', entry.name)
         self.assertEqual('test-system', entry.user_specified_system)
-        self.assertEqual('folder', entry.user_specified_type)
+        self.assertEqual('Folder', entry.user_specified_type)
         self.assertEqual('Test folder', entry.display_name)
         self.assertEqual('https://test.server.com/app/main#/home/a123-b457',
                          entry.linked_resource)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -32,11 +32,11 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
     def test_fulfill_tag_fields_should_resolve_dashboard_folder_mapping(self):
         folder_id = 'parent-folder'
-        folder_entry = self.__make_fake_entry(folder_id, 'folder')
+        folder_entry = self.__make_fake_entry(folder_id, 'Folder')
         folder_tag = self.__make_fake_tag(string_fields=(('id', folder_id),))
 
         dashboard_id = 'test-dashboard'
-        dashboard_entry = self.__make_fake_entry(dashboard_id, 'dashboard')
+        dashboard_entry = self.__make_fake_entry(dashboard_id, 'Dashboard')
         string_fields = ('id', dashboard_id), ('folder_id', folder_id)
         dashboard_tag = self.__make_fake_tag(string_fields=string_fields)
 
@@ -56,12 +56,12 @@ class EntryRelationshipMapperTest(unittest.TestCase):
     def test_fulfill_tag_fields_should_resolve_parent_folder_mapping(self):
         parent_folder_id = 'parent-folder'
         parent_folder_entry = self.__make_fake_entry(parent_folder_id,
-                                                     'folder')
+                                                     'Folder')
         parent_folder_tag = self.__make_fake_tag(
             string_fields=(('id', parent_folder_id),))
 
         folder_id = 'test-folder'
-        folder_entry = self.__make_fake_entry(folder_id, 'folder')
+        folder_entry = self.__make_fake_entry(folder_id, 'Folder')
         string_fields = ('id', folder_id), ('parent_id', parent_folder_id)
         folder_tag = self.__make_fake_tag(string_fields=string_fields)
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import unittest
-from unittest import mock
 
 from google.cloud import datacatalog
 from google.cloud.datacatalog import Entry, Tag

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+from unittest import mock
 
 from google.cloud import datacatalog
 from google.cloud.datacatalog import Entry, Tag

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sync/metadata_synchronizer_test.py
@@ -142,12 +142,11 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         top_level_assets_dict = \
             self.__synchronizer._MetadataSynchronizer__assemble_sisense_assets(
-                flat_folders)
+                flat_folders, [])
 
         self.assertEqual(1, len(top_level_assets_dict))
-        mock_assemble_folder_from_flat_lists.assert_called_once()
-        mock_assemble_folder_from_flat_lists.assert_called_with(
-            parent_folder, flat_folders)
+        mock_assemble_folder_from_flat_lists.assert_called_once_with(
+            parent_folder, flat_folders, [])
 
     def test_assemble_folder_from_flat_lists_should_build_hierarchy(self):
         child_folder_1_1 = self.__make_fake_folder('test-child-folder-1.1')
@@ -162,7 +161,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         folder_id, assembled_folder = self.__synchronizer\
             ._MetadataSynchronizer__assemble_folder_from_flat_lists(
-                top_level_folder, flat_folders)
+                top_level_folder, flat_folders, [])
 
         self.assertEqual('test-top-level-folder', folder_id)
         self.assertEqual(child_folder_1, assembled_folder['folders'][0])
@@ -199,7 +198,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
     def test_map_datacatalog_relationships_should_process_all_entries(
             self, mock_entry_relationship_mapper):
 
-        entry = self.__make_fake_entry('folder')
+        entry = self.__make_fake_entry('Folder')
 
         assembled_entries = {
             'test-folder-1': [entry],
@@ -220,7 +219,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
     def test_delete_obsolete_entries_should_delegate_to_metadata_cleaner(
             self, mock_datacatalog_metadata_cleaner):
 
-        entry = self.__make_fake_entry('folder')
+        entry = self.__make_fake_entry('Folder')
 
         assembled_entries = {
             'test-folder-1': [entry],
@@ -236,7 +235,7 @@ class MetadataSynchronizerTest(unittest.TestCase):
 
         self.assertEqual(1, mock_delete_obsolete_metadata.call_count)
         mock_delete_obsolete_metadata.assert_called_with(
-            [entry, entry, entry], 'system=sisense tag:server_url:test-server')
+            [entry, entry, entry], 'system=Sisense tag:server_url:test-server')
 
     @mock.patch(f'{__SYNCR_MODULE}.ingest.DataCatalogMetadataIngestor')
     def test_ingest_metadata_should_delegate_to_metadata_ingestor(

--- a/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
@@ -28,7 +28,7 @@ __datacatalog = datacatalog.DataCatalogClient()
 def __delete_entries_and_groups(project_ids: List[str]) -> None:
     entry_name_pattern = '(?P<entry_group_name>.+?)/entries/(.+?)'
 
-    query = 'system=sisense'
+    query = 'system=Sisense'
 
     scope = datacatalog.SearchCatalogRequest.Scope()
     scope.include_project_ids.extend(project_ids)


### PR DESCRIPTION
**- What I did**
Added features that allow the Sisense Connector to synchronize Dashboard metadata with Google Data Catalog.

**- How I did it**
1. Added the below methods and their unit test as well:
- `prepare.AssembledEntryFacory.__make_assembled_entry_for_dashboard()`
- `sync.MetadataSynchronizer.__scrape_dashboards()`
2. Performed minor refactorings to accommodate the changes.

**- How to verify it**
Run the unit tests and, if possible, the connector in an integrated environment to check the results.

**- Description for the changelog**
Added features that allow the Sisense Connector to synchronize Dashboard metadata with Google Data Catalog.

PS: This PR is part of the effort to implement #70.