### PR TITLE
Sync tags for JAQL queries

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -154,6 +154,9 @@ class AssembledEntryFactory:
         jaql_tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_JAQL)
         if jaql_tag_template:
             tags.extend(
+                self.__datacatalog_tag_factory.make_tags_for_widget_fields(
+                    jaql_tag_template, widget_metadata))
+            tags.extend(
                 self.__datacatalog_tag_factory.make_tags_for_widget_filters(
                     jaql_tag_template, widget_metadata))
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -120,11 +120,17 @@ class AssembledEntryFactory:
                 dashboard_metadata)
 
         tags = []
-        tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_DASHBOARD)
-        if tag_template:
+        dashboard_tag_template = tag_templates.get(
+            constants.TAG_TEMPLATE_ID_DASHBOARD)
+        if dashboard_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_dashboard(
-                    tag_template, dashboard_metadata))
+                    dashboard_tag_template, dashboard_metadata))
+        jaql_tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_JAQL)
+        if jaql_tag_template:
+            tags.extend(
+                self.__datacatalog_tag_factory.make_tags_for_dashboard_filters(
+                    jaql_tag_template, dashboard_metadata))
 
         return prepare.AssembledEntryData(entry_id=entry_id,
                                           entry=entry,

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory.py
@@ -145,11 +145,17 @@ class AssembledEntryFactory:
                 widget_metadata)
 
         tags = []
-        tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_WIDGET)
-        if tag_template:
+        widget_tag_template = tag_templates.get(
+            constants.TAG_TEMPLATE_ID_WIDGET)
+        if widget_tag_template:
             tags.append(
                 self.__datacatalog_tag_factory.make_tag_for_widget(
-                    tag_template, widget_metadata))
+                    widget_tag_template, widget_metadata))
+        jaql_tag_template = tag_templates.get(constants.TAG_TEMPLATE_ID_JAQL)
+        if jaql_tag_template:
+            tags.extend(
+                self.__datacatalog_tag_factory.make_tags_for_widget_filters(
+                    jaql_tag_template, widget_metadata))
 
         return prepare.AssembledEntryData(entry_id=entry_id,
                                           entry=entry,

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -46,3 +46,18 @@ USER_SPECIFIED_TYPE_DASHBOARD = 'Dashboard'
 USER_SPECIFIED_TYPE_FOLDER = 'Folder'
 # The user specified type of Widget-related Entries.
 USER_SPECIFIED_TYPE_WIDGET = 'Widget'
+
+# Name of the field used by Sisense Dashboards to store their filters.
+DASHBOARD_FILTERS_FIELD_NAME = 'filters'
+# Name of the column used to store filters metadata in Dashboard-related
+# Data Catalog entries.
+DASHBOARD_ENTRY_FILTERS_COLUMN_NAME = 'filters'
+
+# Name of the panel used by Sisense Widgets to store their filters.
+WIDGET_FILTERS_PANEL_NAME = 'filters'
+# Name of the column used to store fields metadata in Widget-related
+# Data Catalog entries.
+WIDGET_ENTRY_FIELDS_COLUMN_NAME = 'fields'
+# Name of the column used to store filters metadata in Widget-related
+# Data Catalog entries.
+WIDGET_ENTRY_FILTERS_COLUMN_NAME = 'filters'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -29,7 +29,6 @@ from google.datacatalog_connectors.sisense.prepare import \
 class DataCatalogEntryFactory(prepare.BaseEntryFactory):
     __INCOMING_TIMESTAMP_UTC_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
     __UNNAMED = 'Unnamed'
-    __WIDGET_FILTERS_PANEL_NAME = 'filters'
 
     def __init__(self, project_id: str, location_id: str, entry_group_id: str,
                  user_specified_system: str, server_address: str):
@@ -95,11 +94,12 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             return
 
         filters_column = datacatalog.ColumnSchema()
-        filters_column.column = 'filters'
+        filters_column.column = constants.DASHBOARD_ENTRY_FILTERS_COLUMN_NAME
         filters_column.type = 'array'
         filters_column.description = 'The Dashboard filters'
 
-        for dashboard_filter in dashboard_metadata['filters']:
+        for dashboard_filter in dashboard_metadata[
+                constants.DASHBOARD_FILTERS_FIELD_NAME]:
             filters_column.subcolumns.append(
                 cls.__make_column_schema_for_jaql(
                     dashboard_filter.get('jaql')))
@@ -224,14 +224,14 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             return
 
         fields_column = datacatalog.ColumnSchema()
-        fields_column.column = 'fields'
+        fields_column.column = constants.WIDGET_ENTRY_FIELDS_COLUMN_NAME
         fields_column.type = 'array'
         fields_column.description = 'The Widget fields'
 
         panels = widget_metadata['metadata']['panels']
         fields = [
             panel for panel in panels
-            if not panel.get('name') == cls.__WIDGET_FILTERS_PANEL_NAME
+            if not panel.get('name') == constants.WIDGET_FILTERS_PANEL_NAME
         ]
         for field in fields:
             for item in field.get('items'):
@@ -252,12 +252,13 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         filters = next(
             (panel.get('items')
              for panel in panels
-             if panel.get('name') == cls.__WIDGET_FILTERS_PANEL_NAME), None)
+             if panel.get('name') == constants.WIDGET_FILTERS_PANEL_NAME),
+            None)
         if not filters:
             return
 
         filters_column = datacatalog.ColumnSchema()
