### PR TITLE
Make JAQL query tags

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -34,8 +34,8 @@ TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 # The ID of the Tag Template created to store lineage metadata for
-# JAQL Object-related entities.
-TAG_TEMPLATE_ID_JAQL_OBJECT = 'sisense_jaql_object_metadata'
+# JAQL-dependent entities.
+TAG_TEMPLATE_ID_JAQL = 'sisense_jaql_metadata'
 # The ID of the Tag Template created to store additional metadata for
 # Widget-related Entries.
 TAG_TEMPLATE_ID_WIDGET = 'sisense_widget_metadata'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -33,9 +33,9 @@ TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
 # The ID of the Tag Template created to store additional metadata for
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
-# The ID of the Tag Template created to store additional metadata for
-# JAQL Query-related Entries.
-TAG_TEMPLATE_ID_JAQL_QUERY = 'sisense_jaql_query_metadata'
+# The ID of the Tag Template created to store lineage metadata for
+# JAQL Object-related entities.
+TAG_TEMPLATE_ID_JAQL_OBJECT = 'sisense_jaql_object_metadata'
 # The ID of the Tag Template created to store additional metadata for
 # Widget-related Entries.
 TAG_TEMPLATE_ID_WIDGET = 'sisense_widget_metadata'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -34,6 +34,9 @@ TAG_TEMPLATE_ID_DASHBOARD = 'sisense_dashboard_metadata'
 # Folder-related Entries.
 TAG_TEMPLATE_ID_FOLDER = 'sisense_folder_metadata'
 # The ID of the Tag Template created to store additional metadata for
+# JAQL Query-related Entries.
+TAG_TEMPLATE_ID_JAQL_QUERY = 'sisense_jaql_query_metadata'
+# The ID of the Tag Template created to store additional metadata for
 # Widget-related Entries.
 TAG_TEMPLATE_ID_WIDGET = 'sisense_widget_metadata'
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -238,5 +238,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         column = datacatalog.ColumnSchema()
         column.column = jaql_metadata.get('title')
-        column.type = jaql_metadata.get('datatype')
+        column.type = jaql_metadata.get('datatype') or jaql_metadata.get(
+            'type')
+
         return column

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from datetime import datetime
+import re
 from typing import Any, Dict
 
 from google.cloud import datacatalog
@@ -115,6 +116,43 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             self._set_double_field(tag, 'dashboard_count', dashboard_count)
 
         self._set_string_field(tag, 'server_url', self.__server_address)
+
+        return tag
+
+    def make_tag_for_jaql_object(self, tag_template: TagTemplate,
+                                 jaql_metadata: Dict[str, Any]) -> Tag:
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        dim_table = None
+        dim_column = None
+        dimension = jaql_metadata.get('dim')
+        if dimension:
+            self._set_string_field(tag, 'dimension', dimension)
+
+            # According to the Sisense Support Team, JAQL objects should
+            # contain the ``table`` and ``column`` fields, but we have seen
+            # some cases in which it does not happen -- e.g.: dashboards that
+            # were created a long time ago and migrated from version to
+            # version, as well as from platform to platform (Windows to Linux),
+            # have the ``dim`` field, but not ``table`` and ``column``. So, we
+            # decided to scrape table and column metadata from the dimension
+            # when the appropriate fields are not available to avoid losing
+            # relevant lineage information. A regex is used to do so.
+            dim_matches = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
+                                    dimension)
+            dim_table = dim_matches.groups('table')
+            dim_column = dim_matches.groups('column')
+
+        self._set_string_field(tag, 'table',
+                               jaql_metadata.get('table') or dim_table)
+        self._set_string_field(tag, 'column',
+                               jaql_metadata.get('column') or dim_column)
+
+        self._set_string_field(tag, 'formula', jaql_metadata.get('formula'))
+        self._set_string_field(tag, 'aggregation', jaql_metadata.get('agg'))
 
         return tag
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -119,43 +119,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         return tag
 
