### PR TITLE
Make column schema for fields

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -278,6 +278,17 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
                       f'{source_type_identifier}{source_id}'
         return self._format_id(prefixed_id)
 
+    @classmethod
+    def __make_column_schema_for_jaql(
+            cls, jaql_metadata: Dict[str, Any]) -> ColumnSchema:
+
+        column = datacatalog.ColumnSchema()
+        column.column = cls.__format_column_name(jaql_metadata.get('title'))
+        column.type = jaql_metadata.get('datatype') or jaql_metadata.get(
+            'type') or 'unknown'
+
+        return column
+
     # TODO Move this method to the ``BaseEntryFactory`` super class.
     @classmethod
     def __format_column_name(cls, column_name, normalize=True):
@@ -301,14 +312,3 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
 
         return prepare.DataCatalogStringsHelper.truncate_string(
             formatted_column_name, cls.__COLUMN_NAME_UTF8_MAX_LENGTH)
-
-    @classmethod
-    def __make_column_schema_for_jaql(
-            cls, jaql_metadata: Dict[str, Any]) -> ColumnSchema:
-
-        column = datacatalog.ColumnSchema()
-        column.column = cls.__format_column_name(jaql_metadata.get('title'))
-        column.type = jaql_metadata.get('datatype') or jaql_metadata.get(
-            'type') or 'unknown'
-
-        return column

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -218,7 +218,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         if filters_column:
             schema.columns.append(filters_column)
 
