### PR TITLE
Make column schema for filters

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -201,8 +201,8 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     def __make_schema_for_widget(
             cls, widget_metadata: Dict[str, Any]) -> Optional[Schema]:
 
-        if not widget_metadata.get(
-                'metadata') and widget_metadata['metadata'].get('panels'):
+        if not (widget_metadata.get('metadata') and
+                widget_metadata['metadata'].get('panels')):
             return
 
         panels = widget_metadata['metadata']['panels']

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import Entry
+from google.cloud.datacatalog import ColumnSchema, Entry, Schema
 from google.protobuf import timestamp_pb2
 from google.datacatalog_connectors.commons import prepare
 
@@ -81,7 +81,31 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             update_timestamp.FromDatetime(modified_datetime)
             entry.source_system_timestamps.update_time = update_timestamp
 
+        entry.schema = self.__make_schema_for_dashboard(dashboard_metadata)
+
         return generated_id, entry
+
+    @classmethod
+    def __make_schema_for_dashboard(
+            cls, dashboard_metadata: Dict[str, Any]) -> Optional[Schema]:
+
+        if not dashboard_metadata.get('filters'):
+            return
+
+        filters_column = datacatalog.ColumnSchema()
+        filters_column.column = 'filters'
+        filters_column.type = 'array of filters'
+        filters_column.description = 'The Dashboard filters'
+
+        for dashboard_filter in dashboard_metadata['filters']:
+            filters_column.subcolumns.append(
+                cls.__make_column_schema_for_jaql(
+                    dashboard_filter.get('jaql')))
+
+        schema = datacatalog.Schema()
+        schema.columns.append(filters_column)
+
+        return schema
 
     def make_entry_for_folder(
             self, folder_metadata: Dict[str, Any]) -> Tuple[str, Entry]:
@@ -169,10 +193,50 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             update_timestamp.FromDatetime(modified_datetime)
             entry.source_system_timestamps.update_time = update_timestamp
 
+        entry.schema = self.__make_schema_for_widget(widget_metadata)
+
         return generated_id, entry
+
+    @classmethod
+    def __make_schema_for_widget(
+            cls, widget_metadata: Dict[str, Any]) -> Optional[Schema]:
+
+        if not widget_metadata.get(
+                'metadata') and widget_metadata['metadata'].get('panels'):
+            return
+
+        panels = widget_metadata['metadata']['panels']
+        filters = next((panel.get('items')
+                        for panel in panels
+                        if panel.get('name') == 'filters'), None)
+        if not filters:
+            return
+
+        filters_column = datacatalog.ColumnSchema()
+        filters_column.column = 'filters'
+        filters_column.type = 'array of filters'
+        filters_column.description = 'The Widget filters'
+
+        for widget_filter in filters:
+            filters_column.subcolumns.append(
+                cls.__make_column_schema_for_jaql(widget_filter.get('jaql')))
+
+        schema = datacatalog.Schema()
+        schema.columns.append(filters_column)
+
+        return schema
 
     def __format_id(self, source_type_identifier, source_id):
         prefixed_id = f'{constants.ENTRY_ID_PREFIX}' \
                       f'{self.__server_id}_' \
                       f'{source_type_identifier}{source_id}'
         return self._format_id(prefixed_id)
+
+    @classmethod
+    def __make_column_schema_for_jaql(
+            cls, jaql_metadata: Dict[str, Any]) -> ColumnSchema:
+
+        column = datacatalog.ColumnSchema()
+        column.column = jaql_metadata.get('title')
+        column.type = jaql_metadata.get('datatype')
+        return column

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -94,7 +94,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         filters_column = datacatalog.ColumnSchema()
         filters_column.column = 'filters'
-        filters_column.type = 'array of filters'
+        filters_column.type = 'array'
         filters_column.description = 'The Dashboard filters'
 
         for dashboard_filter in dashboard_metadata['filters']:
@@ -214,7 +214,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         filters_column = datacatalog.ColumnSchema()
         filters_column.column = 'filters'
-        filters_column.type = 'array of filters'
+        filters_column.type = 'array'
         filters_column.description = 'The Widget filters'
 
         for widget_filter in filters:

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -16,12 +16,20 @@
 
 from datetime import datetime
 import unittest