-        filters_column.column = 'filters'
+        filters_column.column = constants.WIDGET_ENTRY_FILTERS_COLUMN_NAME
         filters_column.type = 'array'
         filters_column.description = 'The Widget filters'
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -16,7 +16,7 @@
 
 from datetime import datetime
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from google.cloud import datacatalog
 from google.cloud.datacatalog import Tag, TagTemplate
@@ -76,6 +76,23 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         self._set_string_field(tag, 'server_url', self.__server_address)
 
         return tag
+
+    def make_tags_for_dashboard_filters(
+            self, tag_template: TagTemplate,
+            dashboard_metadata: Dict[str, Any]) -> List[Tag]:
+
+        tags = []
+
+        if not dashboard_metadata.get('filters'):
+            return tags
+
+        for dashboard_filter in dashboard_metadata['filters']:
+            jaql = dashboard_filter.get('jaql')
+            tag = self.make_tag_for_jaql_object(tag_template, jaql)
+            tag.column = f'filters.{jaql.get("title")}'
+            tags.append(tag)
+
+        return tags
 
     def make_tag_for_folder(self, tag_template: TagTemplate,
                             folder_metadata: Dict[str, Any]) -> Tag:

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -78,7 +78,7 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         return tag
 
     def make_tags_for_dashboard_filters(
-            self, tag_template: TagTemplate,
+            self, jaql_tag_template: TagTemplate,
             dashboard_metadata: Dict[str, Any]) -> List[Tag]:
 
         tags = []
@@ -87,12 +87,21 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             return tags
 
         for dashboard_filter in dashboard_metadata['filters']:
-            jaql = dashboard_filter.get('jaql')
-            tag = self.make_tag_for_jaql_object(tag_template, jaql)
-            tag.column = f'filters.{jaql.get("title")}'
-            tags.append(tag)
+            tags.append(
+                self.__make_jaql_tag_for_dashboard_filter(
+                    jaql_tag_template, dashboard_filter))
 
         return tags
+
+    def __make_jaql_tag_for_dashboard_filter(
+            self, tag_template: TagTemplate,
+            filter_metadata: Dict[str, Any]) -> Tag:
+
+        jaql = filter_metadata.get('jaql')
+        tag = self.__make_tag_for_jaql(tag_template, jaql)
+        tag.column = f'filters.{jaql.get("title")}'
+
+        return tag
 
     def make_tag_for_folder(self, tag_template: TagTemplate,
                             folder_metadata: Dict[str, Any]) -> Tag:
@@ -193,10 +202,10 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             # decided to scrape table and column metadata from the dimension
             # when the appropriate fields are not available to avoid losing
             # relevant lineage information. A regex is used to do so.
