### PR TITLE
Ingest JAQL formula metadata

### DIFF
--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -197,11 +197,11 @@ scenarios are described below:
 
 Please notice the connector creates Data Catalog Tags for all Dashboard and
 Widget components (e.g.: fields, filters, and nested formulas) that depend on
-JAQL queries. The tags themselves are quite simple (~4 fields each), and the
-connector creates a lot of them to store metadata from a given Sisense server.
-Such tags enable a column-level lineage mechanism which allows users to search
-Data Catalog to find where/which ElastiCube Table fields are used in Widgets or
-Dashboards.
+JAQL queries. Such tags are created from the **JAQL Metadata** template and are
+quite simple (~4 fields each). The connector creates a lot of them to store
+metadata for a given Sisense server. These tags enable a column-level lineage
+mechanism which allows users to search Data Catalog to find where/which
+ElastiCube Table fields are used in Widgets or Dashboards.
 
 ## 6. Troubleshooting
 

--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -1,13 +1,15 @@
 # google-datacatalog-sisense-connector
 
 Package for ingesting [Sisense](https://www.sisense.com/) metadata into Google
-Cloud Data Catalog, currently supporting below asset types:
+Cloud Data Catalog, currently supporting the below assets:
 - Folder
 - Dashboard
-  - Filters (including upstream ElastiCube Table and Column names)
+  * Filters
+  * Nested formulas
 - Widget
-  - Fields (including upstream ElastiCube Table and Column names)
-  - Filters (including upstream ElastiCube Table and Column names)
+  * Fields
+  * Filters
+  * Nested formulas
 
 **Disclaimer: This is not an officially supported Google product.**
 
@@ -195,13 +197,13 @@ scenarios are described below:
 | Widget Metadata (`sisense_widget_metadata`)       | <ul><li>Id</li><li>Type</li><li>Subtype</li><li>Owner username</li><li>Owner name</li><li>Dashboard Id</li><li>Dashboard Title</li><li>Data Catalog Entry for the Dashboard</li><li>Data Source</li><li>Sisense Server Url</li></ul>                                          | Store additional metadata for Widget-related Entries.                                                                              |
 | JAQL Metadata (`sisense_jaql_metadata`)           | <ul><li>Table</li><li>Column</li><li>Dimension</li><li>Formula</li><li>Aggregation</li><li>Sisense Server Url</li></ul>                                                                                                                                                       | Store lineage metadata for JAQL-dependent entities such as Dashboard filters, Widget fields and filters, formulas and their parts. |
 
-Please notice the connector creates Data Catalog Tags for all Dashboard and
-Widget components (e.g.: fields, filters, and nested formulas) that depend on
-JAQL queries. Such tags are created from the **JAQL Metadata** template and are
-quite simple (~4 fields each). The connector creates a lot of them to store
-metadata for a given Sisense server. These tags enable a column-level lineage
-mechanism which allows users to search Data Catalog to find where/which
-ElastiCube Table fields are used in Widgets or Dashboards.
+Please notice the connector creates Data Catalog Tags for most Dashboard and
+Widget components (e.g., fields, filters, and nested formulas) that depend on
+JAQL queries. Such tags, created from the **JAQL Metadata** template, are quite
+simple: ~4 fields each. The connector creates a lot of them to store metadata
+for a given Sisense server. These tags enable a column-level lineage mechanism
+that allows users to search Data Catalog to find where/which ElastiCube Table
+fields are used in Widgets or Dashboards.
 
 ## 6. Troubleshooting
 

--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -4,7 +4,10 @@ Package for ingesting [Sisense](https://www.sisense.com/) metadata into Google
 Cloud Data Catalog, currently supporting below asset types:
 - Folder
 - Dashboard
+  - Filters (including upstream ElastiCube Table and Column names)
 - Widget
+  - Fields (including upstream ElastiCube Table and Column names)
+  - Filters (including upstream ElastiCube Table and Column names)
 
 **Disclaimer: This is not an officially supported Google product.**
 
@@ -39,9 +42,10 @@ Cloud Data Catalog, currently supporting below asset types:
   * [4.2. Install and run the Flake8 linter](#42-install-and-run-the-flake8-linter)
   * [4.3. Run Tests](#43-run-tests)
   * [4.4. Additional resources](#44-additional-resources)
-- [5. Troubleshooting](#5-troubleshooting)
-  * [5.1. Sisense APIs compatibility](#51-sisense-apis-compatibility)
-  * [5.2. Data Catalog quota](#52-data-catalog-quota)
+- [5. Templates, Tags, and Data Lineage](#5-templates-tags-and-data-lineage)
+- [6. Troubleshooting](#6-troubleshooting)
+  * [6.1. Sisense APIs compatibility](#61-sisense-apis-compatibility)
+  * [6.2. Data Catalog quota](#62-data-catalog-quota)
 
 <!-- tocstop -->
 
@@ -179,9 +183,29 @@ python setup.py test
 Please refer to the [Developer Resources
 documentation](docs/developer-resources).
 
-## 5. Troubleshooting
+## 5. Templates, Tags, and Data Lineage
 
-### 5.1. Sisense APIs compatibility
+The Data Catalog Tag Templates created by this connector and their usage
+scenarios are described below:
+
+| TAG TEMPLATE                                      | FIELDS                                                                                                                                                                                                                                                                        | USAGE                                                                                                                              |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Folder Metadata (`sisense_folder_metadata`)       | <ul><li>Id</li><li>Owner username</li><li>Owner name</li><li>Id of Parent</li><li>Parent Folder</li><li>Data Catalog Entry for the parent Folder</li><li>Has children</li><li>Child count</li><li>Has dashboards</li><li>Dashboard count</li><li>Sisense Server Url</li></ul> | Store additional metadata for Folder-related Entries.                                                                              |
+| Dashboard Metadata (`sisense_dashboard_metadata`) | <ul><li>Id</li><li>Owner username</li><li>Owner name</li><li>Folder Id</li><li>Folder Name</li><li>Data Catalog Entry for the Folder</li><li>Data Source</li><li>Time it was last published</li><li>Time it was last opened</li><li>Sisense Server Url</li></ul>              | Store additional metadata for Dashboard-related Entries.                                                                           |
+| Widget Metadata (`sisense_widget_metadata`)       | <ul><li>Id</li><li>Type</li><li>Subtype</li><li>Owner username</li><li>Owner name</li><li>Dashboard Id</li><li>Dashboard Title</li><li>Data Catalog Entry for the Dashboard</li><li>Data Source</li><li>Sisense Server Url</li></ul>                                          | Store additional metadata for Widget-related Entries.                                                                              |
+| JAQL Metadata (`sisense_jaql_metadata`)           | <ul><li>Table</li><li>Column</li><li>Dimension</li><li>Formula</li><li>Aggregation</li><li>Sisense Server Url</li></ul>                                                                                                                                                       | Store lineage metadata for JAQL-dependent entities such as Dashboard filters, Widget fields and filters, formulas and their parts. |
+
+Please notice the connector creates Data Catalog Tags for all Dashboard and
+Widget components (e.g.: fields, filters, and nested formulas) that depend on
+JAQL queries. The tags themselves are quite simple (~4 fields each), and the
+connector creates a lot of them to store metadata from a given Sisense server.
+Such tags enable a column-level lineage mechanism which allows users to search
+Data Catalog to find where/which ElastiCube Table fields are used in Widgets or
+Dashboards.
+
+## 6. Troubleshooting
+
+### 6.1. Sisense APIs compatibility
 
 The connector may fail during the scrape stage if the Sisense API do not return
 metadata in the expected format. As a reference, the below versions were
@@ -193,7 +217,7 @@ already validated:
 | ------------- | :-----: |
 | Windows 8.2.5 | SUCCESS |
 
-### 5.2. Data Catalog quota
+### 6.2. Data Catalog quota
 
 In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -22,6 +22,14 @@ ENTRY_ID_PART_DASHBOARD = 'db_'
 ENTRY_ID_PART_FOLDER = 'fd_'
 ENTRY_ID_PART_WIDGET = 'wg_'
 
+# Name of the column used to store formula context metadata in Data Catalog
+# entries.
+ENTRY_COLUMN_CONTEXT = 'context'
+# Name of the column used to store fields metadata in Data Catalog entries.
+ENTRY_COLUMN_FIELDS = 'fields'
+# Name of the column used to store filters metadata in Data Catalog entries.
+ENTRY_COLUMN_FILTERS = 'filters'
+
 # The Sisense type for Dashboard assets.
 SISENSE_ASSET_TYPE_DASHBOARD = 'dashboard'
 # The Sisense type for Folder assets.
@@ -49,15 +57,10 @@ USER_SPECIFIED_TYPE_WIDGET = 'Widget'
 
 # Name of the field used by Sisense Dashboards to store their filters.
 DASHBOARD_FILTERS_FIELD_NAME = 'filters'
-# Name of the column used to store filters metadata in Dashboard-related
-# Data Catalog entries.
-DASHBOARD_ENTRY_FILTERS_COLUMN_NAME = 'filters'
-
+# Name of the field used by Sisense JAQL Queries to store their formula
+# contexts.
+JAQL_CONTEXT_FIELD_NAME = 'context'
+# Name of the field used by Sisense JAQL Queries to store their formulas.
+JAQL_FORMULA_FIELD_NAME = 'formula'
 # Name of the panel used by Sisense Widgets to store their filters.
 WIDGET_FILTERS_PANEL_NAME = 'filters'
-# Name of the column used to store fields metadata in Widget-related
-# Data Catalog entries.
-WIDGET_ENTRY_FIELDS_COLUMN_NAME = 'fields'
-# Name of the column used to store filters metadata in Widget-related
-# Data Catalog entries.
-WIDGET_ENTRY_FILTERS_COLUMN_NAME = 'filters'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/constants.py
@@ -22,13 +22,12 @@ ENTRY_ID_PART_DASHBOARD = 'db_'
 ENTRY_ID_PART_FOLDER = 'fd_'
 ENTRY_ID_PART_WIDGET = 'wg_'
 
-# Name of the column used to store formula context metadata in Data Catalog
-# entries.
-ENTRY_COLUMN_CONTEXT = 'context'
 # Name of the column used to store fields metadata in Data Catalog entries.
 ENTRY_COLUMN_FIELDS = 'fields'
 # Name of the column used to store filters metadata in Data Catalog entries.
 ENTRY_COLUMN_FILTERS = 'filters'
+# Name of the column used to store formula metadata in Data Catalog entries.
+ENTRY_COLUMN_FORMULA = 'formula'
 
 # The Sisense type for Dashboard assets.
 SISENSE_ASSET_TYPE_DASHBOARD = 'dashboard'

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory.py
@@ -286,16 +286,15 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
         column.type = jaql_metadata.get('datatype') or jaql_metadata.get(
             'type') or 'unknown'
 
-        context_subcolumn = cls.__make_column_schema_for_jaql_context(
+        formula_subcolumn = cls.__make_column_schema_for_jaql_formula(
             jaql_metadata)
-
-        if context_subcolumn:
-            column.subcolumns.append(context_subcolumn)
+        if formula_subcolumn:
+            column.subcolumns.append(formula_subcolumn)
 
         return column
 
     @classmethod
-    def __make_column_schema_for_jaql_context(
+    def __make_column_schema_for_jaql_formula(
             cls, jaql_metadata: Dict[str, Any]) -> Optional[ColumnSchema]:
 
         formula = jaql_metadata.get(constants.JAQL_FORMULA_FIELD_NAME)
@@ -305,15 +304,14 @@ class DataCatalogEntryFactory(prepare.BaseEntryFactory):
             return
 
         column = datacatalog.ColumnSchema()
-        column.column = constants.ENTRY_COLUMN_CONTEXT
+        column.column = constants.ENTRY_COLUMN_FORMULA
         column.type = 'array'
         column.description = \
-            f'The {jaql_metadata.get("title")} context'
+            f'The {jaql_metadata.get("title")} formula'
 
-        context_ids = re.findall(r'\[(.*?)]', formula)
-        for context_id in context_ids:
+        parts = re.findall(r'\[(.*?)]', formula)
+        for part in parts:
             column.subcolumns.append(
-                cls.__make_column_schema_for_jaql(
-                    context.get(f'[{context_id}]')))
+                cls.__make_column_schema_for_jaql(context.get(f'[{part}]')))
 
         return column

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -268,11 +268,11 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         context = jaql_metadata.get(constants.JAQL_CONTEXT_FIELD_NAME)
         if formula and context:
             human_readable_formula = formula
-            context_ids = re.findall(r'\[(.*?)]', formula)
-            for context_id in context_ids:
-                context_title = context.get(f'[{context_id}]').get('title')
+            parts = re.findall(r'\[(.*?)]', formula)
+            for part in parts:
+                context_title = context.get(f'[{part}]').get('title')
                 human_readable_formula = human_readable_formula.replace(
-                    context_id, context_title)
+                    part, context_title)
             self._set_string_field(tag, 'formula', human_readable_formula)
         else:
             self._set_string_field(tag, 'formula', formula)
@@ -288,12 +288,12 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         tags.append(tag)
 
         tags.extend(
-            self.__make_tags_for_jaql_context(tag_template, jaql_metadata,
+            self.__make_tags_for_jaql_formula(tag_template, jaql_metadata,
                                               tag.column))
 
         return tags
 
-    def __make_tags_for_jaql_context(self, tag_template: TagTemplate,
+    def __make_tags_for_jaql_formula(self, tag_template: TagTemplate,
                                      jaql_metadata: Dict[str, Any],
                                      column_prefix: str) -> List[Tag]:
 
@@ -305,11 +305,11 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         if not (formula and context):
             return tags
 
-        context_ids = re.findall(r'\[(.*?)]', formula)
-        for context_id in context_ids:
+        parts = re.findall(r'\[(.*?)]', formula)
+        for part in parts:
             tags.extend(
-                self.__make_tags_for_jaql(tag_template,
-                                          context.get(f'[{context_id}]'),
-                                          f'{column_prefix}.context'))
+                self.__make_tags_for_jaql(
+                    tag_template, context.get(f'[{part}]'),
+                    f'{column_prefix}.{constants.ENTRY_COLUMN_FORMULA}'))
 
         return tags

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory.py
@@ -92,9 +92,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         for dashboard_filter in dashboard_metadata[
                 constants.DASHBOARD_FILTERS_FIELD_NAME]:
             tags.append(
-                self.__make_tag_for_jaql(
-                    jaql_tag_template, dashboard_filter.get('jaql'),
-                    constants.DASHBOARD_ENTRY_FILTERS_COLUMN_NAME))
+                self.__make_tag_for_jaql(jaql_tag_template,
+                                         dashboard_filter.get('jaql'),
+                                         constants.ENTRY_COLUMN_FILTERS))
 
         return tags
 
@@ -196,9 +196,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
         for field in fields:
             for item in field.get('items'):
                 tags.append(
-                    self.__make_tag_for_jaql(
-                        jaql_tag_template, item.get('jaql'),
-                        constants.WIDGET_ENTRY_FIELDS_COLUMN_NAME))
+                    self.__make_tag_for_jaql(jaql_tag_template,
+                                             item.get('jaql'),
+                                             constants.ENTRY_COLUMN_FIELDS))
 
         return tags
 
@@ -223,9 +223,9 @@ class DataCatalogTagFactory(prepare.BaseTagFactory):
 
         for widget_filter in filters:
             tags.append(
-                self.__make_tag_for_jaql(
-                    jaql_tag_template, widget_filter.get('jaql'),
-                    constants.WIDGET_ENTRY_FILTERS_COLUMN_NAME))
+                self.__make_tag_for_jaql(jaql_tag_template,
+                                         widget_filter.get('jaql'),
+                                         constants.ENTRY_COLUMN_FILTERS))
 
         return tags
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -536,3 +536,16 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 metadata)
 
         self.assertIsNone(column)
+
+    def test_make_column_schema_for_jaql_formula_should_skip_if_no_context(
+            self):
+
+        metadata = {
+            'formula': 'AVG([OrderDateYears], [CountOrderID])',
+        }
+
+        column = self.__factory \
+            ._DataCatalogEntryFactory__make_column_schema_for_jaql_formula(
+                metadata)
+
+        self.assertIsNone(column)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_entry_factory_test.py
@@ -454,29 +454,29 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertIsNone(schema)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}'
-                f'__make_column_schema_for_jaql_context')
+                f'__make_column_schema_for_jaql_formula')
     @mock.patch(f'{__FACTORY_PACKAGE}.sisense_connector_strings_helper'
                 f'.SisenseConnectorStringsHelper.format_column_name',
                 lambda *args: args[0])
     def test_make_column_schema_for_jaql_should_set_all_available_fields(
-            self, mock_make_column_schema_for_jaql_context):
+            self, mock_make_column_schema_for_jaql_formula):
 
         metadata = {'datatype': 'datetime', 'title': 'TEST'}
 
         column = datacatalog.ColumnSchema()
-        column.column = 'context'
-        mock_make_column_schema_for_jaql_context.return_value = column
+        column.column = 'formula'
+        mock_make_column_schema_for_jaql_formula.return_value = column
 
         column = self.__factory\
             ._DataCatalogEntryFactory__make_column_schema_for_jaql(metadata)
 
         self.assertEqual('TEST', column.column)
         self.assertEqual('datetime', column.type)
-        mock_make_column_schema_for_jaql_context.assert_called_once_with(
+        mock_make_column_schema_for_jaql_formula.assert_called_once_with(
             metadata)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}'
-                f'__make_column_schema_for_jaql_context', lambda *args: None)
+                f'__make_column_schema_for_jaql_formula', lambda *args: None)
     @mock.patch(f'{__FACTORY_PACKAGE}.sisense_connector_strings_helper'
                 f'.SisenseConnectorStringsHelper.format_column_name',
                 lambda *args: args[0])
@@ -490,7 +490,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('datetime', column.type)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_column_schema_for_jaql')
-    def test_make_column_schema_for_jaql_context_should_process_all_fields(
+    def test_make_column_schema_for_jaql_formula_should_process_all_fields(
             self, mock_make_column_schema_for_jaql):
 
         metadata = {
@@ -512,15 +512,15 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         mock_make_column_schema_for_jaql.return_value = column
 
         column = self.__factory \
-            ._DataCatalogEntryFactory__make_column_schema_for_jaql_context(
+            ._DataCatalogEntryFactory__make_column_schema_for_jaql_formula(
                 metadata)
 
-        self.assertEqual('context', column.column)
+        self.assertEqual('formula', column.column)
         self.assertEqual('array', column.type)
-        self.assertEqual('The JAQL Formula test context', column.description)
+        self.assertEqual('The JAQL Formula test formula', column.description)
         self.assertEqual(2, len(column.subcolumns))
 
-    def test_make_column_schema_for_jaql_context_should_skip_if_no_formula(
+    def test_make_column_schema_for_jaql_formula_should_skip_if_no_formula(
             self):
 
         metadata = {
@@ -532,7 +532,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         column = self.__factory \
-            ._DataCatalogEntryFactory__make_column_schema_for_jaql_context(
+            ._DataCatalogEntryFactory__make_column_schema_for_jaql_formula(
                 metadata)
 
         self.assertIsNone(column)

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -381,9 +381,10 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual(0, len(tags))
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
-                lambda *args: [])
-    def test_make_tags_for_jaql_should_set_all_available_fields(self):
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_formula')
+    def test_make_tags_for_jaql_should_set_all_available_fields(
+            self, mock_make_tags_for_jaql_formula):
+
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
 
@@ -404,6 +405,8 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'title': 'TEST',
         }
 
+        mock_make_tags_for_jaql_formula.return_value = []
+
         tags = self.__factory._DataCatalogTagFactory__make_tags_for_jaql(
             tag_template, metadata, 'test')
 
@@ -422,7 +425,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
+        mock_make_tags_for_jaql_formula.assert_called_once()
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_formula',
                 lambda *args: [])
     def test_make_tags_for_jaql_should_read_table_and_column_fields(self):
         tag_template = datacatalog.TagTemplate()
@@ -450,7 +455,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('[table_b.column_b]',
                          tag.fields['dimension'].string_value)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_formula',
                 lambda *args: [])
     def test_make_tags_for_jaql_should_fulfill_formula_as_is_if_no_context(
             self):
@@ -471,7 +476,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                          tag.fields['formula'].string_value)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql')
-    def test_make_tags_for_jaql_context_should_process_all_fields(
+    def test_make_tags_for_jaql_formula_should_process_all_fields(
             self, mock_make_tags_for_jaql):
 
         tag_template = datacatalog.TagTemplate()
@@ -493,7 +498,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         mock_make_tags_for_jaql.return_value = [tag]
 
         tags = self.__factory \
-            ._DataCatalogTagFactory__make_tags_for_jaql_context(
+            ._DataCatalogTagFactory__make_tags_for_jaql_formula(
                 tag_template, metadata, 'JAQL Formula test')
 
         self.assertEqual(2, len(tags))
@@ -502,14 +507,14 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         calls = [
             mock.call(tag_template, {
                 'dim': '[Orders.OrderDate (Calendar)]',
-            }, 'JAQL Formula test.context'),
+            }, 'JAQL Formula test.formula'),
             mock.call(tag_template, {
                 'dim': '[Orders.OrderID]',
-            }, 'JAQL Formula test.context')
+            }, 'JAQL Formula test.formula')
         ]
         mock_make_tags_for_jaql.assert_has_calls(calls)
 
-    def test_make_tags_for_jaql_context_should_skip_if_no_formula(self):
+    def test_make_tags_for_jaql_formula_should_skip_if_no_formula(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
 
@@ -522,7 +527,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         }
 
         tags = self.__factory \
-            ._DataCatalogTagFactory__make_tags_for_jaql_context(
+            ._DataCatalogTagFactory__make_tags_for_jaql_formula(
                 tag_template, metadata, 'JAQL Formula test')
 
         self.assertEqual(0, len(tags))

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/prepare/datacatalog_tag_factory_test.py
@@ -92,9 +92,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql')
     def test_make_tags_for_dashboard_filters_should_process_all_filters(
-            self, mock_make_tag_for_jaql):
+            self, mock_make_tags_for_jaql):
 
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
@@ -114,11 +114,13 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             ],
         }
 