+from unittest import mock
+
+from google.cloud import datacatalog
 
 from google.datacatalog_connectors.sisense.prepare import \
     datacatalog_entry_factory
 
 
 class DataCatalogEntryFactoryTest(unittest.TestCase):
+    __FACTORY_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
+    __FACTORY_MODULE = f'{__FACTORY_PACKAGE}.datacatalog_entry_factory'
+    __FACTORY_CLASS = f'{__FACTORY_MODULE}.DataCatalogEntryFactory'
+    __PRIVATE_METHOD_PREFIX = f'{__FACTORY_CLASS}._DataCatalogEntryFactory'
+
     __DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
 
     def setUp(self):
@@ -47,7 +55,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.server.com',
                          attrs['_DataCatalogEntryFactory__server_address'])
 
-    def test_make_entry_for_dashboard_should_set_all_available_fields(self):
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_dashboard')
+    def test_make_entry_for_dashboard_should_set_all_available_fields(
+            self, mock_make_schema_for_dashboard):
+
         metadata = {
             '_id': 'a123-b456',
             'oid': 'a123-b457',
@@ -56,6 +67,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'created': '2019-09-12T16:30:00.005Z',
             'lastUpdated': '2019-09-12T16:31:00.005Z',
         }
+
+        schema = datacatalog.Schema()
+        mock_make_schema_for_dashboard.return_value = schema
 
         entry_id, entry = self.__factory.make_entry_for_dashboard(metadata)
 
@@ -85,6 +99,11 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             updated_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+        mock_make_schema_for_dashboard.assert_called_once_with(metadata)
+        self.assertEqual(schema, entry.schema)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_dashboard',
+                lambda *args: datacatalog.Schema())
     def test_make_entry_for_dashboard_should_succeed_on_missing_created_date(
             self):
 
@@ -98,6 +117,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertIsNone(entry.source_system_timestamps.create_time)
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_dashboard',
+                lambda *args: datacatalog.Schema())
     def test_make_entry_for_dashboard_should_use_created_on_no_updated_date(
             self):
 
@@ -194,7 +215,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             created_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
-    def test_make_entry_for_widget_should_set_all_available_fields(self):
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_widget')
+    def test_make_entry_for_widget_should_set_all_available_fields(
+            self, mock_make_schema_for_widget):
+
         metadata = {
             '_id': 'a123-b456',
             'oid': 'a123-b457',
@@ -204,6 +228,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'lastUpdated': '2019-09-12T16:31:00.005Z',
             'dashboardid': 'a123',
         }
+
+        schema = datacatalog.Schema()
+        mock_make_schema_for_widget.return_value = schema
 
         entry_id, entry = self.__factory.make_entry_for_widget(metadata)
 
@@ -233,6 +260,11 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             updated_datetime.timestamp(),
             entry.source_system_timestamps.update_time.timestamp())
 
+        mock_make_schema_for_widget.assert_called_once_with(metadata)
+        self.assertEqual(schema, entry.schema)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_widget',
+                lambda *args: datacatalog.Schema())
     def test_make_entry_for_widget_should_set_unnamed_on_missing_title(self):
 
         metadata = {
@@ -244,6 +276,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('Unnamed', entry.display_name)
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_widget',
+                lambda *args: datacatalog.Schema())
     def test_make_entry_for_widget_should_succeed_on_missing_created_date(
             self):
 
@@ -257,6 +291,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertIsNone(entry.source_system_timestamps.create_time)
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_schema_for_widget',
+                lambda *args: datacatalog.Schema())
     def test_make_entry_for_widget_should_use_created_on_no_updated_date(self):
         metadata = {
             '_id': 'a123-b456',


### PR DESCRIPTION
**- What I did**
Added features that allow the Sisense Connector to synchronize Dashboard and Widget filters as schema columns in Google Data Catalog.

**- How I did it**
Added the `__make_schema_for_dashboard()` and `__make_schema_for_widget()` methods to the `scrape.DataCatalogEntryFactory` class.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added features that allow the Sisense Connector to synchronize Dashboard and Widget filters as schema columns in Google Data Catalog.

PS: This PR is part of the effort to deliver #70.