-    def make_tag_for_jaql_object(self, tag_template: TagTemplate,
-                                 jaql_metadata: Dict[str, Any]) -> Tag:
-
-        tag = datacatalog.Tag()
-
-        tag.template = tag_template.name
-
-        dim_table = None
-        dim_column = None
-        dimension = jaql_metadata.get('dim')
-        if dimension:
-            self._set_string_field(tag, 'dimension', dimension)
-
-            # According to the Sisense Support Team, JAQL objects should
-            # contain the ``table`` and ``column`` fields, but we have seen
-            # some cases in which it does not happen -- e.g.: dashboards that
-            # were created a long time ago and migrated from version to
-            # version, as well as from platform to platform (Windows to Linux),
-            # have the ``dim`` field, but not ``table`` and ``column``. So, we
-            # decided to scrape table and column metadata from the dimension
-            # when the appropriate fields are not available to avoid losing
-            # relevant lineage information. A regex is used to do so.
-            dim_matches = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
-                                    dimension)
-            dim_table = dim_matches.groups('table')
-            dim_column = dim_matches.groups('column')
-
-        self._set_string_field(tag, 'table',
-                               jaql_metadata.get('table') or dim_table)
-        self._set_string_field(tag, 'column',
-                               jaql_metadata.get('column') or dim_column)
-
-        self._set_string_field(tag, 'formula', jaql_metadata.get('formula'))
-        self._set_string_field(tag, 'aggregation', jaql_metadata.get('agg'))
-
-        return tag
-
     def make_tag_for_widget(self, tag_template: TagTemplate,
                             widget_metadata: Dict[str, Any]) -> Tag:
 
@@ -188,5 +151,42 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             self._set_string_field(tag, 'datasource', datasource)
 
         self._set_string_field(tag, 'server_url', self.__server_address)
+
+        return tag
+
+    def __make_tag_for_jaql(self, tag_template: TagTemplate,
+                            jaql_metadata: Dict[str, Any]) -> Tag:
+
+        tag = datacatalog.Tag()
+
+        tag.template = tag_template.name
+
+        dim_table = None
+        dim_column = None
+        dimension = jaql_metadata.get('dim')
+        if dimension:
+            self._set_string_field(tag, 'dimension', dimension)
+
+            # According to the Sisense Support Team, JAQL objects should
+            # contain the ``table`` and ``column`` fields, but we have seen
+            # some cases in which it does not happen -- e.g.: dashboards that
+            # were created a long time ago and migrated from version to
+            # version, as well as from platform to platform (Windows to Linux),
+            # have the ``dim`` field, but not ``table`` and ``column``. So, we
+            # decided to scrape table and column metadata from the dimension
+            # when the appropriate fields are not available to avoid losing
+            # relevant lineage information. A regex is used to do so.
+            dim_matches = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
+                                    dimension)
+            dim_table = dim_matches.groups('table')
+            dim_column = dim_matches.groups('column')
+
+        self._set_string_field(tag, 'table',
+                               jaql_metadata.get('table') or dim_table)
+        self._set_string_field(tag, 'column',
+                               jaql_metadata.get('column') or dim_column)
+
+        self._set_string_field(tag, 'formula', jaql_metadata.get('formula'))
+        self._set_string_field(tag, 'aggregation', jaql_metadata.get('agg'))
 
         return tag

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -178,8 +178,8 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             # relevant lineage information. A regex is used to do so.
             dim_matches = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
                                     dimension)
-            dim_table = dim_matches.groups('table')
-            dim_column = dim_matches.groups('column')
+            dim_table = dim_matches.group('table')
+            dim_column = dim_matches.group('column')
 
         self._set_string_field(tag, 'table',
                                jaql_metadata.get('table') or dim_table)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -189,4 +189,6 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'formula', jaql_metadata.get('formula'))
         self._set_string_field(tag, 'aggregation', jaql_metadata.get('agg'))
 
+        self._set_string_field(tag, 'server_url', self.__server_address)
+
         return tag

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -190,6 +190,61 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
+    def make_tag_template_for_jaql_query(self) -> TagTemplate:
+        tag_template = datacatalog.TagTemplate()
+
+        tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
+            project=self.__project_id,
+            location=self.__location_id,
+            tag_template=constants.TAG_TEMPLATE_ID_JAQL_QUERY)
+
+        tag_template.display_name = 'Sisense JAQL Query Metadata'
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='table',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Table',
+                                       order=7)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='column',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Column',
+                                       order=6)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='dimension',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Dimension',
+                                       order=5)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='formula',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Formula',
+                                       order=4)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='aggregation',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Aggregation',
+                                       order=3)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='datatype',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Datatype',
+                                       order=2)
+
+        self._add_primitive_type_field(tag_template=tag_template,
+                                       field_id='server_url',
+                                       field_type=self.__STRING_TYPE,
+                                       display_name='Sisense Server Url',
+                                       is_required=True,
+                                       order=1)
+
+        return tag_template
+
     def make_tag_template_for_widget(self) -> TagTemplate:
         tag_template = datacatalog.TagTemplate()
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -190,15 +190,15 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
-    def make_tag_template_for_jaql_object(self) -> TagTemplate:
+    def make_tag_template_for_jaql(self) -> TagTemplate:
         tag_template = datacatalog.TagTemplate()
 
         tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
             project=self.__project_id,
             location=self.__location_id,