+        mock_make_tags_for_jaql.return_value = [datacatalog.Tag()]
+
         tags = self.__factory.make_tags_for_dashboard_filters(
             tag_template, metadata)
 
         self.assertEqual(2, len(tags))
-        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+        self.assertEqual(2, mock_make_tags_for_jaql.call_count)
 
         calls = [
             mock.call(tag_template, {
@@ -128,7 +130,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 'datatype': 'datetime',
             }, 'filters')
         ]
-        mock_make_tag_for_jaql.assert_has_calls(calls)
+        mock_make_tags_for_jaql.assert_has_calls(calls)
 
     def test_make_tags_for_dashboard_filters_should_skip_if_no_filters(self):
         tag_template = datacatalog.TagTemplate()
@@ -237,9 +239,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('Test Data Source',
                          tag.fields['datasource'].string_value)
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql')
     def test_make_tags_for_widget_fields_should_process_all_fields(
-            self, mock_make_tag_for_jaql):
+            self, mock_make_tags_for_jaql):
 
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
@@ -265,11 +267,13 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             },
         }
 
+        mock_make_tags_for_jaql.return_value = [datacatalog.Tag()]
+
         tags = self.__factory.make_tags_for_widget_fields(
             tag_template, metadata)
 
         self.assertEqual(2, len(tags))