-            dim_matches = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
-                                    dimension)
-            dim_table = dim_matches.group('table')
-            dim_column = dim_matches.group('column')
+            dim_match = re.search(r'^\[(?P<table>.*)\.(?P<column>.*)]$',
+                                  dimension)
+            dim_table = dim_match.group('table')
+            dim_column = dim_match.group('column')
 
         self._set_string_field(tag, 'table',
                                jaql_metadata.get('table') or dim_table)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -22,7 +22,8 @@ from google.cloud import datacatalog
 from google.cloud.datacatalog import Tag, TagTemplate
 from google.datacatalog_connectors.commons import prepare
 
-from google.datacatalog_connectors.sisense.prepare import constants
+from google.datacatalog_connectors.sisense.prepare import \
+    constants, sisense_connector_strings_helper
 
 
 class DataCatalogTagFactory(prepare.BaseTagFactory):
@@ -193,10 +194,11 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
             return tags
 
         for field in fields:
-            tags.append(
-                self.__make_tag_for_jaql(
-                    jaql_tag_template, field.get('jaql'),
-                    constants.WIDGET_ENTRY_FIELDS_COLUMN_NAME))
+            for item in field.get('items'):
+                tags.append(
+                    self.__make_tag_for_jaql(
+                        jaql_tag_template, item.get('jaql'),
+                        constants.WIDGET_ENTRY_FIELDS_COLUMN_NAME))
 
         return tags
 
@@ -265,6 +267,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         self._set_string_field(tag, 'server_url', self.__server_address)
 
-        tag.column = f'{column_prefix}.{jaql_metadata.get("title")}'
+        title = jaql_metadata.get('title')
+        subcolumn_name = sisense_connector_strings_helper\
+            .SisenseConnectorStringsHelper.format_column_name(title)
+        tag.column = f'{column_prefix}.{subcolumn_name}'
 
         return tag

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -180,6 +180,64 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         return tag
 
+    def make_tags_for_widget_fields(
+            self, jaql_tag_template: TagTemplate,
+            widget_metadata: Dict[str, Any]) -> List[Tag]:
+
+        tags = []
+
+        if not (widget_metadata.get('metadata') and
+                widget_metadata['metadata'].get('panels')):
+            return tags
+
+        panels = widget_metadata['metadata']['panels']
+        filters = next((panel.get('items')
+                        for panel in panels
+                        if panel.get('name') == 'filters'), None)
+        if not filters:
+            return tags
+
+        for widget_filter in filters:
+            tags.append(
+                self.__make_jaql_tag_for_widget_filter(jaql_tag_template,
+                                                       widget_filter))
+
+        return tags
+
+    def make_tags_for_widget_filters(
+            self, jaql_tag_template: TagTemplate,
+            widget_metadata: Dict[str, Any]) -> List[Tag]:
+
+        tags = []
+
+        if not (widget_metadata.get('metadata') and
+                widget_metadata['metadata'].get('panels')):
+            return tags
+
+        panels = widget_metadata['metadata']['panels']
+        filters = next((panel.get('items')
+                        for panel in panels
+                        if panel.get('name') == 'filters'), None)
+        if not filters:
+            return tags
+
+        for widget_filter in filters:
+            tags.append(
+                self.__make_jaql_tag_for_widget_filter(jaql_tag_template,
+                                                       widget_filter))
+
+        return tags
+
+    def __make_jaql_tag_for_widget_filter(
+            self, tag_template: TagTemplate,
+            filter_metadata: Dict[str, Any]) -> Tag:
+
+        jaql = filter_metadata.get('jaql')
+        tag = self.__make_tag_for_jaql(tag_template, jaql)
+        tag.column = f'filters.{jaql.get("title")}'
+
+        return tag
+
     def __make_tag_for_jaql(self, tag_template: TagTemplate,
                             jaql_metadata: Dict[str, Any]) -> Tag:
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sync/metadata_synchronizer.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sync/metadata_synchronizer.py
@@ -275,6 +275,8 @@ class MetadataSynchronizer:
                 self.__tag_template_factory.make_tag_template_for_folder(),
             constants.TAG_TEMPLATE_ID_DASHBOARD:
                 self.__tag_template_factory.make_tag_template_for_dashboard(),