-            tag_template=constants.TAG_TEMPLATE_ID_JAQL_OBJECT)
+            tag_template=constants.TAG_TEMPLATE_ID_JAQL)
 
-        tag_template.display_name = 'Sisense JAQL Object Metadata'
+        tag_template.display_name = 'Sisense JAQL Metadata'
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='table',

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory.py
@@ -190,50 +190,44 @@ class DataCatalogTagTemplateFactory(prepare.BaseTagTemplateFactory):
 
         return tag_template
 
-    def make_tag_template_for_jaql_query(self) -> TagTemplate:
+    def make_tag_template_for_jaql_object(self) -> TagTemplate:
         tag_template = datacatalog.TagTemplate()
 
         tag_template.name = datacatalog.DataCatalogClient.tag_template_path(
             project=self.__project_id,
             location=self.__location_id,
-            tag_template=constants.TAG_TEMPLATE_ID_JAQL_QUERY)
+            tag_template=constants.TAG_TEMPLATE_ID_JAQL_OBJECT)
 
-        tag_template.display_name = 'Sisense JAQL Query Metadata'
+        tag_template.display_name = 'Sisense JAQL Object Metadata'
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='table',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Table',
-                                       order=7)
+                                       order=6)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='column',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Column',
-                                       order=6)
+                                       order=5)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='dimension',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Dimension',
-                                       order=5)
+                                       order=4)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='formula',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Formula',
-                                       order=4)
+                                       order=3)
 
         self._add_primitive_type_field(tag_template=tag_template,
                                        field_id='aggregation',
                                        field_type=self.__STRING_TYPE,
                                        display_name='Aggregation',
-                                       order=3)
-
-        self._add_primitive_type_field(tag_template=tag_template,
-                                       field_id='datatype',
-                                       field_type=self.__STRING_TYPE,
-                                       display_name='Datatype',
                                        order=2)
 
         self._add_primitive_type_field(tag_template=tag_template,

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -392,3 +392,14 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('TEST', column.column)
         self.assertEqual('datetime', column.type)
+
+    def test_make_column_schema_for_jaql_should_use_type_field_fallback(self):
+        metadata = {'type': 'datetime', 'title': 'TEST'}
+
+        column = \
+            self.__factory\
+                ._DataCatalogEntryFactory__make_column_schema_for_jaql(
+                    metadata)
+
+        self.assertEqual('TEST', column.column)
+        self.assertEqual('datetime', column.type)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -129,6 +129,53 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
 
+    def test_make_tag_for_jaql_should_set_all_available_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'dim': '[table_a.column_a]',
+            'formula': 'GrowthPastYear([AVG COST])',
+            'agg': 'avg',
+        }
+
+        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+            tag_template, metadata)
+
+        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
+
+        self.assertEqual('table_a', tag.fields['table'].string_value)
+        self.assertEqual('column_a', tag.fields['column'].string_value)
+        self.assertEqual('[table_a.column_a]',
+                         tag.fields['dimension'].string_value)
+        self.assertEqual('GrowthPastYear([AVG COST])',
+                         tag.fields['formula'].string_value)
+        self.assertEqual('avg', tag.fields['aggregation'].string_value)
+        self.assertEqual('https://test.com',
+                         tag.fields['server_url'].string_value)
+
+    def test_make_tag_for_jaql_should_read_table_and_column_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'table': 'table_a',
+            'column': 'column_a',
+            'dim': '[table_b.column_b]',
+        }
+
+        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+            tag_template, metadata)
+
+        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
+
+        # The ``table`` field takes priority over ``dim``.
+        self.assertEqual('table_a', tag.fields['table'].string_value)
+        # The ``column`` field takes priority over ``dim``.
+        self.assertEqual('column_a', tag.fields['column'].string_value)
+        self.assertEqual('[table_b.column_b]',
+                         tag.fields['dimension'].string_value)
+
     def test_make_tag_for_widget_should_set_all_available_fields(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_widget_metadata'

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -200,15 +200,14 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
                          tag_template.fields['server_url'].display_name)
         self.assertTrue(tag_template.fields['server_url'].is_required)
 
-    def test_make_tag_template_for_jaql_object(self):
-        tag_template = self.__factory.make_tag_template_for_jaql_object()
+    def test_make_tag_template_for_jaql(self):
+        tag_template = self.__factory.make_tag_template_for_jaql()
 
         self.assertEqual(
             'projects/test-project/locations/test-location/'
-            'tagTemplates/sisense_jaql_object_metadata', tag_template.name)
+            'tagTemplates/sisense_jaql_metadata', tag_template.name)
 
