### PR TITLE
Prepare the Widget tags

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -33,6 +33,9 @@ TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
 # The ID of the Tag Template created to store additional metadata for
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
+# The ID of the Tag Template created to store additional metadata for
+# Widget-related Entries.
+TAG_TEMPLATE_ID_WIDGET = 'sisense_widget_metadata'
 
 # The user specified type of Dashboard-related Entries.
 USER_SPECIFIED_TYPE_DASHBOARD = 'Dashboard'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -144,8 +144,10 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'dashboard_title', dashboard.get('title'))
 
         datasource = widget_metadata.get('datasource')
-        if datasource:
+        if isinstance(datasource, dict):
             self._set_string_field(tag, 'datasource', datasource.get('title'))
+        elif isinstance(datasource, str):
+            self._set_string_field(tag, 'datasource', datasource)
 
         self._set_string_field(tag, 'server_url', self.__server_address)
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -117,3 +117,36 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'server_url', self.__server_address)
 
         return tag
+
+    def make_tag_for_widget(self, tag_template: TagTemplate,
+                            widget_metadata: Dict[str, Any]) -> Tag:
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        self._set_string_field(tag, 'id', widget_metadata.get('oid'))
+        self._set_string_field(tag, 'type', widget_metadata.get('type'))
+        self._set_string_field(tag, 'subtype', widget_metadata.get('subtype'))
+
+        owner = widget_metadata.get('ownerData')
+        if owner:
+            self._set_string_field(tag, 'owner_username',
+                                   owner.get('userName'))
+
+            first_name = owner.get('firstName') or ''
+            last_name = owner.get('lastName') or ''
+            self._set_string_field(tag, 'owner_name',
+                                   f'{first_name} {last_name}')
+
+        dashboard = widget_metadata.get('dashboardData')
+        self._set_string_field(tag, 'dashboard_id', dashboard.get('oid'))
+        self._set_string_field(tag, 'dashboard_title', dashboard.get('title'))
+
+        datasource = widget_metadata.get('datasource')
+        if datasource:
+            self._set_string_field(tag, 'datasource', datasource.get('title'))
+
+        self._set_string_field(tag, 'server_url', self.__server_address)
+
+        return tag

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -240,9 +240,9 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        order=5)
 
         self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='dashboard_name',
+                                       field_id='dashboard_title',
                                        field_type=self.__STRING_TYPE,
-                                       display_name='Dashboard Name',
+                                       display_name='Dashboard Title',
                                        is_required=True,
                                        order=4)
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -189,3 +189,82 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
                                        order=1)
 
         return tag_template
+
+    def make_tag_template_for_widget(self) -> TagTemplate:
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_WIDGET)
+
+        tag_template.display_name = 'Sisense Widget Metadata'
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Id',
+                                       is_required=True,
+                                       order=10)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='type',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Type',
+                                       is_required=True,
+                                       order=9)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='subtype',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Subtype',
+                                       order=8)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_username',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner username',
+                                       order=7)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='owner_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Owner name',
+                                       order=6)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='dashboard_id',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Dashboard Id',
+                                       is_required=True,
+                                       order=5)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='dashboard_name',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Dashboard Name',
+                                       is_required=True,
+                                       order=4)
+
+        self._add_primitive_type_field(
+            tag_template=tag_template,
+            field_id='dashboard_entry',
+            field_type=self.__STRING_TYPE,
+            display_name='Data Catalog Entry for the Dashboard',
+            is_required=True,
+            order=3)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='datasource',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Data Source',
+                                       order=2)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='server_url',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Sisense Server Url',
+                                       is_required=True,
+                                       order=1)
+
+        return tag_template

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper.py
@@ -22,10 +22,12 @@ from google.datacatalog_connectors.sisense.prepare import constants
 class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
     __DASHBOARD = constants.USER_SPECIFIED_TYPE_DASHBOARD
     __FOLDER = constants.USER_SPECIFIED_TYPE_FOLDER
+    __WIDGET = constants.USER_SPECIFIED_TYPE_WIDGET
 
     def fulfill_tag_fields(self, assembled_entries_data):
         resolvers = (self.__resolve_dashboard_mappings,
-                     self.__resolve_folder_mappings)
+                     self.__resolve_folder_mappings,
+                     self.__resolve_widget_mappings)
 
         self._fulfill_tag_fields(assembled_entries_data, resolvers)
 