+            constants.TAG_TEMPLATE_ID_JAQL:
+                self.__tag_template_factory.make_tag_template_for_jaql(),
             constants.TAG_TEMPLATE_ID_WIDGET:
                 self.__tag_template_factory.make_tag_template_for_widget(),
         }

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/assembled_entry_factory_test.py
@@ -209,18 +209,29 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             self):
 
         dashboard = self.__make_fake_dashboard()
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/sisense_dashboard_metadata'
-        tag_templates_dict = {'sisense_dashboard_metadata': tag_template}
+
+        dashboard_tag_template = datacatalog.TagTemplate()
+        dashboard_tag_template.name = 'tagTemplates/sisense_dashboard_metadata'
+        jaql_tag_template = datacatalog.TagTemplate()
+        jaql_tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+        tag_templates_dict = {
+            'sisense_dashboard_metadata': dashboard_tag_template,
+            'sisense_jaql_metadata': jaql_tag_template
+        }
 
         fake_entry = ('test-dashboard', {})
         entry_factory = self.__mock_entry_factory
         entry_factory.make_entry_for_dashboard.return_value = fake_entry
 
-        fake_tag = datacatalog.Tag()
-        fake_tag.template = 'tagTemplates/sisense_dashboard_metadata'
         tag_factory = self.__mock_tag_factory
-        tag_factory.make_tag_for_dashboard.return_value = fake_tag
+        fake_dashboard_tag = datacatalog.Tag()
+        fake_dashboard_tag.template = 'tagTemplates/sisense_dashboard_metadata'
+        tag_factory.make_tag_for_dashboard.return_value = fake_dashboard_tag
+        fake_filter_tag = datacatalog.Tag()
+        fake_filter_tag.template = 'tagTemplates/sisense_jaql_metadata'
+        tag_factory.make_tags_for_dashboard_filters.return_value = [
+            fake_filter_tag
+        ]
 
         assembled_entry = self.__factory\
             ._AssembledEntryFactory__make_assembled_entry_for_dashboard(
@@ -232,27 +243,45 @@ class AssembledEntryFactoryTest(unittest.TestCase):
             dashboard)
 
         tags = assembled_entry.tags
-        self.assertEqual(1, len(tags))
+        self.assertEqual(2, len(tags))
         self.assertEqual('tagTemplates/sisense_dashboard_metadata',
                          tags[0].template)
+        self.assertEqual('tagTemplates/sisense_jaql_metadata',
+                         tags[1].template)
         tag_factory.make_tag_for_dashboard.assert_called_once_with(
-            tag_template, dashboard)
+            dashboard_tag_template, dashboard)
+        tag_factory.make_tags_for_dashboard_filters.assert_called_once_with(
+            jaql_tag_template, dashboard)
 
     def test_make_assembled_entry_for_widget_should_make_entry_and_tags(self):
 
         widget = self.__make_fake_widget()
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/sisense_widget_metadata'
-        tag_templates_dict = {'sisense_widget_metadata': tag_template}
+
+        widget_tag_template = datacatalog.TagTemplate()
+        widget_tag_template.name = 'tagTemplates/sisense_widget_metadata'
+        jaql_tag_template = datacatalog.TagTemplate()
+        jaql_tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+        tag_templates_dict = {
+            'sisense_widget_metadata': widget_tag_template,
+            'sisense_jaql_metadata': jaql_tag_template
+        }
 
         fake_entry = ('test-widget', {})
         entry_factory = self.__mock_entry_factory
         entry_factory.make_entry_for_widget.return_value = fake_entry
 
-        fake_tag = datacatalog.Tag()
-        fake_tag.template = 'tagTemplates/sisense_widget_metadata'
         tag_factory = self.__mock_tag_factory