-        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+        self.assertEqual(2, mock_make_tags_for_jaql.call_count)
 
         calls = [
             mock.call(tag_template, {
@@ -279,7 +283,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 'datatype': 'datetime',
             }, 'fields')
         ]
-        mock_make_tag_for_jaql.assert_has_calls(calls)
+        mock_make_tags_for_jaql.assert_has_calls(calls)
 
     def test_make_tags_for_widget_fields_should_skip_if_no_panels(self):
         tag_template = datacatalog.TagTemplate()
@@ -306,9 +310,9 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual(0, len(tags))
 
-    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tag_for_jaql')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql')
     def test_make_tags_for_widget_filters_should_process_all_filters(
-            self, mock_make_tag_for_jaql):
+            self, mock_make_tags_for_jaql):
 
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
@@ -334,11 +338,13 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             },
         }
 
+        mock_make_tags_for_jaql.return_value = [datacatalog.Tag()]
+
         tags = self.__factory.make_tags_for_widget_filters(
             tag_template, metadata)
 
         self.assertEqual(2, len(tags))
-        self.assertEqual(2, mock_make_tag_for_jaql.call_count)
+        self.assertEqual(2, mock_make_tags_for_jaql.call_count)
 
         calls = [
             mock.call(tag_template, {
@@ -348,7 +354,7 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
                 'datatype': 'datetime',
             }, 'filters')
         ]
