### PR TITLE
Add the parent folder name to the Folder tags

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -87,9 +87,10 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         folder_id = folder_metadata.get('oid') or folder_metadata.get('name')
         self._set_string_field(tag, 'id', folder_id)
 
-        self._set_string_field(tag, 'name', folder_metadata.get('name'))
-        self._set_string_field(tag, 'parent_id',
-                               folder_metadata.get('parentId'))
+        parent = folder_metadata.get('parentFolderData')
+        if parent:
+            self._set_string_field(tag, 'parent_id', parent.get('oid'))
+            self._set_string_field(tag, 'parent_name', parent.get('name'))
 
         owner = folder_metadata.get('ownerData')
         if owner:

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -52,7 +52,6 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        field_id='owner_username',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Owner username',
-                                       is_required=True,
                                        order=9)
 
         self._add_primitive_type_field(tag_template=tag_template,

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -126,28 +126,27 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        order=11)
 
         self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='name',
-                                       field_type=self.__STRING_TYPE,
-                                       display_name='Name',
-                                       is_required=True,
-                                       order=10)
-
-        self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='owner_username',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Owner username',
-                                       order=9)
+                                       order=10)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='owner_name',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Owner name',
-                                       order=8)
+                                       order=9)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='parent_id',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Id of Parent',
+                                       order=8)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='parent_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Parent Folder',
                                        order=7)
 
         self._add_primitive_type_field(

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sync/metadata_synchronizer.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sync/metadata_synchronizer.py
@@ -112,6 +112,7 @@ class MetadataSynchronizer:
         - ``ownerData``: added when the authenticated user is allowed to read
         users' information; intended to provide ownership-related metadata to
         the Data Catalog Tags created for the Folder.
+        - ``parentFolderData``: added when the Folder has a parent.
 
         Returns:
             A ``list``.
@@ -124,6 +125,10 @@ class MetadataSynchronizer:
             owner_data = self.__scrape_user(owner_id) if owner_id else None
             if owner_data:
                 folder['ownerData'] = owner_data
+            parent_id = folder.get('parentId')
+            if parent_id:
+                folder['parentFolderData'] = next(
+                    fdr for fdr in all_folders if fdr.get('oid') == parent_id)
 
         return all_folders
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -93,11 +93,14 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         metadata = {
             'oid': 'test-folder',
             'name': 'Test folder',
-            'parentId': 'parent-folder',
             'ownerData': {
                 'userName': 'johndoe@test.com',
                 'firstName': 'John',
                 'lastName': 'Doe',
+            },
+            'parentFolderData': {
+                'oid': 'parent-folder',
+                'name': 'Parent folder',
             },
             'folders': [{
                 'oid': 'child-folder',
@@ -112,8 +115,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('tagTemplates/sisense_folder_metadata', tag.template)
 
         self.assertEqual('test-folder', tag.fields['id'].string_value)
-        self.assertEqual('Test folder', tag.fields['name'].string_value)
         self.assertEqual('parent-folder', tag.fields['parent_id'].string_value)
+        self.assertEqual('Parent folder',
+                         tag.fields['parent_name'].string_value)
         self.assertEqual('johndoe@test.com',
                          tag.fields['owner_username'].string_value)
         self.assertEqual('John Doe', tag.fields['owner_name'].string_value)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -120,10 +120,6 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
                          tag_template.fields['id'].type.primitive_type)
         self.assertEqual('Id', tag_template.fields['id'].display_name)
 
-        self.assertEqual(self.__STRING_TYPE,
-                         tag_template.fields['name'].type.primitive_type)
-        self.assertEqual('Name', tag_template.fields['name'].display_name)
-
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['owner_username'].type.primitive_type)
@@ -139,6 +135,12 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
                          tag_template.fields['parent_id'].type.primitive_type)
         self.assertEqual('Id of Parent',
                          tag_template.fields['parent_id'].display_name)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['parent_name'].type.primitive_type)
+        self.assertEqual('Parent Folder',
+                         tag_template.fields['parent_name'].display_name)
 
         self.assertEqual(
             self.__STRING_TYPE,

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sync/metadata_synchronizer_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sync/metadata_synchronizer_test.py
@@ -130,6 +130,22 @@ class MetadataSynchronizerTest(unittest.TestCase):
         self.assertEqual(folder, folders[0])
         mock_scraper.scrape_user.assert_called_once()
 
+    def test_scrape_folders_should_add_parent_data_when_folder_has_parent(
+            self):
+
+        parent_folder = self.__make_fake_folder()
+        child_folder = self.__make_fake_folder('test-child-folder')
+        child_folder['parentId'] = 'test-folder'
+
+        mock_scraper = self.__mock_metadata_scraper
+        mock_scraper.scrape_all_folders.return_value = [
+            parent_folder, child_folder
+        ]
+
+        folders = self.__synchronizer._MetadataSynchronizer__scrape_folders()
+
+        self.assertEqual(parent_folder, folders[1]['parentFolderData'])
+
     def test_scrape_dashboards_should_scrape_all_dashboards(self):
         mock_scraper = self.__mock_metadata_scraper
         self.__synchronizer._MetadataSynchronizer__scrape_dashboards([])


### PR DESCRIPTION
**- What I did**
Added the parent folder name to the Folder tags.

**- How I did it**
1. Removed the `name` field from the Folder tags (it was redundant as their entry name is fulfilled with the same value).
2. Added the `parent_name` field to the Folder tags, providing users with more friendly metadata.
3. Update `MetadataSynchronizer.__scrape_folders()` in order to handle the changes in the tags.
4. Updated the unit tests.

**- How to verify it**
Run the unit tests and, if possible, the connector in an integrated environment to check the results (this is a breaking change, so the cleanup script must be executed before running the present code).

**- Description for the changelog**
Added the parent folder name to the Folder tags.

PS: This PR is part of the effort to implement #70.