-        tag_factory.make_tag_for_widget.return_value = fake_tag
+        fake_widget_tag = datacatalog.Tag()
+        fake_widget_tag.template = 'tagTemplates/sisense_widget_metadata'
+        tag_factory.make_tag_for_widget.return_value = fake_widget_tag
+        fake_field_tag = datacatalog.Tag()
+        fake_field_tag.template = 'tagTemplates/sisense_jaql_metadata'
+        tag_factory.make_tags_for_widget_fields.return_value = [fake_field_tag]
+        fake_filter_tag = datacatalog.Tag()
+        fake_filter_tag.template = 'tagTemplates/sisense_jaql_metadata'
+        tag_factory.make_tags_for_widget_filters.return_value = [
+            fake_filter_tag
+        ]
 
         assembled_entry = self.__factory\
             ._AssembledEntryFactory__make_assembled_entry_for_widget(
@@ -263,11 +292,19 @@ class AssembledEntryFactoryTest(unittest.TestCase):
         entry_factory.make_entry_for_widget.assert_called_once_with(widget)
 
         tags = assembled_entry.tags
-        self.assertEqual(1, len(tags))
+        self.assertEqual(3, len(tags))
         self.assertEqual('tagTemplates/sisense_widget_metadata',
                          tags[0].template)
+        self.assertEqual('tagTemplates/sisense_jaql_metadata',
+                         tags[1].template)
+        self.assertEqual('tagTemplates/sisense_jaql_metadata',
+                         tags[2].template)
         tag_factory.make_tag_for_widget.assert_called_once_with(
-            tag_template, widget)
+            widget_tag_template, widget)
+        tag_factory.make_tags_for_widget_fields.assert_called_once_with(
+            jaql_tag_template, widget)
+        tag_factory.make_tags_for_widget_filters.assert_called_once_with(
+            jaql_tag_template, widget)
 
     @classmethod
     def __make_fake_folder(cls) -> Dict[str, Any]:

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -137,10 +137,11 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'dim': '[table_a.column_a]',
             'formula': 'GrowthPastYear([AVG COST])',
             'agg': 'avg',
+            'title': 'TEST',
         }
 
         tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
-            tag_template, metadata)
+            tag_template, metadata, 'test')
 
         self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
 
@@ -162,10 +163,11 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'table': 'table_a',
             'column': 'column_a',
             'dim': '[table_b.column_b]',
+            'title': 'TEST',
         }
 
         tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
-            tag_template, metadata)
+            tag_template, metadata, 'test')
 
         self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -16,6 +16,7 @@
 
 from datetime import datetime
 import unittest
+from unittest import mock
 
 from google.cloud import datacatalog
 
@@ -24,6 +25,11 @@ from google.datacatalog_connectors.sisense.prepare import \
 
 
 class DataCatalogEntryFactoryTest(unittest.TestCase):
+    __FACTORY_PACKAGE = 'google.datacatalog_connectors.sisense.prepare'
+    __FACTORY_MODULE = f'{__FACTORY_PACKAGE}.datacatalog_tag_factory'
+    __FACTORY_CLASS = f'{__FACTORY_MODULE}.DataCatalogTagFactory'
+    __PRIVATE_METHOD_PREFIX = f'{__FACTORY_CLASS}._DataCatalogTagFactory'
+
     __DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f%z'
 
     def setUp(self):