-        mock_make_tag_for_jaql.assert_has_calls(calls)
+        mock_make_tags_for_jaql.assert_has_calls(calls)
 
     def test_make_tags_for_widget_filters_should_skip_if_no_panels(self):
         tag_template = datacatalog.TagTemplate()
@@ -375,33 +381,50 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
 
         self.assertEqual(0, len(tags))
 
-    def test_make_tag_for_jaql_should_set_all_available_fields(self):
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
+                lambda *args: [])
+    def test_make_tags_for_jaql_should_set_all_available_fields(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
 
         metadata = {
             'dim': '[table_a.column_a]',
-            'formula': 'GrowthPastYear([AVG COST])',
+            'formula': 'AVG([ODY], [COID])',
+            'context': {
+                '[ODY]': {
+                    'dim': '[Orders.OrderDate (Calendar)]',
+                    'title': 'OrderDateYears',
+                },
+                '[COID]': {
+                    'dim': '[Orders.OrderID]',
+                    'title': 'CountOrderID',
+                },
+            },
             'agg': 'avg',
             'title': 'TEST',
         }
 
-        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+        tags = self.__factory._DataCatalogTagFactory__make_tags_for_jaql(
             tag_template, metadata, 'test')
 
+        self.assertEqual(1, len(tags))
+
+        tag = tags[0]
         self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
 
         self.assertEqual('table_a', tag.fields['table'].string_value)
         self.assertEqual('column_a', tag.fields['column'].string_value)
         self.assertEqual('[table_a.column_a]',
                          tag.fields['dimension'].string_value)
-        self.assertEqual('GrowthPastYear([AVG COST])',
+        self.assertEqual('AVG([OrderDateYears], [CountOrderID])',
                          tag.fields['formula'].string_value)
         self.assertEqual('avg', tag.fields['aggregation'].string_value)
         self.assertEqual('https://test.com',
                          tag.fields['server_url'].string_value)
 
-    def test_make_tag_for_jaql_should_read_table_and_column_fields(self):
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
+                lambda *args: [])
+    def test_make_tags_for_jaql_should_read_table_and_column_fields(self):
         tag_template = datacatalog.TagTemplate()
         tag_template.name = 'tagTemplates/sisense_jaql_metadata'
 
@@ -412,9 +435,12 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
             'title': 'TEST',
         }
 