-        return schema
+        return schema if schema.columns else None
 
     @classmethod
     def __make_fields_column_for_widget(
@@ -243,7 +243,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
                 fields_column.subcolumns.append(
                     cls.__make_column_schema_for_jaql(item.get('jaql')))
 
-        return fields_column
+        return fields_column if fields_column.subcolumns else None
 
     @classmethod
     def __make_filters_column_for_widget(
@@ -270,7 +270,7 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             filters_column.subcolumns.append(
                 cls.__make_column_schema_for_jaql(widget_filter.get('jaql')))
 
-        return filters_column
+        return filters_column if filters_column.subcolumns else None
 
     def __format_id(self, source_type_identifier, source_id):
         prefixed_id = f'{constants.ENTRY_ID_PREFIX}' \

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/sisense_connector_strings_helper.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/sisense_connector_strings_helper.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import six
+import unicodedata
+
+from google.datacatalog_connectors.commons import prepare
+
+
+class SisenseConnectorStringsHelper:
+    """
+    Temporary class providing the logic to format column names currently
+    required by the Entry and Tag factories.
+
+    TODO
+     1. Merge this class with
+     ``...datacatalog_connectors.commons.prepare.DataCatalogStringsHelper``.
+     2. Delete this class.
+     3. Refactor ``...commons.prepare.DataCatalogStringsHelper`` to turn
+     ``normalize_string`` a public method.
+     4. Refactor ``...commons.prepare.BaseEntryFactory`` to call
+     ``...commons.prepare.DataCatalogStringsHelper.normalize_string`` instead
+     of declaring its own __normalize_string method as it will be a duplicate.
+     5. Refactor ``DataCatalogEntryFactory`` to call
+     ``...commons.prepare.DataCatalogStringsHelper.normalize_string`` as the
+     present class will no longer exist after the refactoring.
+     6. Refactor ``DataCatalogTagFactory`` to call
+     ``...commons.prepare.DataCatalogStringsHelper.normalize_string`` as the
+     present class will no longer exist after the refactoring.
+    """
+    __ASCII_CHARACTER_ENCODING = 'ASCII'
+    # Column names must contain only unicode characters excluding dots and
+    # control characters and be at most 300 bytes long when encoded in UTF-8.
+    __COLUMN_NAME_INVALID_CHARS_REGEX_PATTERN = r'[\.]+'
+    __COLUMN_NAME_UTF8_MAX_LENGTH = 300
+
+    @classmethod
+    def format_column_name(cls, column_name, normalize=True):
+        """
+        Formats the column_name to fit the string bytes limit enforced by
+        Data Catalog, and optionally normalizes it by applying a regex pattern
+        that replaces unsupported characters with underscore.
+
+        Warning: truncating and normalizing column names may lead to slightly
+        different names from the source system columns.
+
+        :param column_name: the value to be formatted.
+        :param normalize: enables the normalize logic.
+
+        :return: The formatted column name.
+        """
+        formatted_column_name = column_name
+        if normalize:
+            formatted_column_name = cls.__normalize_string(
+                cls.__COLUMN_NAME_INVALID_CHARS_REGEX_PATTERN, column_name)
+
+        return prepare.DataCatalogStringsHelper.truncate_string(
+            formatted_column_name, cls.__COLUMN_NAME_UTF8_MAX_LENGTH)
+
+    @classmethod
+    def __normalize_string(cls, regex_pattern, source_string):
+        formatted_str = re.sub(
+            regex_pattern, '_',
+            cls.__normalize_ascii_chars(source_string.strip()))
+
+        # The __normalize_ascii_chars logic may replace a non ascii
+        # char with space at the end of the string, so we need to do
+        # an additional strip() to make sure it is removed from the
+        # final normalized string.
+        return formatted_str.strip()
+
+    @classmethod
+    def __normalize_ascii_chars(cls, source_string):
+        encoding = cls.__ASCII_CHARACTER_ENCODING
+        normalized = unicodedata.normalize(
+            'NFKD', source_string
+            if isinstance(source_string, six.string_types) else u'')
+        encoded = normalized.encode(encoding, 'ignore')
+        return encoded.decode()

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -25,7 +25,6 @@ from google.datacatalog_connectors.sisense.prepare import \
 
 
 class DataCatalogEntryFactoryTest(unittest.TestCase):
-    __COMMONS_PREP_PACKAGE = 'google.datacatalog_connectors.commons.prepare'
     __FACTORY_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
     __FACTORY_MODULE = f'{__FACTORY_PACKAGE}.datacatalog_entry_factory'
     __FACTORY_CLASS = f'{__FACTORY_MODULE}.DataCatalogEntryFactory'
@@ -456,7 +455,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertIsNone(schema)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__format_column_name',
+    @mock.patch(f'{__FACTORY_PACKAGE}.sisense_connector_strings_helper'
+                f'.SisenseConnectorStringsHelper.format_column_name',
                 lambda *args: args[0])
     def test_make_column_schema_for_jaql_should_set_all_available_fields(self):
         metadata = {'datatype': 'datetime', 'title': 'TEST'}
@@ -469,7 +469,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('TEST', column.column)
         self.assertEqual('datetime', column.type)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__format_column_name',
+    @mock.patch(f'{__FACTORY_PACKAGE}.sisense_connector_strings_helper'
+                f'.SisenseConnectorStringsHelper.format_column_name',
                 lambda *args: args[0])
     def test_make_column_schema_for_jaql_should_use_type_field_fallback(self):
         metadata = {'type': 'datetime', 'title': 'TEST'}
@@ -481,43 +482,3 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('TEST', column.column)
         self.assertEqual('datetime', column.type)
-
-    # TODO Move all format_column_name tests to the ``BaseEntryFactory`` super
-    #  class.
-    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
-                f'.truncate_string', lambda *args: args[0])
-    def test_format_column_name_should_not_change_compliant_string(self):
-        formatted_column_name = self.__factory\
-            ._DataCatalogEntryFactory__format_column_name('# (test)')
-
-        self.assertEqual('# (test)', formatted_column_name)
-
-    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
-                f'.truncate_string', lambda *args: args[0])
-    def test_format_column_name_should_normalize_non_compliant_string(self):
-        formatted_column_name = self.__factory\
-            ._DataCatalogEntryFactory__format_column_name('#.(test)')
-
-        self.assertEqual('#_(test)', formatted_column_name)
-
-    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
-                f'.truncate_string', lambda *args: args[0])
-    def test_format_column_name_can_optionally_avoid_normalizing_string(self):
-        formatted_column_name = self.__factory\
-            ._DataCatalogEntryFactory__format_column_name('#.(test)', False)
-
-        self.assertEqual('#.(test)', formatted_column_name)
-
-    @mock.patch(f'{__COMMONS_PREP_PACKAGE}'
-                f'.DataCatalogStringsHelper.truncate_string')
-    def test_format_column_name_should_return_truncated_string(
-            self, mock_truncate_string):
-
-        expected_value = 'truncated_str...'
-        mock_truncate_string.return_value = expected_value
-
-        formatted_column_name = self.__factory\
-            ._DataCatalogEntryFactory__format_column_name('# (test) # (test)')
-
-        mock_truncate_string.assert_called_once_with('# (test) # (test)', 300)
-        self.assertEqual(expected_value, formatted_column_name)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/sisense_connector_strings_helper_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/sisense_connector_strings_helper_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.datacatalog_connectors.sisense.prepare import \
+    sisense_connector_strings_helper
+
+
+class SisenseConnectorStringsHelperTest(unittest.TestCase):
+    __COMMONS_PREP_PACKAGE = 'google.datacatalog_connectors.commons.prepare'
+
+    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
+                f'.truncate_string', lambda *args: args[0])
+    def test_format_column_name_should_not_change_compliant_string(self):
+        formatted_column_name = sisense_connector_strings_helper\
+            .SisenseConnectorStringsHelper.format_column_name('# (test)')
+
+        self.assertEqual('# (test)', formatted_column_name)
+
+    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
+                f'.truncate_string', lambda *args: args[0])
+    def test_format_column_name_should_normalize_non_compliant_string(self):
+        formatted_column_name = sisense_connector_strings_helper\
+            .SisenseConnectorStringsHelper.format_column_name('#.(test)')
+
+        self.assertEqual('#_(test)', formatted_column_name)
+
+    @mock.patch(f'{__COMMONS_PREP_PACKAGE}.DataCatalogStringsHelper'
+                f'.truncate_string', lambda *args: args[0])
+    def test_format_column_name_can_optionally_avoid_normalizing_string(self):
+        formatted_column_name = sisense_connector_strings_helper\
+            .SisenseConnectorStringsHelper\
+            .format_column_name('#.(test)', False)
+
+        self.assertEqual('#.(test)', formatted_column_name)
+
+    @mock.patch(f'{__COMMONS_PREP_PACKAGE}'
+                f'.DataCatalogStringsHelper.truncate_string')
+    def test_format_column_name_should_return_truncated_string(
+            self, mock_truncate_string):
+
+        expected_value = 'truncated_str...'
+        mock_truncate_string.return_value = expected_value
+
+        formatted_column_name = sisense_connector_strings_helper\
+            .SisenseConnectorStringsHelper\
+            .format_column_name('# (test) # (test)')
+
+        mock_truncate_string.assert_called_once_with('# (test) # (test)', 300)
+        self.assertEqual(expected_value, formatted_column_name)


### PR DESCRIPTION
**- What I did**
Added a feature that allows the Sisense Connector to synchronize Widget fields as schema columns in Google Data Catalog.

**- How I did it**
1. Refactored the `__make_schema_for_widget()` method of `scrape.DataCatalogEntryFactory` so it delegates fields and filters columns generation.
2. Created the `DataCatalogEntryFactory.__make_fields_column_for_widget()` method.
3. Created the `DataCatalogEntryFactory.__make_filters_column_for_widget()` method.
4. Added the `prepare.SisenseConnectorStringsHelper` temporary class (instructions on how to remove it in the future are available in the class docs).
5. Add unit tests to fully cover the above changes.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added a feature that allows the Sisense Connector to synchronize Widget fields as schema columns in Google Data Catalog.

PS: This PR is part of the effort to deliver #70.