@@ -86,6 +92,52 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
 
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    def test_make_tags_for_dashboard_filters_should_process_all_filters(
+            self, mock_make_tag_for_jaql):
+
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'filters': [
+                {
+                    'jaql': {
+                        'datatype': 'text',
+                    },
+                },
+                {
+                    'jaql': {
+                        'datatype': 'datetime',
+                    },
+                },
+            ],
+        }
+
+        tags = self.__factory.make_tags_for_dashboard_filters(
+            tag_template, metadata)
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+
+        calls = [
+            mock.call(tag_template, {
+                'datatype': 'text',
+            }, 'filters'),
+            mock.call(tag_template, {
+                'datatype': 'datetime',
+            }, 'filters')
+        ]
+        mock_make_tag_for_jaql.assert_has_calls(calls)
+
+    def test_make_tags_for_dashboard_filters_should_skip_if_no_filters(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        tags = self.__factory.make_tags_for_dashboard_filters(tag_template, {})
+
+        self.assertEqual(0, len(tags))
+
     def test_make_tag_for_folder_should_set_all_available_fields(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_folder_metadata'
@@ -128,55 +180,6 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
-
-    def test_make_tag_for_jaql_should_set_all_available_fields(self):
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
-
-        metadata = {
-            'dim': '[table_a.column_a]',
-            'formula': 'GrowthPastYear([AVG COST])',
-            'agg': 'avg',
-            'title': 'TEST',
-        }
-
-        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
-            tag_template, metadata, 'test')
-
-        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
-
-        self.assertEqual('table_a', tag.fields['table'].string_value)
-        self.assertEqual('column_a', tag.fields['column'].string_value)
-        self.assertEqual('[table_a.column_a]',
-                         tag.fields['dimension'].string_value)
-        self.assertEqual('GrowthPastYear([AVG COST])',
-                         tag.fields['formula'].string_value)
-        self.assertEqual('avg', tag.fields['aggregation'].string_value)
-        self.assertEqual('https://test.com',
-                         tag.fields['server_url'].string_value)
-
-    def test_make_tag_for_jaql_should_read_table_and_column_fields(self):
-        tag_template = datacatalog.TagTemplate()
-        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
-
-        metadata = {
-            'table': 'table_a',
-            'column': 'column_a',
-            'dim': '[table_b.column_b]',
-            'title': 'TEST',
-        }
-
-        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
-            tag_template, metadata, 'test')
-
-        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
-
-        # The ``table`` field takes priority over ``dim``.
-        self.assertEqual('table_a', tag.fields['table'].string_value)
-        # The ``column`` field takes priority over ``dim``.
-        self.assertEqual('column_a', tag.fields['column'].string_value)
-        self.assertEqual('[table_b.column_b]',
-                         tag.fields['dimension'].string_value)
 
     def test_make_tag_for_widget_should_set_all_available_fields(self):
         tag_template = datacatalog.TagTemplate()
@@ -233,3 +236,190 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual('Test Data Source',
                          tag.fields['datasource'].string_value)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    def test_make_tags_for_widget_fields_should_process_all_fields(
+            self, mock_make_tag_for_jaql):
+
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'metadata': {
+                'panels': [{
+                    'name':
+                        'testField',
+                    'items': [
+                        {
+                            'jaql': {
+                                'datatype': 'text',
+                            },
+                        },
+                        {
+                            'jaql': {
+                                'datatype': 'datetime',
+                            },
+                        },
+                    ],
+                }],
+            },
+        }
+
+        tags = self.__factory.make_tags_for_widget_fields(
+            tag_template, metadata)
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+
+        calls = [
+            mock.call(tag_template, {
+                'datatype': 'text',
+            }, 'fields'),
+            mock.call(tag_template, {
+                'datatype': 'datetime',
+            }, 'fields')
+        ]
+        mock_make_tag_for_jaql.assert_has_calls(calls)
+
+    def test_make_tags_for_widget_fields_should_skip_if_no_panels(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        tags = self.__factory.make_tags_for_widget_fields(tag_template, {})
+
+        self.assertEqual(0, len(tags))
+
+    def test_make_tags_for_widget_fields_should_skip_if_no_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'metadata': {
+                'panels': [{
+                    'name': 'filters',
+                }],
+            },
+        }
+
+        tags = self.__factory.make_tags_for_widget_fields(
+            tag_template, metadata)
+
+        self.assertEqual(0, len(tags))
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    def test_make_tags_for_widget_filters_should_process_all_filters(
+            self, mock_make_tag_for_jaql):
+
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'metadata': {
+                'panels': [{
+                    'name':
+                        'filters',
+                    'items': [
+                        {
+                            'jaql': {
+                                'datatype': 'text',
+                            },
+                        },
+                        {
+                            'jaql': {
+                                'datatype': 'datetime',
+                            },
+                        },
+                    ],
+                }],
+            },
+        }
+
+        tags = self.__factory.make_tags_for_widget_filters(
+            tag_template, metadata)
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+
+        calls = [
+            mock.call(tag_template, {
+                'datatype': 'text',
+            }, 'filters'),
+            mock.call(tag_template, {
+                'datatype': 'datetime',
+            }, 'filters')
+        ]
+        mock_make_tag_for_jaql.assert_has_calls(calls)
+
+    def test_make_tags_for_widget_filters_should_skip_if_no_panels(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        tags = self.__factory.make_tags_for_widget_filters(tag_template, {})
+
+        self.assertEqual(0, len(tags))
+
+    def test_make_tags_for_widget_filters_should_skip_if_no_filters(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'metadata': {
+                'panels': [{
+                    'name': 'testField',
+                }],
+            },
+        }
+
+        tags = self.__factory.make_tags_for_widget_filters(
+            tag_template, metadata)
+
+        self.assertEqual(0, len(tags))
+
+    def test_make_tag_for_jaql_should_set_all_available_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'dim': '[table_a.column_a]',
+            'formula': 'GrowthPastYear([AVG COST])',
+            'agg': 'avg',
+            'title': 'TEST',
+        }
+
+        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+            tag_template, metadata, 'test')
+
+        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
+
+        self.assertEqual('table_a', tag.fields['table'].string_value)
+        self.assertEqual('column_a', tag.fields['column'].string_value)
+        self.assertEqual('[table_a.column_a]',
+                         tag.fields['dimension'].string_value)
+        self.assertEqual('GrowthPastYear([AVG COST])',
+                         tag.fields['formula'].string_value)
+        self.assertEqual('avg', tag.fields['aggregation'].string_value)
+        self.assertEqual('https://test.com',
+                         tag.fields['server_url'].string_value)
+
+    def test_make_tag_for_jaql_should_read_table_and_column_fields(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'table': 'table_a',
+            'column': 'column_a',
+            'dim': '[table_b.column_b]',
+            'title': 'TEST',
+        }
+
+        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+            tag_template, metadata, 'test')
+
+        self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
+
+        # The ``table`` field takes priority over ``dim``.
+        self.assertEqual('table_a', tag.fields['table'].string_value)
+        # The ``column`` field takes priority over ``dim``.
+        self.assertEqual('column_a', tag.fields['column'].string_value)
+        self.assertEqual('[table_b.column_b]',
+                         tag.fields['dimension'].string_value)

