### PR TITLE
Prepare the Widget entries

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -20,6 +20,7 @@ ENTRY_ID_PREFIX = 'sss_'
 # ENTRY_ID_PREFIX when generating Sisense Entry IDs.
 ENTRY_ID_PART_DASHBOARD = 'db_'
 ENTRY_ID_PART_FOLDER = 'fd_'
+ENTRY_ID_PART_WIDGET = 'wg_'
 
 # The Sisense type for Dashboard assets.
 SISENSE_ASSET_TYPE_DASHBOARD = 'dashboard'
@@ -37,3 +38,5 @@ TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 USER_SPECIFIED_TYPE_DASHBOARD = 'Dashboard'
 # The user specified type of Folder-related Entries.
 USER_SPECIFIED_TYPE_FOLDER = 'Folder'
+# The user specified type of Widget-related Entries.
+USER_SPECIFIED_TYPE_WIDGET = 'Widget'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -27,6 +27,7 @@ from google.datacatalog_connectors.sisense.prepare import constants
 
 class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+    __UNNAMED = 'Unnamed'
 
     def __init__(self, project_id: str, location_id: str, entry_group_id: str,
                  user_specified_system: str, server_address: str):
@@ -60,10 +61,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             dashboard_metadata.get('title'))
         entry.description = dashboard_metadata.get('desc')
 
-        if dashboard_metadata.get('oid'):
-            entry.linked_resource = f'{self.__server_address}' \
-                                    f'/app/main#/dashboards' \
-                                    f'/{dashboard_metadata.get("oid")}'
+        entry.linked_resource = f'{self.__server_address}' \
+                                f'/app/main#/dashboards/{dashboard_id}'
 
         if dashboard_metadata.get('created'):
             created_datetime = datetime.strptime(
@@ -119,6 +118,43 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
             modified_date = folder_metadata.get('lastUpdated')
             resolved_modified_date = modified_date or folder_metadata.get(
+                'created')
+            modified_datetime = datetime.strptime(
+                resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+            update_timestamp = timestamp_pb2.Timestamp()
+            update_timestamp.FromDatetime(modified_datetime)
+            entry.source_system_timestamps.update_time = update_timestamp
+
+        return generated_id, entry
+
+    def make_entry_for_widget(
+            self, widget_metadata: Dict[str, Any]) -> Tuple[str, Entry]:
+
+        entry = datacatalog.Entry()
+
+        generated_id = self.__format_id(constants.ENTRY_ID_PART_WIDGET,
+                                        widget_metadata.get('oid'))
+        entry.name = datacatalog.DataCatalogClient.entry_path(
+            self.__project_id, self.__location_id, self.__entry_group_id,
+            generated_id)
+
+        entry.user_specified_system = self.__user_specified_system
+        entry.user_specified_type = constants.USER_SPECIFIED_TYPE_WIDGET
+
+        entry.display_name = self._format_display_name(
+            widget_metadata.get('title') or self.__UNNAMED)
+        entry.description = widget_metadata.get('desc')
+
+        if widget_metadata.get('created'):
+            created_datetime = datetime.strptime(
+                widget_metadata.get('created'),
+                self.__INCOMING_TIMESTAMP_UTC_FORMAT)
+            create_timestamp = timestamp_pb2.Timestamp()
+            create_timestamp.FromDatetime(created_datetime)
+            entry.source_system_timestamps.create_time = create_timestamp
+
+            modified_date = widget_metadata.get('lastUpdated')
+            resolved_modified_date = modified_date or widget_metadata.get(
                 'created')
             modified_datetime = datetime.strptime(
                 resolved_modified_date, self.__INCOMING_TIMESTAMP_UTC_FORMAT)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -193,3 +193,79 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual(
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_widget_should_set_all_available_fields(self):
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test widget',
+            'desc': 'Test widget description',
+            'created': '2019-09-12T16:30:00.005Z',
+            'lastUpdated': '2019-09-12T16:31:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_widget(metadata)
+
+        self.assertEqual('sss_test_server_com_wg_a123_b457', entry_id)
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'entryGroups/test-entry-group/entries/'
+            'sss_test_server_com_wg_a123_b457', entry.name)
+        self.assertEqual('test-system', entry.user_specified_system)
+        self.assertEqual('Widget', entry.user_specified_type)
+        self.assertEqual('Test widget', entry.display_name)
+        self.assertEqual('Test widget description', entry.description)
+        self.assertEqual('', entry.linked_resource)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.create_time.timestamp())
+
+        updated_datetime = datetime.strptime('2019-09-12T16:31:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            updated_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())
+
+    def test_make_entry_for_widget_should_set_unnamed_on_missing_title(self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_widget(metadata)
+
+        self.assertEqual('Unnamed', entry.display_name)
+
+    def test_make_entry_for_widget_should_succeed_on_missing_created_date(
+            self):
+
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test widget',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_widget(metadata)
+
+        self.assertIsNone(entry.source_system_timestamps.create_time)
+
+    def test_make_entry_for_widget_should_use_created_on_no_updated_date(self):
+        metadata = {
+            '_id': 'a123-b456',
+            'oid': 'a123-b457',
+            'title': 'Test widget',
+            'created': '2019-09-12T16:30:00.005Z',
+        }
+
+        entry_id, entry = self.__factory.make_entry_for_widget(metadata)
+
+        created_datetime = datetime.strptime('2019-09-12T16:30:00.005+0000',
+                                             self.__DATETIME_FORMAT)
+        self.assertEqual(
+            created_datetime.timestamp(),
+            entry.source_system_timestamps.update_time.timestamp())


### PR DESCRIPTION
**- What I did**
Added the feature that allows Sisense Connector to prepare Widget entries.
The tags will be tackled in the next PR.

**- How I did it**
Added the `prepare.DataCatalogEntryFactory.make_entry_for_widget()` method, and its unit tests.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added the feature that allows Sisense Connector to prepare Widget entries.

PS: This PR is part of the effort to deliver feature #70.