@@ -49,4 +51,15 @@ class EntryRelationshipMapper(prepare.BaseEntryRelationshipMapper):
 
             cls._map_related_entry(assembled_entry_data, cls.__FOLDER,
                                    'parent_id', 'parent_folder_entry',
+                                   id_name_pairs)
+
+    @classmethod
+    def __resolve_widget_mappings(cls, assembled_entries_data, id_name_pairs):
+        for assembled_entry_data in assembled_entries_data:
+            entry = assembled_entry_data.entry
+            if not entry.user_specified_type == cls.__WIDGET:
+                continue
+
+            cls._map_related_entry(assembled_entry_data, cls.__DASHBOARD,
+                                   'dashboard_id', 'dashboard_entry',
                                    id_name_pairs)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -170,3 +170,17 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['datasource'].string_value)
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
+
+    def test_make_tag_for_widget_should_set_datasource_from_string(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_widget_metadata'
+
+        metadata = {
+            'dashboardData': {},
+            'datasource': 'Test Data Source',
+        }
+
+        tag = self.__factory.make_tag_for_widget(tag_template, metadata)
+
+        self.assertEqual('Test Data Source',
+                         tag.fields['datasource'].string_value)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -128,3 +128,45 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
+
+    def test_make_tag_for_widget_should_set_all_available_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_widget_metadata'
+
+        metadata = {
+            'oid': 'test-widget',
+            'type': 'indicator',
+            'subtype': 'indicator/numeric',
+            'dashboardData': {
+                'oid': 'dashboard-id',
+                'title': 'Dashboard Title',
+            },
+            'ownerData': {
+                'userName': 'johndoe@test.com',
+                'firstName': 'John',
+                'lastName': 'Doe',
+            },
+            'datasource': {
+                'title': 'Test Data Source',
+            },
+        }
+
+        tag = self.__factory.make_tag_for_widget(tag_template, metadata)
+
+        self.assertEqual('tagTemplates/sisense_widget_metadata', tag.template)
+
+        self.assertEqual('test-widget', tag.fields['id'].string_value)
+        self.assertEqual('indicator', tag.fields['type'].string_value)
+        self.assertEqual('indicator/numeric',
+                         tag.fields['subtype'].string_value)
+        self.assertEqual('dashboard-id',
+                         tag.fields['dashboard_id'].string_value)
+        self.assertEqual('Dashboard Title',
+                         tag.fields['dashboard_title'].string_value)
+        self.assertEqual('johndoe@test.com',
+                         tag.fields['owner_username'].string_value)
+        self.assertEqual('John Doe', tag.fields['owner_name'].string_value)
+        self.assertEqual('Test Data Source',
+                         tag.fields['datasource'].string_value)
+        self.assertEqual('https://test.com',
+                         tag.fields['server_url'].string_value)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -247,10 +247,10 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
 
         self.assertEqual(
             self.__STRING_TYPE,
-            tag_template.fields['dashboard_name'].type.primitive_type)
-        self.assertEqual('Dashboard Name',
-                         tag_template.fields['dashboard_name'].display_name)
-        self.assertTrue(tag_template.fields['dashboard_name'].is_required)
+            tag_template.fields['dashboard_title'].type.primitive_type)
+        self.assertEqual('Dashboard Title',
+                         tag_template.fields['dashboard_title'].display_name)
+        self.assertTrue(tag_template.fields['dashboard_title'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -56,56 +56,66 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['id'].type.primitive_type)
         self.assertEqual('Id', tag_template.fields['id'].display_name)
+        self.assertTrue(tag_template.fields['id'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['owner_username'].type.primitive_type)
         self.assertEqual('Owner username',
                          tag_template.fields['owner_username'].display_name)
+        self.assertFalse(tag_template.fields['owner_username'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['owner_name'].type.primitive_type)
         self.assertEqual('Owner name',
                          tag_template.fields['owner_name'].display_name)
+        self.assertFalse(tag_template.fields['owner_name'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['folder_id'].type.primitive_type)
         self.assertEqual('Folder Id',
                          tag_template.fields['folder_id'].display_name)
+        self.assertFalse(tag_template.fields['folder_id'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['folder_name'].type.primitive_type)
         self.assertEqual('Folder Name',
                          tag_template.fields['folder_name'].display_name)
+        self.assertFalse(tag_template.fields['folder_name'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['folder_entry'].type.primitive_type)
         self.assertEqual('Data Catalog Entry for the Folder',
                          tag_template.fields['folder_entry'].display_name)
+        self.assertFalse(tag_template.fields['folder_entry'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['datasource'].type.primitive_type)
         self.assertEqual('Data Source',
                          tag_template.fields['datasource'].display_name)
+        self.assertFalse(tag_template.fields['datasource'].is_required)
 
         self.assertEqual(
             self.__TIMESTAMP_TYPE,
             tag_template.fields['last_publish'].type.primitive_type)
         self.assertEqual('Time it was last published',
                          tag_template.fields['last_publish'].display_name)
+        self.assertFalse(tag_template.fields['last_publish'].is_required)
 
         self.assertEqual(
             self.__TIMESTAMP_TYPE,
             tag_template.fields['last_opened'].type.primitive_type)
         self.assertEqual('Time it was last opened',
                          tag_template.fields['last_opened'].display_name)
+        self.assertFalse(tag_template.fields['last_opened'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['server_url'].type.primitive_type)
         self.assertEqual('Sisense Server Url',
                          tag_template.fields['server_url'].display_name)
+        self.assertTrue(tag_template.fields['server_url'].is_required)
 
     def test_make_tag_template_for_folder(self):
         tag_template = self.__factory.make_tag_template_for_folder()
@@ -119,28 +129,33 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['id'].type.primitive_type)
         self.assertEqual('Id', tag_template.fields['id'].display_name)
+        self.assertTrue(tag_template.fields['id'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['owner_username'].type.primitive_type)
         self.assertEqual('Owner username',
                          tag_template.fields['owner_username'].display_name)
+        self.assertFalse(tag_template.fields['owner_username'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['owner_name'].type.primitive_type)
         self.assertEqual('Owner name',
                          tag_template.fields['owner_name'].display_name)
+        self.assertFalse(tag_template.fields['owner_name'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['parent_id'].type.primitive_type)
         self.assertEqual('Id of Parent',
                          tag_template.fields['parent_id'].display_name)
+        self.assertFalse(tag_template.fields['parent_id'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
             tag_template.fields['parent_name'].type.primitive_type)
         self.assertEqual('Parent Folder',
                          tag_template.fields['parent_name'].display_name)
+        self.assertFalse(tag_template.fields['parent_name'].is_required)
 
         self.assertEqual(
             self.__STRING_TYPE,
@@ -148,32 +163,110 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual(
             'Data Catalog Entry for the parent Folder',
             tag_template.fields['parent_folder_entry'].display_name)
+        self.assertFalse(
+            tag_template.fields['parent_folder_entry'].is_required)
 
         self.assertEqual(
             self.__BOOL_TYPE,
             tag_template.fields['has_children'].type.primitive_type)
         self.assertEqual('Has children',
                          tag_template.fields['has_children'].display_name)
+        self.assertTrue(tag_template.fields['has_children'].is_required)
 
         self.assertEqual(
             self.__DOUBLE_TYPE,
             tag_template.fields['child_count'].type.primitive_type)
         self.assertEqual('Child count',
                          tag_template.fields['child_count'].display_name)
+        self.assertFalse(tag_template.fields['child_count'].is_required)
 
         self.assertEqual(
             self.__BOOL_TYPE,
             tag_template.fields['has_dashboards'].type.primitive_type)
         self.assertEqual('Has dashboards',
                          tag_template.fields['has_dashboards'].display_name)
+        self.assertTrue(tag_template.fields['has_dashboards'].is_required)
 
         self.assertEqual(
             self.__DOUBLE_TYPE,
             tag_template.fields['dashboard_count'].type.primitive_type)
         self.assertEqual('Dashboard count',
                          tag_template.fields['dashboard_count'].display_name)
+        self.assertFalse(tag_template.fields['dashboard_count'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['server_url'].type.primitive_type)
         self.assertEqual('Sisense Server Url',
                          tag_template.fields['server_url'].display_name)
+        self.assertTrue(tag_template.fields['server_url'].is_required)
+
+    def test_make_tag_template_for_widget(self):
+        tag_template = self.__factory.make_tag_template_for_widget()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/sisense_widget_metadata', tag_template.name)
+
+        self.assertEqual('Sisense Widget Metadata', tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['id'].type.primitive_type)
+        self.assertEqual('Id', tag_template.fields['id'].display_name)
+        self.assertTrue(tag_template.fields['id'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['type'].type.primitive_type)
+        self.assertEqual('Type', tag_template.fields['type'].display_name)
+        self.assertTrue(tag_template.fields['type'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['subtype'].type.primitive_type)
+        self.assertEqual('Subtype',
+                         tag_template.fields['subtype'].display_name)
+        self.assertFalse(tag_template.fields['subtype'].is_required)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['owner_username'].type.primitive_type)
+        self.assertEqual('Owner username',
+                         tag_template.fields['owner_username'].display_name)
+        self.assertFalse(tag_template.fields['owner_username'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['owner_name'].type.primitive_type)
+        self.assertEqual('Owner name',
+                         tag_template.fields['owner_name'].display_name)
+        self.assertFalse(tag_template.fields['owner_name'].is_required)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['dashboard_id'].type.primitive_type)
+        self.assertEqual('Dashboard Id',
+                         tag_template.fields['dashboard_id'].display_name)
+        self.assertTrue(tag_template.fields['dashboard_id'].is_required)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['dashboard_name'].type.primitive_type)
+        self.assertEqual('Dashboard Name',
+                         tag_template.fields['dashboard_name'].display_name)
+        self.assertTrue(tag_template.fields['dashboard_name'].is_required)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['dashboard_entry'].type.primitive_type)
+        self.assertEqual('Data Catalog Entry for the Dashboard',
+                         tag_template.fields['dashboard_entry'].display_name)
+        self.assertTrue(tag_template.fields['dashboard_entry'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['datasource'].type.primitive_type)
+        self.assertEqual('Data Source',
+                         tag_template.fields['datasource'].display_name)
+        self.assertFalse(tag_template.fields['datasource'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['server_url'].type.primitive_type)
+        self.assertEqual('Sisense Server Url',
+                         tag_template.fields['server_url'].display_name)
+        self.assertTrue(tag_template.fields['server_url'].is_required)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/entry_relationship_mapper_test.py
@@ -95,6 +95,30 @@ class EntryRelationshipMapperTest(unittest.TestCase):
 
         mock_map_related_entry.assert_not_called()
 
+    def test_fulfill_tag_fields_should_resolve_widget_dashboard_mapping(self):
+        dashboard_id = 'parent-dashboard'
+        dashboard_entry = self.__make_fake_entry(dashboard_id, 'Dashboard')
+        dashboard_tag = self.__make_fake_tag(string_fields=(('id',
+                                                             dashboard_id),))
+
+        widget_id = 'test-widget'
+        widget_entry = self.__make_fake_entry(widget_id, 'Widget')
+        string_fields = ('id', widget_id), ('dashboard_id', dashboard_id)
+        widget_tag = self.__make_fake_tag(string_fields=string_fields)
+
+        dashboard_assembled_entry = commons_prepare.AssembledEntryData(
+            dashboard_id, dashboard_entry, [dashboard_tag])
+        widget_assembled_entry = commons_prepare.AssembledEntryData(
+            widget_id, widget_entry, [widget_tag])
+
+        prepare.EntryRelationshipMapper().fulfill_tag_fields(
+            [dashboard_assembled_entry, widget_assembled_entry])
+
+        self.assertEqual(
+            f'https://console.cloud.google.com/datacatalog/'
+            f'{dashboard_entry.name}',
+            widget_tag.fields['dashboard_entry'].string_value)
+
     @classmethod
     def __make_fake_entry(cls, entry_id, entry_type) -> Entry:
         entry = datacatalog.Entry()

--- a/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
@@ -74,6 +74,9 @@ def __delete_tag_templates(project_id: str, location_id: str) -> None:
     __delete_tag_template(
         datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'sisense_folder_metadata'))
+    __delete_tag_template(
+        datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'sisense_widget_metadata'))
 
 
 def __delete_tag_template(name: str) -> None:


### PR DESCRIPTION
**- What I did**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Widgets.

**- How I did it**
Added the below methods and their unit tests as well:

- `prepare.DataCatalogTagTemplateFactory.make_tag_template_for_widget()`
- `prepare.DataCatalogTagFactory.make_tag_for_widget()`
- `prepare.EntryRelationshipMapper.__resolve_widget_mappings()`

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added a feature that allows the Sisense Connector to prepare Data Catalog Tags for Widgets.

PS: This PR is part of the effort to deliver feature #70.