-        self.assertEqual('Sisense JAQL Object Metadata',
-                         tag_template.display_name)
+        self.assertEqual('Sisense JAQL Metadata', tag_template.display_name)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['table'].type.primitive_type)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -200,14 +200,14 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
                          tag_template.fields['server_url'].display_name)
         self.assertTrue(tag_template.fields['server_url'].is_required)
 
-    def test_make_tag_template_for_jaql_query(self):
-        tag_template = self.__factory.make_tag_template_for_jaql_query()
+    def test_make_tag_template_for_jaql_object(self):
+        tag_template = self.__factory.make_tag_template_for_jaql_object()
 
         self.assertEqual(
             'projects/test-project/locations/test-location/'
-            'tagTemplates/sisense_jaql_query_metadata', tag_template.name)
+            'tagTemplates/sisense_jaql_object_metadata', tag_template.name)
 
-        self.assertEqual('Sisense JAQL Query Metadata',
+        self.assertEqual('Sisense JAQL Object Metadata',
                          tag_template.display_name)
 
         self.assertEqual(self.__STRING_TYPE,
@@ -238,12 +238,6 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
         self.assertEqual('Aggregation',
                          tag_template.fields['aggregation'].display_name)
         self.assertFalse(tag_template.fields['aggregation'].is_required)
-
-        self.assertEqual(self.__STRING_TYPE,
-                         tag_template.fields['datatype'].type.primitive_type)
-        self.assertEqual('Datatype',
-                         tag_template.fields['datatype'].display_name)
-        self.assertFalse(tag_template.fields['datatype'].is_required)
 
         self.assertEqual(self.__STRING_TYPE,
                          tag_template.fields['server_url'].type.primitive_type)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_template_factory_test.py
@@ -200,6 +200,57 @@ class DataCatalogTagTemplateFactoryTest(unittest.TestCase):
                          tag_template.fields['server_url'].display_name)
         self.assertTrue(tag_template.fields['server_url'].is_required)
 
+    def test_make_tag_template_for_jaql_query(self):
+        tag_template = self.__factory.make_tag_template_for_jaql_query()
+
+        self.assertEqual(
+            'projects/test-project/locations/test-location/'
+            'tagTemplates/sisense_jaql_query_metadata', tag_template.name)
+
+        self.assertEqual('Sisense JAQL Query Metadata',
+                         tag_template.display_name)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['table'].type.primitive_type)
+        self.assertEqual('Table', tag_template.fields['table'].display_name)
+        self.assertFalse(tag_template.fields['table'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['column'].type.primitive_type)
+        self.assertEqual('Column', tag_template.fields['column'].display_name)
+        self.assertFalse(tag_template.fields['column'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['dimension'].type.primitive_type)
+        self.assertEqual('Dimension',
+                         tag_template.fields['dimension'].display_name)
+        self.assertFalse(tag_template.fields['dimension'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['formula'].type.primitive_type)
+        self.assertEqual('Formula',
+                         tag_template.fields['formula'].display_name)
+        self.assertFalse(tag_template.fields['formula'].is_required)
+
+        self.assertEqual(
+            self.__STRING_TYPE,
+            tag_template.fields['aggregation'].type.primitive_type)
+        self.assertEqual('Aggregation',
+                         tag_template.fields['aggregation'].display_name)
+        self.assertFalse(tag_template.fields['aggregation'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['datatype'].type.primitive_type)
+        self.assertEqual('Datatype',
+                         tag_template.fields['datatype'].display_name)
+        self.assertFalse(tag_template.fields['datatype'].is_required)
+
+        self.assertEqual(self.__STRING_TYPE,
+                         tag_template.fields['server_url'].type.primitive_type)
+        self.assertEqual('Sisense Server Url',
+                         tag_template.fields['server_url'].display_name)
+        self.assertTrue(tag_template.fields['server_url'].is_required)
+
     def test_make_tag_template_for_widget(self):
         tag_template = self.__factory.make_tag_template_for_widget()
 


### PR DESCRIPTION
**- What I did**
Added features that allow the Sisense Connector to create a Tag Template and Tags to store JAQL query metadata.

**- How I did it**
Added `DataCatalogTagTemplateFactory.make_tag_template_for_jaql()` and `DataCatalogTagFactory.__make_tag_for_jaql()`, and their unit tests as well.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added features that allow the Sisense Connector to create a Tag Template and Tags to store JAQL query metadata.