-        tag = self.__factory._DataCatalogTagFactory__make_tag_for_jaql(
+        tags = self.__factory._DataCatalogTagFactory__make_tags_for_jaql(
             tag_template, metadata, 'test')
 
+        self.assertEqual(1, len(tags))
+
+        tag = tags[0]
         self.assertEqual('tagTemplates/sisense_jaql_metadata', tag.template)
 
         # The ``table`` field takes priority over ``dim``.
@@ -423,3 +449,80 @@ class DataCatalogEntryFactoryTest(unittest.TestCase):
         self.assertEqual('column_a', tag.fields['column'].string_value)
         self.assertEqual('[table_b.column_b]',
                          tag.fields['dimension'].string_value)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql_context',
+                lambda *args: [])
+    def test_make_tags_for_jaql_should_fulfill_formula_as_is_if_no_context(
+            self):
+
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'formula': 'AVG([ODY], [COID])',
+            'title': 'TEST',
+        }
+
+        tags = self.__factory._DataCatalogTagFactory__make_tags_for_jaql(
+            tag_template, metadata, 'test')
+
+        tag = tags[0]
+        self.assertEqual('AVG([ODY], [COID])',
+                         tag.fields['formula'].string_value)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_tags_for_jaql')
+    def test_make_tags_for_jaql_context_should_process_all_fields(
+            self, mock_make_tags_for_jaql):
+
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'formula': 'AVG([ODY], [COID])',
+            'context': {
+                '[ODY]': {
+                    'dim': '[Orders.OrderDate (Calendar)]',
+                },
+                '[COID]': {
+                    'dim': '[Orders.OrderID]',
+                },
+            },
+        }
+
+        tag = datacatalog.Tag()
+        mock_make_tags_for_jaql.return_value = [tag]
+
+        tags = self.__factory \
+            ._DataCatalogTagFactory__make_tags_for_jaql_context(
+                tag_template, metadata, 'JAQL Formula test')
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(2, mock_make_tags_for_jaql.call_count)
+
+        calls = [
+            mock.call(tag_template, {
+                'dim': '[Orders.OrderDate (Calendar)]',
+            }, 'JAQL Formula test.context'),
+            mock.call(tag_template, {
+                'dim': '[Orders.OrderID]',
+            }, 'JAQL Formula test.context')
+        ]
+        mock_make_tags_for_jaql.assert_has_calls(calls)
+
+    def test_make_tags_for_jaql_context_should_skip_if_no_formula(self):
+        tag_template = datacatalog.TagTemplate()
+        tag_template.name = 'tagTemplates/sisense_jaql_metadata'
+
+        metadata = {
+            'context': {
+                '[ODY]': {
+                    'dim': '[Orders.OrderDate (Calendar)]',
+                },
+            },
+        }
+
+        tags = self.__factory \
+            ._DataCatalogTagFactory__make_tags_for_jaql_context(
+                tag_template, metadata, 'JAQL Formula test')
+
+        self.assertEqual(0, len(tags))


### PR DESCRIPTION
**- What I did**
Added features that enable the Sisense connector to ingest JAQL formula metadata. The `formula` field is available for [JAQL queries with formulas](https://sisense.dev/guides/query/jaql/#step-7-adding-a-formula).

**- How I did it**
1. Added the `DataCatalogEntryFactory.__make_column_schema_for_jaql_formula()` method.
2. Added the `DataCatalogTagFactory.__make_tags_for_jaql_formula()` method.
3. Added unit tests to fully cover the new methods and required changes.

**- How to verify it**
Run the unit tests and, if possible, the connector in an integrated environment to check the results.

**- Description for the changelog**
Added features that enable the Sisense connector to ingest JAQL formula metadata.

PS: This PR is part of the effort to deliver #70.