### PR TITLE
Scrape Sisense Widgets metadata

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -62,6 +62,19 @@ class MetadataScraper:
 
         return user
 
+    def scrape_widgets(self, dashboard_id) -> List[Dict[str, Any]]:
+        self.__log_scrape_start(f'Scraping Widgets metadata'
+                                f' (Dashboard Id: {dashboard_id})...')
+        widgets = self.__api_helper.get_widgets(dashboard_id)
+
+        logging.info('')
+        logging.info('  %s Widgets found:', len(widgets))
+        for widget in widgets:
+            logging.info('    - %s, %s [%s]', widget.get('title'),
+                         widget.get('type'), widget.get('oid'))
+
+        return widgets
+
     @classmethod
     def __log_scrape_start(cls, message: str, *args: Any) -> None:
         logging.info('')

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -71,8 +71,9 @@ class MetadataScraper:
         logging.info('')
         logging.info('  %s Widgets found:', len(widgets))
         for widget in widgets:
-            logging.info('    - %s, %s [%s]', widget.get('title'),
-                         widget.get('type'), widget.get('oid'))
+            logging.info('    - %s, %s [%s]',
+                         widget.get('title') or 'Unnamed', widget.get('type'),
+                         widget.get('oid'))
 
         return widgets
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -71,9 +71,9 @@ class MetadataScraper:
         logging.info('')
         logging.info('  %s Widgets found:', len(widgets))
         for widget in widgets:
-            logging.info('    - %s, %s [%s]',
-                         widget.get('title') or 'Unnamed', widget.get('type'),
-                         widget.get('oid'))
+            logging.info('    - %s [%s, %s]',
+                         widget.get('title') or 'Unnamed', widget.get('oid'),
+                         widget.get('type'))
 
         return widgets
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/metadata_scraper.py
@@ -52,7 +52,7 @@ class MetadataScraper:
 
         return folders
 
-    def scrape_user(self, user_id) -> Dict[str, Any]:
+    def scrape_user(self, user_id: str) -> Dict[str, Any]:
         self.__log_scrape_start(f'Scraping User metadata (Id: {user_id})...')
         user = self.__api_helper.get_user(user_id)
 
@@ -62,10 +62,11 @@ class MetadataScraper:
 
         return user
 
-    def scrape_widgets(self, dashboard_id) -> List[Dict[str, Any]]:
+    def scrape_widgets(self, dashboard: Dict[str,
+                                             Any]) -> List[Dict[str, Any]]:
         self.__log_scrape_start(f'Scraping Widgets metadata'
-                                f' (Dashboard Id: {dashboard_id})...')
-        widgets = self.__api_helper.get_widgets(dashboard_id)
+                                f' (Dashboard: {dashboard.get("title")})...')
+        widgets = self.__api_helper.get_widgets(dashboard.get('oid'))
 
         logging.info('')
         logging.info('  %s Widgets found:', len(widgets))

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/scrape/rest_api_helper.py
@@ -128,6 +128,21 @@ class RESTAPIHelper:
         response = requests.get(url=url, headers=self.__common_headers)
         return self.__get_response_body_or_raise(response)
 
+    def get_widgets(self, dashboard_id) -> List[Dict[str, Any]]:
+        """Get all Widgets belonging to a given Dashboard.
+
+        Returns:
+            A ``list``.
+
+        Raises:
+            Exception: If the API returns any status code than ``200``.
+        """
+        self.__set_up_auth()
+
+        url = f'{self.__base_api_endpoint}/dashboards/{dashboard_id}/widgets'
+        return self.__get_list_using_pagination(base_url=url,
+                                                results_per_page=50)
+
     def __set_up_auth(self) -> None:
         if self.__auth_credentials:
             return

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -89,7 +89,7 @@ class MetadataScraperTest(unittest.TestCase):
         api_helper = self.__mock_api_helper
         api_helper.get_widgets.return_value = widgets_metadata
 
-        widgets = self.__scraper.scrape_widgets('dashboard-id')
+        widgets = self.__scraper.scrape_widgets({'oid': 'dashboard-id'})
 
         self.assertEqual(1, len(widgets))
         self.assertEqual('widget-id', widgets[0]['oid'])

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/metadata_scraper_test.py
@@ -80,3 +80,17 @@ class MetadataScraperTest(unittest.TestCase):
 
         self.assertEqual('user-id', user['_id'])
         api_helper.get_user.assert_called_once()
+
+    def test_scrape_widgets_should_delegate_to_api_helper(self):
+        widgets_metadata = [{
+            'oid': 'widget-id',
+        }]
+
+        api_helper = self.__mock_api_helper
+        api_helper.get_widgets.return_value = widgets_metadata
+
+        widgets = self.__scraper.scrape_widgets('dashboard-id')
+
+        self.assertEqual(1, len(widgets))
+        self.assertEqual('widget-id', widgets[0]['oid'])
+        api_helper.get_widgets.assert_called_once_with('dashboard-id')

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/scrape/rest_api_helper_test.py
@@ -138,6 +138,31 @@ class RESTAPIHelperTest(unittest.TestCase):
 
         self.assertEqual('user-id', user['oid'])
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_list_using_pagination')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_widgets_should_return_list_on_success(
+            self, mock_get_list_using_pagination):
+
+        mock_get_list_using_pagination.return_value = [{'oid': 'widget-id'}]
+
+        widgets = self.__helper.get_widgets('dashboard-id')
+
+        self.assertEqual(1, len(widgets))
+        self.assertEqual('widget-id', widgets[0]['oid'])
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_list_using_pagination')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__set_up_auth', lambda *args: None)
+    def test_get_widgets_should_use_pagination(self,
+                                               mock_get_list_using_pagination):
+
+        self.__helper.get_widgets('dashboard-id')
+
+        mock_get_list_using_pagination.assert_called_once_with(
+            base_url='test-server/api/test-version'
+            '/dashboards/dashboard-id/widgets',
+            results_per_page=50,
+        )
+
     @mock.patch(f'{__HELPER_MODULE}.authenticator.Authenticator.authenticate')
     def test_set_up_auth_should_set_credentials_if_not_authenticated(
             self, mock_authenticate):


### PR DESCRIPTION
**- What I did**
Added support for Sisense Widgets metadata scraping.

**- How I did it**
Added 2 new methods and their unit tests:
1. `MetadataScraper.scrape_widgets()`
2. `RESTAPIHelper.get_widgets()`

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added support for Sisense Widgets metadata scraping.

PS: This PR is part of the effort to deliver feature #70.