--- a/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
+++ b/google-datacatalog-sisense-connector/tools/scripts/cleanup_datacatalog.py
@@ -76,6 +76,9 @@ def __delete_tag_templates(project_id: str, location_id: str) -> None:
             project_id, location_id, 'sisense_folder_metadata'))
     __delete_tag_template(
         datacatalog.DataCatalogClient.tag_template_path(
+            project_id, location_id, 'sisense_jaql_metadata'))
+    __delete_tag_template(
+        datacatalog.DataCatalogClient.tag_template_path(
             project_id, location_id, 'sisense_widget_metadata'))
 
 


### PR DESCRIPTION
**- What I did**
Added features that enable the Sisense Connector to synchronize column-level tags comprising JAQL metadata for Dashboard filters, Widget fields, and filters in Google Data Catalog. These features make it possible for users to search Data Catalog to find where/which Sisense ElastiCube table fields are used in Widgets as data (fields) or filters, or Dashboards as filters.

**- How I did it**
1. Improved `AssembledEntryFactory.__make_assembled_entry_for_dashboard()` in order to create JAQL-based tags for Dashboard filters.
2. Improved `AssembledEntryFactory.__make_assembled_entry_for_widget()` in order to create JAQL-based tags for Widget fields and filters.
3. Added `DataCatalogTagFactory.make_tags_for_dashboard_filters()`.
4. Added `DataCatalogTagFactory.make_tags_for_widget_fields()`.
5. Added `DataCatalogTagFactory.make_tags_for_widget_filters()`.
6. Created some constants to avoid repeating hard-coded strings and updated the code accordingly.
7. Added unit tests to cover the above changes.

**- How to verify it**
Run the unit tests and, if possible, the connector in an integrated environment to check the results.

**- Description for the changelog**
Synchronize column-level tags comprising JAQL metadata for Dashboard filters, Widget fields, and filters in Data Catalog

PS 1: This PR is part of the effort to deliver #70.
PS 2: There are at least two corner cases that will result in additional JAQL-related tags but I'm going to tackle them in separate PRs to make the code review less complex.