### PR TITLE
Find ElastiCube dependencies

### DIFF
--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .elasticube_dependency_finder import ElastiCubeDependencyFinder
+
+__all__ = ('ElastiCubeDependencyFinder',)

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
@@ -155,7 +155,8 @@ class ElastiCubeDependencyFinder:
         return f'({" OR ".join(type_query_terms)})'
 
     @classmethod
-    def __make_datasource_search_term(cls, datasource: str) -> Optional[str]:
+    def __make_datasource_search_term(cls,
+                                      datasource: str = None) -> Optional[str]:
         """Make a Data Catalog search string with the `tag:datasource:val`
         qualifier.
 
@@ -170,7 +171,7 @@ class ElastiCubeDependencyFinder:
         return f'tag:datasource:"{datasource}"' if datasource else None
 
     @classmethod
-    def __make_table_search_term(cls, table: str) -> Optional[str]:
+    def __make_table_search_term(cls, table: str = None) -> Optional[str]:
         """Make a Data Catalog search string with the `tag:table:val`
         qualifier.
 
@@ -184,7 +185,7 @@ class ElastiCubeDependencyFinder:
         return f'tag:table:"{table}"' if table else None
 
     @classmethod
-    def __make_column_search_term(cls, column: str) -> Optional[str]:
+    def __make_column_search_term(cls, column: str = None) -> Optional[str]:
         """Make a Data Catalog search string with the `tag:column:val`
         qualifier.
 
@@ -225,8 +226,11 @@ class ElastiCubeDependencyFinder:
         return tags_dict
 
     @classmethod
-    def __filter_relevant_tags(cls, entry: Entry, tags: List[Tag], table: str,
-                               column: str) -> List[Tag]:
+    def __filter_relevant_tags(cls,
+                               entry: Entry,
+                               tags: List[Tag],
+                               table: str = None,
+                               column: str = None) -> List[Tag]:
         """Filter Tags for ElastiCube dependencies finding. "Relevant", in this
         context, means Tags that have ElastiCube-related information such as
         data source, table, or column names.
@@ -240,7 +244,7 @@ class ElastiCubeDependencyFinder:
         if asset_metadata_tag:
             filtered_tags.append(asset_metadata_tag)
         table_column_matching_tags = cls.__filter_table_column_matching_tags(
-            table, column, tags)
+            tags, table=table, column=column)
         filtered_tags.extend(
             cls.__sort_tags_by_schema(entry.schema.columns, '',
                                       table_column_matching_tags))
@@ -269,14 +273,16 @@ class ElastiCubeDependencyFinder:
                 return tag
 
     @classmethod
-    def __filter_table_column_matching_tags(cls, table: str, column: str,
-                                            tags: List[Tag]) -> List[Tag]:
+    def __filter_table_column_matching_tags(cls,
+                                            tags: List[Tag],
+                                            table: str = None,
+                                            column: str = None) -> List[Tag]:
         """Filter JAQL-related Tags which `table` and/or `column` fields match
-        the provided values.
+        the provided args.
 
         If both `table` and `column` args are provided, a given Tag's
-        corresponding fields must match both values in order to added to the
-        resulting list.
+        corresponding fields must match both values in order to have the Tag
+        added to the resulting list.
 
         Returns:
             list: The filtered Tags.

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
@@ -1,0 +1,390 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+from typing import Dict, List, Optional, Tuple, Union
+
+from google.cloud.datacatalog import ColumnSchema, Entry, Tag
+from google.datacatalog_connectors import commons
+
+from google.datacatalog_connectors.sisense.prepare import constants
+
+
+class ElastiCubeDependencyFinder:
+    """Count on Google Data Catalog search capabilities to find
+    ElastiCube-related dependencies.
+
+    The public methods are intended to provide clients a simplified interface
+    for Data Catalog search and results handling.
+    """
+    # Regex used to parse Tag Template names and get specific parts.
+    __TAG_TEMPLATE_NAME_PATTERN = r'^(.+?)/tagTemplates/(?P<id>.+?)$'
+
+    def __init__(self, project_id: str):
+        self.__datacatalog_facade = commons.DataCatalogFacade(project_id)
+
+    def find(self,
+             datasource: str = None,
+             table: str = None,
+             column: str = None) -> Dict[str, Tuple[Entry, List[Tag]]]:
+        """
+        Orchestrate actions that comprise:
+            - generating a query string to search Google Data Catalog;
+            - performing a catalog search;
+            - getting Entries and Tags based on search results;
+            - filtering Tags that contain Entry enrichment metadata or match
+                the table/column search criteria;
+            - assembling the Entries and Tags in a user-friendly dict.
+
+        Returns:
+            dict: Keys are Entry names and values are tuples in which the
+            first element is an Entry object and the second is an array of
+            ElastiCube-related Tags.
+        """
+        logging.info('')
+        logging.info('===> Searching Data Catalog...')
+        query = self.__make_query(datasource=datasource,
+                                  table=table,
+                                  column=column)
+        search_results = self.__datacatalog_facade.search_catalog(query)
+        logging.info('==== DONE ========================================')
+
+        logging.info('')
+        logging.info('Catalog search returned %d results', len(search_results))
+        if not search_results:
+            return {}
+
+        entry_names = [
+            result.relative_resource_name for result in search_results
+        ]
+
+        logging.info('')
+        logging.info('===> Getting entries...')
+        entries_dict = self.__get_entries(entry_names)
+        logging.info('==== DONE ========================================')
+
+        logging.info('')
+        logging.info('===> Listing tags...')
+        tags_dict = self.__list_tags(entry_names)
+        logging.info('==== DONE ========================================')
+
+        logging.info('')
+        logging.info('===> Assembling results...')
+        assembled_results = {}
+        for entry_name in entry_names:
+            entry = entries_dict.get(entry_name)
+            tags = tags_dict.get(entry_name)
+            assembled_results[entry_name] = (entry,
+                                             self.__filter_relevant_tags(
+                                                 entry, tags, table, column))
+        logging.info('==== DONE ========================================')
+
+        return assembled_results
+
+    @classmethod
+    def __make_query(cls,
+                     datasource: str = None,
+                     table: str = None,
+                     column: str = None) -> str:
+        """Make a Data Catalog search string by joining static and dynamic
+        terms.
+
+        Static search qualifiers (always added to the resulting string):
+            - system=<system>
+            - type=<type>
+
+        Dynamic search qualifiers (depend on user input to be added to the
+        resulting string):
+            - tag:datasource:val
+            - tag:table:val
+            - tag:column:val
+
+        Returns:
+            str: The search string.
+
+        Raises:
+            Exception: If no datasource, table, or column are provided.
+        """
+        if not (datasource or table or column):
+            raise Exception(
+                'Either a datasource, table, or column must be provided.')
+
+        query_terms = [
+            'system=Sisense',
+            cls.__make_type_search_term([
+                constants.USER_SPECIFIED_TYPE_DASHBOARD,
+                constants.USER_SPECIFIED_TYPE_WIDGET
+            ]),
+            cls.__make_datasource_search_term(datasource) or '',
+            cls.__make_table_search_term(table) or '',
+            cls.__make_column_search_term(column) or ''
+        ]
+        query = ' '.join(query_terms)
+        logging.info('Query: %s', query)
+        return query
+
+    @classmethod
+    def __make_type_search_term(cls, types: List[str]) -> Optional[str]:
+        """Make a Data Catalog search string with the `type` qualifier.
+
+        Logical `OR` is used to join the types if multiple values are provided,
+        which means all of them will be considered in subsequent catalog search
+        operations.
+
+        Returns:
+            str: The search term.
+        """
+        if not types:
+            return None
+
+        type_query_terms = [f'type={type_str}' for type_str in types]
+        return f'({" OR ".join(type_query_terms)})'
+
+    @classmethod
+    def __make_datasource_search_term(cls, datasource: str) -> Optional[str]:
+        """Make a Data Catalog search string with the `tag:datasource:val`
+        qualifier.
+
+        Sisense assets that connect to ElastiCube data sources, such as
+        Dashboards and Widgets, have the `datasource` field in their metadata
+        enrichment Tags, so we can leverage it when looking for ElastiCube
+        dependencies.
+
+        Returns:
+            str: The search term.
+        """
+        return f'tag:datasource:"{datasource}"' if datasource else None
+
+    @classmethod
+    def __make_table_search_term(cls, table: str) -> Optional[str]:
+        """Make a Data Catalog search string with the `tag:table:val`
+        qualifier.
+
+        Sisense assets that use ElastiCube tables, such as Dashboard/Widget
+        fields and filters, have the `table` field in their JAQL Tags, so we
+        can leverage it when looking for ElastiCube dependencies.
+
+        Returns:
+            str: The search term.
+        """
+        return f'tag:table:"{table}"' if table else None
+
+    @classmethod
+    def __make_column_search_term(cls, column: str) -> Optional[str]:
+        """Make a Data Catalog search string with the `tag:column:val`
+        qualifier.
+
+        Sisense assets that use ElastiCube columns, such as Dashboard/Widget
+        fields and filters, have the `column` field in their JAQL Tags, so we
+        can leverage it when looking for ElastiCube dependencies.
+
+        Returns:
+            str: The search term.
+        """
+        return f'tag:column:"{column}"' if column else None
+
+    def __get_entries(self, entry_names: List[str]) -> Dict[str, Entry]:
+        """Get Data Catalog Entries for a given list of entry names.
+
+        Returns:
+            dict: Keys are the names and values their corresponding entries.
+        """
+        entries_dict = {}
+        for entry_name in entry_names or []:
+            entries_dict[entry_name] = self.__datacatalog_facade.get_entry(
+                entry_name)
+
+        return entries_dict
+
+    def __list_tags(self, entry_names: List[str]) -> Dict[str, List[Tag]]:
+        """Get Data Catalog Tags for a given list of entry names.
+
+        Returns:
+            dict: Keys are the entry names and values are lists that contains
+            all their related tags.
+        """
+        tags_dict = {}
+        for entry_name in entry_names or []:
+            tags_dict[entry_name] = self.__datacatalog_facade.list_tags(
+                entry_name)
+
+        return tags_dict
+
+    @classmethod
+    def __filter_relevant_tags(cls, entry: Entry, tags: List[Tag], table: str,
+                               column: str) -> List[Tag]:
+        """Filter Tags for ElastiCube dependencies finding. "Relevant", in this
+        context, means Tags that have ElastiCube-related information such as
+        data source, table, or column names.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        filtered_tags = []
+
+        asset_metadata_tag = cls.filter_asset_metadata_tag(tags)
+        if asset_metadata_tag:
+            filtered_tags.append(asset_metadata_tag)
+        table_column_matching_tags = cls.__filter_table_column_matching_tags(
+            table, column, tags)
+        filtered_tags.extend(
+            cls.__sort_tags_by_schema(entry.schema.columns, '',
+                                      table_column_matching_tags))
+
+        return filtered_tags
+
+    @classmethod
+    def filter_asset_metadata_tag(cls, tags: List[Tag]) -> Optional[Tag]:
+        """Filter Dashboard and Widget metadata enrichment Tags created from
+        Templates identified by the `TAG_TEMPLATE_ID_DASHBOARD` and
+        `TAG_TEMPLATE_ID_WIDGET` constants.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        template_ids = [
+            constants.TAG_TEMPLATE_ID_DASHBOARD,
+            constants.TAG_TEMPLATE_ID_WIDGET
+        ]
+
+        for tag in tags or []:
+            template_id = re.match(pattern=cls.__TAG_TEMPLATE_NAME_PATTERN,
+                                   string=tag.template).group('id')
+
+            if template_id in template_ids:
+                return tag
+
+    @classmethod
+    def __filter_table_column_matching_tags(cls, table: str, column: str,
+                                            tags: List[Tag]) -> List[Tag]:
+        """Filter JAQL-related Tags which `table` and/or `column` fields match
+        the provided values.
+
+        If both `table` and `column` args are provided, a given Tag's
+        corresponding fields must match both values in order to added to the
+        resulting list.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        jaql_tags = cls.filter_jaql_tags(tags)
+        table_matching_tags = cls.__filter_table_matching_tags(
+            table, jaql_tags)
+        column_matching_tags = cls.__filter_column_matching_tags(
+            column, table_matching_tags if table and column else tags)
+
+        return column_matching_tags if column else table_matching_tags
+
+    @classmethod
+    def filter_jaql_tags(cls, tags: List[Tag]) -> List[Tag]:
+        """Filter JAQL-related Tags created from a Template identified by the
+        `TAG_TEMPLATE_ID_JAQL` constant.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        template_ids = [constants.TAG_TEMPLATE_ID_JAQL]
+
+        filtered_tags = []
+        for tag in tags or []:
+            template_id = re.match(pattern=cls.__TAG_TEMPLATE_NAME_PATTERN,
+                                   string=tag.template).group('id')
+
+            if template_id in template_ids:
+                filtered_tags.append(tag)
+
+        return filtered_tags
+
+    @classmethod
+    def __filter_table_matching_tags(cls, table: str,
+                                     tags: List[Tag]) -> List[Tag]:
+        """Filter Tags that have a `table` field that match the provided table
+        name.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        if not table:
+            return []
+
+        table_field = 'table'
+        table_lower = table.lower()
+
+        return [
+            tag for tag in tags or [] if table_field in tag.fields and
+            table_lower in tag.fields[table_field].string_value.lower()
+        ]
+
+    @classmethod
+    def __filter_column_matching_tags(cls, column: str,
+                                      tags: List[Tag]) -> List[Tag]:
+        """Filter Tags that have a `column` field that match the provided
+        column name.
+
+        Returns:
+            list: The filtered Tags.
+        """
+        if not column:
+            return []
+
+        column_field = 'column'
+        column_lower = column.lower()
+
+        return [
+            tag for tag in tags or [] if column_field in tag.fields and
+            column_lower in tag.fields[column_field].string_value.lower()
+        ]
+
+    @classmethod
+    def __sort_tags_by_schema(
+            cls, schema_columns: List[ColumnSchema], schema_path: str,
+            tags: Union[List[Tag], Dict[str, Tag]]) -> List[Tag]:
+        """Sort column-level Tags according to the order their related columns
+        are listed in the parent Entry's schema.
+
+        This method is intended to bring user friendliness to search results
+        processing as it ensures column-level Tags will be sorted exactly as
+        they are in the Data Catalog UI.
+
+        Returns:
+            list: The sorted Tags.
+        """
+        sorted_tags = []
+
+        if not schema_columns:
+            return sorted_tags
+
+        # No matter whether the `tags` arg is a `list` or a `dict` with unknown
+        # keys, this block converts into a `dict` in which keys are the Tags'
+        # column names and values are the Tag objects. Only column-level Tags
+        # are added to the resulting `dict`.
+        tags_dict = tags if isinstance(tags, dict) else None
+        if isinstance(tags, list):
+            tags_dict = {
+                tag.column.lower(): tag for tag in tags or [] if tag.column
+            }
+
+        for column in schema_columns:
+            column_path = f'{schema_path}{column.column}'.lower()
+            column_tag = tags_dict.get(column_path)
+            if column_tag:
+                sorted_tags.append(column_tag)
+            sorted_tags.extend(
+                cls.__sort_tags_by_schema(column.subcolumns, f'{column_path}.',
+                                          tags_dict))
+
+        return sorted_tags

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder.py
@@ -37,10 +37,12 @@ class ElastiCubeDependencyFinder:
     def __init__(self, project_id: str):
         self.__datacatalog_facade = commons.DataCatalogFacade(project_id)
 
-    def find(self,
-             datasource: str = None,
-             table: str = None,
-             column: str = None) -> Dict[str, Tuple[Entry, List[Tag]]]:
+    def find(
+            self,
+            datasource: Optional[str] = None,
+            table: Optional[str] = None,
+            column: Optional[str] = None
+    ) -> Dict[str, Tuple[Entry, List[Tag]]]:
         """
         Orchestrate actions that comprise:
             - generating a query string to search Google Data Catalog;
@@ -57,9 +59,7 @@ class ElastiCubeDependencyFinder:
         """
         logging.info('')
         logging.info('===> Searching Data Catalog...')
-        query = self.__make_query(datasource=datasource,
-                                  table=table,
-                                  column=column)
+        query = self.__make_query(datasource, table, column)
         search_results = self.__datacatalog_facade.search_catalog(query)
         logging.info('==== DONE ========================================')
 
@@ -97,9 +97,9 @@ class ElastiCubeDependencyFinder:
 
     @classmethod
     def __make_query(cls,
-                     datasource: str = None,
-                     table: str = None,
-                     column: str = None) -> str:
+                     datasource: Optional[str] = None,
+                     table: Optional[str] = None,
+                     column: Optional[str] = None) -> str:
         """Make a Data Catalog search string by joining static and dynamic
         terms.
 
@@ -155,8 +155,9 @@ class ElastiCubeDependencyFinder:
         return f'({" OR ".join(type_query_terms)})'
 
     @classmethod
-    def __make_datasource_search_term(cls,
-                                      datasource: str = None) -> Optional[str]:
+    def __make_datasource_search_term(
+            cls, datasource: Optional[str] = None
+    ) -> Optional[str]:  # yapf: disable
         """Make a Data Catalog search string with the `tag:datasource:val`
         qualifier.
 
@@ -171,7 +172,8 @@ class ElastiCubeDependencyFinder:
         return f'tag:datasource:"{datasource}"' if datasource else None
 
     @classmethod
-    def __make_table_search_term(cls, table: str = None) -> Optional[str]:
+    def __make_table_search_term(cls,
+                                 table: Optional[str] = None) -> Optional[str]:
         """Make a Data Catalog search string with the `tag:table:val`
         qualifier.
 
@@ -185,7 +187,9 @@ class ElastiCubeDependencyFinder:
         return f'tag:table:"{table}"' if table else None
 
     @classmethod
-    def __make_column_search_term(cls, column: str = None) -> Optional[str]:
+    def __make_column_search_term(
+            cls, column: Optional[str] = None
+    ) -> Optional[str]:  # yapf: disable
         """Make a Data Catalog search string with the `tag:column:val`
         qualifier.
 
@@ -229,8 +233,8 @@ class ElastiCubeDependencyFinder:
     def __filter_relevant_tags(cls,
                                entry: Entry,
                                tags: List[Tag],
-                               table: str = None,
-                               column: str = None) -> List[Tag]:
+                               table: Optional[str] = None,
+                               column: Optional[str] = None) -> List[Tag]:
         """Filter Tags for ElastiCube dependencies finding. "Relevant", in this
         context, means Tags that have ElastiCube-related information such as
         data source, table, or column names.
@@ -244,7 +248,7 @@ class ElastiCubeDependencyFinder:
         if asset_metadata_tag:
             filtered_tags.append(asset_metadata_tag)
         table_column_matching_tags = cls.__filter_table_column_matching_tags(
-            tags, table=table, column=column)
+            tags, table, column)
         filtered_tags.extend(
             cls.__sort_tags_by_schema(entry.schema.columns, '',
                                       table_column_matching_tags))
@@ -273,10 +277,11 @@ class ElastiCubeDependencyFinder:
                 return tag
 
     @classmethod
-    def __filter_table_column_matching_tags(cls,
-                                            tags: List[Tag],
-                                            table: str = None,
-                                            column: str = None) -> List[Tag]:
+    def __filter_table_column_matching_tags(
+            cls,
+            tags: List[Tag],
+            table: Optional[str] = None,
+            column: Optional[str] = None) -> List[Tag]:
         """Filter JAQL-related Tags which `table` and/or `column` fields match
         the provided args.
 
@@ -289,9 +294,9 @@ class ElastiCubeDependencyFinder:
         """
         jaql_tags = cls.filter_jaql_tags(tags)
         table_matching_tags = cls.__filter_table_matching_tags(
-            table, jaql_tags)
+            jaql_tags, table)
         column_matching_tags = cls.__filter_column_matching_tags(
-            column, table_matching_tags if table and column else tags)
+            table_matching_tags if table and column else tags, column)
 
         return column_matching_tags if column else table_matching_tags
 
@@ -316,8 +321,9 @@ class ElastiCubeDependencyFinder:
         return filtered_tags
 
     @classmethod
-    def __filter_table_matching_tags(cls, table: str,
-                                     tags: List[Tag]) -> List[Tag]:
+    def __filter_table_matching_tags(cls,
+                                     tags: List[Tag],
+                                     table: Optional[str] = None) -> List[Tag]:
         """Filter Tags that have a `table` field that match the provided table
         name.
 
@@ -336,8 +342,11 @@ class ElastiCubeDependencyFinder:
         ]
 
     @classmethod
-    def __filter_column_matching_tags(cls, column: str,
-                                      tags: List[Tag]) -> List[Tag]:
+    def __filter_column_matching_tags(
+            cls,
+            tags: List[Tag],
+            column: Optional[str] = None
+    ) -> List[Tag]:  # yapf: disable
         """Filter Tags that have a `column` field that match the provided
         column name.
 

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
@@ -71,9 +71,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.__datacatalog_facade.search_catalog.assert_called_once_with(
             fake_query)
 
-        mock_make_query.assert_called_once_with(datasource=None,
-                                                table='test-table',
-                                                column=None)
+        mock_make_query.assert_called_once_with(None, 'test-table', None)
         mock_get_entries.assert_called_once_with(['fake_entries/table-entry'])
         mock_list_tags.assert_called_once_with(['fake_entries/table-entry'])
         mock_filter_relevant_tags.assert_called_once_with(
@@ -134,9 +132,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         mock_make_column_search_term.return_value = 'tag:column:"test-column"'
 
         query = self.__finder._ElastiCubeDependencyFinder__make_query(
-            datasource='test-datasource',
-            table='test-table',
-            column='test-column')
+            'test-datasource', 'test-table', 'test-column')
 
         self.assertTrue('tag:datasource:"test-datasource"' in query)
         self.assertTrue('tag:table:"test-table"' in query)
@@ -253,8 +249,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder._ElastiCubeDependencyFinder__filter_relevant_tags(
             fake_entry, [fake_asset_metadata_tag, fake_table_matching_tag],
-            table='test-table',
-            column='test-column')
+            'test-table', 'test-column')
 
         self.assertEqual(2, len(tags))
         self.assertEqual(fake_asset_metadata_tag, tags[0])
@@ -263,9 +258,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         mock_filter_asset_metadata_tag.assert_called_once_with(
             [fake_asset_metadata_tag, fake_table_matching_tag])
         mock_filter_table_column_matching_tags.assert_called_once_with(
-            [fake_asset_metadata_tag, fake_table_matching_tag],
-            table='test-table',
-            column='test-column')
+            [fake_asset_metadata_tag, fake_table_matching_tag], 'test-table',
+            'test-column')
         mock_sort_tags_by_schema.assert_called_once_with(
             [], '', [fake_table_matching_tag])
 
@@ -316,11 +310,11 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_table_matching_tag, tags[0])
 
         mock_filter_column_matching_tags.assert_called_once_with(
-            None, [fake_table_matching_tag, fake_non_matching_tag])
+            [fake_table_matching_tag, fake_non_matching_tag], None)
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags',
-                lambda *args: None)
+                lambda *args, **kwargs: None)
     @mock.patch(f'{__FINDER_CLASS}.filter_jaql_tags', lambda *args: args)
     def test_filter_table_column_matching_tags_should_return_matching_column(
             self, mock_filter_column_matching_tags):
@@ -341,7 +335,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_column_matching_tag, tags[0])
 
         mock_filter_column_matching_tags.assert_called_once_with(
-            'test-column', [fake_non_matching_tag, fake_column_matching_tag])
+            [fake_non_matching_tag, fake_column_matching_tag], 'test-column')
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags')
@@ -368,14 +362,14 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
                     fake_column_only_matching_tag,
                     fake_table_column_matching_tag
                 ],
-                table='test-table', column='test-column')
+                'test-table', 'test-column')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_table_column_matching_tag, tags[0])
 
         mock_filter_column_matching_tags.assert_called_once_with(
-            'test-column',
-            [fake_table_only_matching_tag, fake_table_column_matching_tag])
+            [fake_table_only_matching_tag, fake_table_column_matching_tag],
+            'test-column')
 
     def test_filter_jaql_tags_should_return_only_jaql_tags(self):
 
@@ -401,7 +395,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder \
             ._ElastiCubeDependencyFinder__filter_table_matching_tags(
-                None, [fake_table_related_tag])
+                [fake_table_related_tag])
 
         self.assertEqual(0, len(tags))
 
@@ -413,7 +407,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder \
             ._ElastiCubeDependencyFinder__filter_table_matching_tags(
-                'test-table', [fake_non_matching_tag, fake_table_matching_tag])
+                [fake_non_matching_tag, fake_table_matching_tag],
+                table='test-table')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_table_matching_tag, tags[0])
@@ -424,7 +419,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder \
             ._ElastiCubeDependencyFinder__filter_column_matching_tags(
-                None, [fake_column_related_tag])
+                [fake_column_related_tag])
 
         self.assertEqual(0, len(tags))
 
@@ -438,8 +433,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder \
             ._ElastiCubeDependencyFinder__filter_column_matching_tags(
-                'test-column',
-                [fake_non_matching_tag, fake_column_matching_tag])
+                [fake_non_matching_tag, fake_column_matching_tag],
+                column='test-column')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_column_matching_tag, tags[0])

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
@@ -1,0 +1,519 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+from typing import Tuple
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import Entry, SearchCatalogResult, Tag
+
+from google.datacatalog_connectors.sisense import addons
+
+
+class ElastiCubeDependencyFinderTest(unittest.TestCase):
+    __ADDONS_PACKAGE = 'google.datacatalog_connectors.sisense.addons'
+    __FINDER_MODULE = f'{__ADDONS_PACKAGE}.elasticube_dependency_finder'
+    __FINDER_CLASS = f'{__FINDER_MODULE}.ElastiCubeDependencyFinder'
+    __PRIVATE_METHOD_PREFIX = f'{__FINDER_CLASS}._ElastiCubeDependencyFinder'
+
+    @mock.patch(f'{__FINDER_MODULE}.commons.DataCatalogFacade')
+    def setUp(self, mock_facade):
+        self.__finder = addons.ElastiCubeDependencyFinder(
+            project_id='test-project')
+        self.__datacatalog_facade = mock_facade.return_value
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_relevant_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__list_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_entries')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_query')
+    def test_run_should_return_assembled_entries_and_tags(
+            self, mock_make_query, mock_get_entries, mock_list_tags,
+            mock_filter_relevant_tags):
+
+        fake_query = 'tag:table:"test-table"'
+        mock_make_query.return_value = fake_query
+
+        self.__datacatalog_facade.search_catalog.return_value = [
+            self.__make_fake_search_result('table-entry')
+        ]
+
+        fake_entry = self.__make_fake_entry('table-entry')
+        mock_get_entries.return_value = {
+            'fake_entries/table-entry': fake_entry
+        }
+
+        fake_tag = self.__make_fake_tag()
+        mock_list_tags.return_value = {'fake_entries/table-entry': [fake_tag]}
+
+        mock_filter_relevant_tags.return_value = [fake_tag]
+
+        results = self.__finder.find(table='test-table')
+
+        self.assertEqual(1, len(results))
+        self.assertTrue('fake_entries/table-entry' in results)
+        self.assertEqual((fake_entry, [fake_tag]),
+                         results['fake_entries/table-entry'])
+
+        self.__datacatalog_facade.search_catalog.assert_called_once_with(
+            fake_query)
+
+        mock_make_query.assert_called_once_with(datasource=None,
+                                                table='test-table',
+                                                column=None)
+        mock_get_entries.assert_called_once_with(['fake_entries/table-entry'])
+        mock_list_tags.assert_called_once_with(['fake_entries/table-entry'])
+        mock_filter_relevant_tags.assert_called_once_with(
+            fake_entry, [fake_tag], 'test-table', None)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_query')
+    def test_run_should_return_empty_dict_if_no_search_results(
+            self, mock_make_query):
+
+        fake_query = 'tag:table:"test-table"'
+        mock_make_query.return_value = fake_query
+
+        self.__datacatalog_facade.search_catalog.return_value = []
+
+        results = self.__finder.find(table='test-table')
+
+        self.assertEqual(0, len(results))
+
+        self.__datacatalog_facade.search_catalog.assert_called_once_with(
+            fake_query)
+
+    def test_make_query_should_raise_exception_if_empty_args(self):
+        self.assertRaises(
+            Exception, self.__finder._ElastiCubeDependencyFinder__make_query)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_column_search_term',
+                lambda *args: None)
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_table_search_term',
+                lambda *args: None)
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_datasource_search_term',
+                lambda *args: None)
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_type_search_term')
+    def test_make_query_should_handle_static_search_terms(
+            self, mock_make_type_search_term):
+
+        mock_make_type_search_term.return_value = \
+            '(type=Dashboard OR type=Widget)'
+
+        query = self.__finder._ElastiCubeDependencyFinder__make_query(
+            table='test-table')
+
+        self.assertTrue('system=Sisense' in query)
+        mock_make_type_search_term.assert_called_once_with(
+            ['Dashboard', 'Widget'])
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_column_search_term')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_table_search_term')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_datasource_search_term')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__make_type_search_term',
+                lambda *args: '(type=Dashboard OR type=Widget')
+    def test_make_query_should_handle_dynamic_search_terms(
+            self, mock_make_datasource_search_term,
+            mock_make_table_search_term, mock_make_column_search_term):
+
+        mock_make_datasource_search_term.return_value = \
+            'tag:datasource:"test-datasource"'
+        mock_make_table_search_term.return_value = 'tag:table:"test-table"'
+        mock_make_column_search_term.return_value = 'tag:column:"test-column"'
+
+        query = self.__finder._ElastiCubeDependencyFinder__make_query(
+            datasource='test-datasource',
+            table='test-table',
+            column='test-column')
+
+        self.assertTrue('tag:datasource:"test-datasource"' in query)
+        self.assertTrue('tag:table:"test-table"' in query)
+        self.assertTrue('tag:column:"test-column"' in query)
+
+        mock_make_datasource_search_term.assert_called_once_with(
+            'test-datasource')
+        mock_make_table_search_term.assert_called_once_with('test-table')
+        mock_make_column_search_term.assert_called_once_with('test-column')
+
+    def test_make_type_search_term_should_return_none_if_no_types(self):
+        query = self\
+            .__finder._ElastiCubeDependencyFinder__make_type_search_term([])
+
+        self.assertIsNone(query)
+
+    def test_make_type_search_term_should_not_use_or_for_single_type(self):
+        query = \
+            self.__finder._ElastiCubeDependencyFinder__make_type_search_term(
+                ['Dashboard'])
+
+        self.assertEqual('(type=Dashboard)', query)
+
+    def test_make_type_search_term_should_use_or_for_multiple_types(self):
+        query = \
+            self.__finder._ElastiCubeDependencyFinder__make_type_search_term(
+                ['Dashboard', 'Widget'])
+
+        self.assertEqual('(type=Dashboard OR type=Widget)', query)
+
+    def test_make_datasource_search_term_should_return_none_if_no_datasource(
+            self):
+
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_datasource_search_term(None)
+
+        self.assertIsNone(query)
+
+    def test_make_datasource_search_term_should_return_tag_qualifier(self):
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_datasource_search_term(
+                'test-datasource')
+
+        self.assertEqual('tag:datasource:"test-datasource"', query)
+
+    def test_make_table_search_term_should_return_none_if_no_table(self):
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_table_search_term(None)
+
+        self.assertIsNone(query)
+
+    def test_make_table_search_term_should_return_tag_qualifier(self):
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_table_search_term('test-table')
+
+        self.assertEqual('tag:table:"test-table"', query)
+
+    def test_make_column_search_term_should_return_none_if_no_column(self):
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_column_search_term(None)
+
+        self.assertIsNone(query)
+
+    def test_make_column_search_term_should_return_tag_qualifier(self):
+        query = self.__finder\
+            ._ElastiCubeDependencyFinder__make_column_search_term(
+                'test-column')
+
+        self.assertEqual('tag:column:"test-column"', query)
+
+    def test_get_entries_should_return_dict(self):
+        fake_entry = self.__make_fake_entry('some-entry')
+        self.__datacatalog_facade.get_entry.return_value = fake_entry
+
+        entries = self.__finder._ElastiCubeDependencyFinder__get_entries(
+            ['fake_entries/some-entry'])
+
+        self.assertEqual(1, len(entries))
+        self.assertEqual(fake_entry, entries['fake_entries/some-entry'])
+
+        self.__datacatalog_facade.get_entry.assert_called_once_with(
+            'fake_entries/some-entry')
+
+    def test_list_tags_should_return_dict(self):
+        fake_tag = self.__make_fake_tag()
+        self.__datacatalog_facade.list_tags.return_value = [fake_tag]
+
+        tags = self.__finder._ElastiCubeDependencyFinder__list_tags(
+            ['fake_entries/some-entry'])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_tag, tags['fake_entries/some-entry'][0])
+
+        self.__datacatalog_facade.list_tags.assert_called_once_with(
+            'fake_entries/some-entry')
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__sort_tags_by_schema')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}'
+                f'__filter_table_column_matching_tags')
+    @mock.patch(f'{__FINDER_CLASS}.filter_asset_metadata_tag')
+    def test_filter_relevant_tags_should_filter_and_sort_tags(
+            self, mock_filter_asset_metadata_tag,
+            mock_filter_table_column_matching_tags, mock_sort_tags_by_schema):
+
+        fake_entry = self.__make_fake_entry('some-entry')
+        fake_asset_metadata_tag = self.__make_fake_tag()
+        fake_table_matching_tag = self.__make_fake_tag()
+
+        mock_filter_asset_metadata_tag.return_value = fake_asset_metadata_tag
+        mock_filter_table_column_matching_tags.return_value = [
+            fake_table_matching_tag
+        ]
+        mock_sort_tags_by_schema.return_value = [fake_table_matching_tag]
+
+        tags = self.__finder._ElastiCubeDependencyFinder__filter_relevant_tags(
+            fake_entry, [fake_asset_metadata_tag, fake_table_matching_tag],
+            'test-table', 'test-column')
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(fake_asset_metadata_tag, tags[0])
+        self.assertEqual(fake_table_matching_tag, tags[1])
+
+        mock_filter_asset_metadata_tag.assert_called_once_with(
+            [fake_asset_metadata_tag, fake_table_matching_tag])
+        mock_filter_table_column_matching_tags.assert_called_once_with(
+            'test-table', 'test-column',
+            [fake_asset_metadata_tag, fake_table_matching_tag])
+        mock_sort_tags_by_schema.assert_called_once_with(
+            [], '', [fake_table_matching_tag])
+
+    def test_filter_asset_metadata_tag_should_return_dashboard_metadata_tag(
+            self):
+
+        fake_jaql_related_tag = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_jaql_metadata')
+        fake_dashboard_metadata_tag = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_dashboard_metadata')
+
+        tag = self.__finder.filter_asset_metadata_tag(
+            [fake_jaql_related_tag, fake_dashboard_metadata_tag])
+
+        self.assertEqual(fake_dashboard_metadata_tag, tag)
+
+    def test_filter_asset_metadata_tag_should_return_widget_metadata_tag(self):
+        fake_jaql_related_tag = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_jaql_metadata')
+        fake_widget_metadata_tag = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_widget_metadata')
+
+        tag = self.__finder.filter_asset_metadata_tag(
+            [fake_jaql_related_tag, fake_widget_metadata_tag])
+
+        self.assertEqual(fake_widget_metadata_tag, tag)
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags')
+    @mock.patch(f'{__FINDER_CLASS}.filter_jaql_tags', lambda *args: args)
+    def test_filter_table_column_matching_tags_should_return_matching_table(
+            self, mock_filter_table_matching_tags,
+            mock_filter_column_matching_tags):
+
+        fake_table_matching_tag = self.__make_fake_tag()
+        fake_non_matching_tag = self.__make_fake_tag()
+
+        mock_filter_table_matching_tags.return_value = [
+            fake_table_matching_tag
+        ]
+
+        tags = self.__finder\
+            ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
+                'test-table', '',
+                [fake_table_matching_tag, fake_non_matching_tag])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_table_matching_tag, tags[0])
+
+        mock_filter_column_matching_tags.assert_called_once_with(
+            '', [fake_table_matching_tag, fake_non_matching_tag])
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags',
+                lambda *args: None)
+    @mock.patch(f'{__FINDER_CLASS}.filter_jaql_tags', lambda *args: args)
+    def test_filter_table_column_matching_tags_should_return_matching_column(
+            self, mock_filter_column_matching_tags):
+
+        fake_non_matching_tag = self.__make_fake_tag()
+        fake_column_matching_tag = self.__make_fake_tag()
+
+        mock_filter_column_matching_tags.return_value = [
+            fake_column_matching_tag
+        ]
+
+        tags = self.__finder\
+            ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
+                '', 'test-column',
+                [fake_non_matching_tag, fake_column_matching_tag])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_column_matching_tag, tags[0])
+
+        mock_filter_column_matching_tags.assert_called_once_with(
+            'test-column', [fake_non_matching_tag, fake_column_matching_tag])
+
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags')
+    @mock.patch(f'{__FINDER_CLASS}.filter_jaql_tags', lambda *args: args)
+    def test_filter_table_column_matching_tags_should_return_matching_both(
+            self, mock_filter_table_matching_tags,
+            mock_filter_column_matching_tags):
+
+        fake_table_only_matching_tag = self.__make_fake_tag()
+        fake_column_only_matching_tag = self.__make_fake_tag()
+        fake_table_column_matching_tag = self.__make_fake_tag()
+
+        mock_filter_table_matching_tags.return_value = [
+            fake_table_only_matching_tag, fake_table_column_matching_tag
+        ]
+        mock_filter_column_matching_tags.return_value = [
+            fake_table_column_matching_tag
+        ]
+
+        tags = self.__finder\
+            ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
+                'test-table', 'test-column',
+                [
+                    fake_table_only_matching_tag,
+                    fake_column_only_matching_tag,
+                    fake_table_column_matching_tag
+                ])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_table_column_matching_tag, tags[0])
+
+        mock_filter_column_matching_tags.assert_called_once_with(
+            'test-column',
+            [fake_table_only_matching_tag, fake_table_column_matching_tag])
+
+    def test_filter_jaql_tags_should_return_only_jaql_tags(self):
+
+        fake_jaql_related_tag_1 = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_jaql_metadata')
+        fake_widget_metadata_tag = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_widget_metadata')
+        fake_jaql_related_tag_2 = self.__make_fake_tag(
+            template='test/tagTemplates/sisense_jaql_metadata')
+
+        tags = self.__finder.filter_jaql_tags([
+            fake_jaql_related_tag_1, fake_widget_metadata_tag,
+            fake_jaql_related_tag_2
+        ])
+
+        self.assertEqual(2, len(tags))
+        self.assertEqual(fake_jaql_related_tag_1, tags[0])
+        self.assertEqual(fake_jaql_related_tag_2, tags[1])
+
+    def test_filter_table_matching_tags_should_none_if_no_table_name(self):
+        fake_table_related_tag = self.__make_fake_tag(
+            string_fields=(('table', 'test-table'),))
+
+        tags = self.__finder \
+            ._ElastiCubeDependencyFinder__filter_table_matching_tags(
+                None, [fake_table_related_tag])
+
+        self.assertEqual(0, len(tags))
+
+    def test_filter_table_matching_tags_should_return_only_matching_tags(self):
+        fake_non_matching_tag = self.__make_fake_tag(
+            string_fields=(('column', 'test-column'),))
+        fake_table_matching_tag = self.__make_fake_tag(
+            string_fields=(('table', 'test-table'),))
+
+        tags = self.__finder \
+            ._ElastiCubeDependencyFinder__filter_table_matching_tags(
+                'test-table', [fake_non_matching_tag, fake_table_matching_tag])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_table_matching_tag, tags[0])
+
+    def test_filter_column_matching_tags_should_none_if_no_column_name(self):
+        fake_column_related_tag = self.__make_fake_tag(
+            string_fields=(('column', 'test-column'),))
+
+        tags = self.__finder \
+            ._ElastiCubeDependencyFinder__filter_column_matching_tags(
+                None, [fake_column_related_tag])
+
+        self.assertEqual(0, len(tags))
+
+    def test_filter_column_matching_tags_should_return_only_matching_tags(
+            self):
+
+        fake_non_matching_tag = self.__make_fake_tag(
+            string_fields=(('table', 'test-table'),))
+        fake_column_matching_tag = self.__make_fake_tag(
+            string_fields=(('column', 'test-column'),))
+
+        tags = self.__finder \
+            ._ElastiCubeDependencyFinder__filter_column_matching_tags(
+                'test-column',
+                [fake_non_matching_tag, fake_column_matching_tag])
+
+        self.assertEqual(1, len(tags))
+        self.assertEqual(fake_column_matching_tag, tags[0])
+
+    def test_sort_tags_by_schema_should_return_sorted_tags(self):
+        fields_column = datacatalog.ColumnSchema()
+        fields_column.column = 'fields'
+
+        field1_column = datacatalog.ColumnSchema()
+        field1_column.column = 'field1'
+
+        field2_column = datacatalog.ColumnSchema()
+        field2_column.column = 'field2'
+
+        subfields_column = datacatalog.ColumnSchema()
+        subfields_column.column = 'subfields'
+
+        subfield1_column = datacatalog.ColumnSchema()
+        subfield1_column.column = 'subfield1'
+
+        fields_column.subcolumns.append(field1_column)
+        subfields_column.subcolumns.append(subfield1_column)
+        field2_column.subcolumns.append(subfields_column)
+        fields_column.subcolumns.append(field2_column)
+
+        schema = datacatalog.Schema()
+        schema.columns.append(fields_column)
+
+        fake_column_level_tag_1 = self.__make_fake_tag(column='fields.field1')
+        fake_column_level_tag_2 = self.__make_fake_tag(column='fields.field2')
+        fake_column_level_tag_3 = self.__make_fake_tag(
+            column='fields.field2.subfields.subfield1')
+
+        tags = self.__finder \
+            ._ElastiCubeDependencyFinder__sort_tags_by_schema(
+                schema.columns, '',
+                [
+                    fake_column_level_tag_2,
+                    fake_column_level_tag_3,
+                    fake_column_level_tag_1
+                ])
+
+        self.assertEqual(3, len(tags))
+        self.assertEqual(fake_column_level_tag_1, tags[0])
+        self.assertEqual(fake_column_level_tag_2, tags[1])
+        self.assertEqual(fake_column_level_tag_3, tags[2])
+
+    @classmethod
+    def __make_fake_search_result(cls, entry_id: str) -> SearchCatalogResult:
+        result = datacatalog.SearchCatalogResult()
+        result.relative_resource_name = f'fake_entries/{entry_id}'
+        return result
+
+    @classmethod
+    def __make_fake_entry(cls, entry_id: str) -> Entry:
+        entry = datacatalog.Entry()
+        entry.name = f'fake_entries/{entry_id}'
+        entry.schema = datacatalog.Schema()
+        return entry
+
+    @classmethod
+    def __make_fake_tag(cls,
+                        template: str = 'template',
+                        column: str = None,
+                        string_fields: Tuple[Tuple[str, str]] = None) -> Tag:
+
+        tag = datacatalog.Tag()
+        tag.template = template
+
+        if column:
+            tag.column = column
+
+        if string_fields:
+            for string_field in string_fields:
+                tag_field = datacatalog.TagField()
+                tag_field.string_value = string_field[1]
+                tag.fields[string_field[0]] = tag_field
+
+        return tag

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
@@ -171,7 +171,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
             self):
 
         query = self.__finder\
-            ._ElastiCubeDependencyFinder__make_datasource_search_term(None)
+            ._ElastiCubeDependencyFinder__make_datasource_search_term()
 
         self.assertIsNone(query)
 
@@ -184,7 +184,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
     def test_make_table_search_term_should_return_none_if_no_table(self):
         query = self.__finder\
-            ._ElastiCubeDependencyFinder__make_table_search_term(None)
+            ._ElastiCubeDependencyFinder__make_table_search_term()
 
         self.assertIsNone(query)
 
@@ -196,7 +196,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
     def test_make_column_search_term_should_return_none_if_no_column(self):
         query = self.__finder\
-            ._ElastiCubeDependencyFinder__make_column_search_term(None)
+            ._ElastiCubeDependencyFinder__make_column_search_term()
 
         self.assertIsNone(query)
 
@@ -253,7 +253,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder._ElastiCubeDependencyFinder__filter_relevant_tags(
             fake_entry, [fake_asset_metadata_tag, fake_table_matching_tag],
-            'test-table', 'test-column')
+            table='test-table',
+            column='test-column')
 
         self.assertEqual(2, len(tags))
         self.assertEqual(fake_asset_metadata_tag, tags[0])
@@ -262,8 +263,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         mock_filter_asset_metadata_tag.assert_called_once_with(
             [fake_asset_metadata_tag, fake_table_matching_tag])
         mock_filter_table_column_matching_tags.assert_called_once_with(
-            'test-table', 'test-column',
-            [fake_asset_metadata_tag, fake_table_matching_tag])
+            [fake_asset_metadata_tag, fake_table_matching_tag],
+            table='test-table',
+            column='test-column')
         mock_sort_tags_by_schema.assert_called_once_with(
             [], '', [fake_table_matching_tag])
 
@@ -307,14 +309,14 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder\
             ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
-                'test-table', '',
-                [fake_table_matching_tag, fake_non_matching_tag])
+                [fake_table_matching_tag, fake_non_matching_tag],
+                table='test-table')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_table_matching_tag, tags[0])
 
         mock_filter_column_matching_tags.assert_called_once_with(
-            '', [fake_table_matching_tag, fake_non_matching_tag])
+            None, [fake_table_matching_tag, fake_non_matching_tag])
 
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_column_matching_tags')
     @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__filter_table_matching_tags',
@@ -332,8 +334,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder\
             ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
-                '', 'test-column',
-                [fake_non_matching_tag, fake_column_matching_tag])
+                [fake_non_matching_tag, fake_column_matching_tag],
+                column='test-column')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_column_matching_tag, tags[0])
@@ -361,12 +363,12 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
         tags = self.__finder\
             ._ElastiCubeDependencyFinder__filter_table_column_matching_tags(
-                'test-table', 'test-column',
                 [
                     fake_table_only_matching_tag,
                     fake_column_only_matching_tag,
                     fake_table_column_matching_tag
-                ])
+                ],
+                table='test-table', column='test-column')
 
         self.assertEqual(1, len(tags))
         self.assertEqual(fake_table_column_matching_tag, tags[0])


### PR DESCRIPTION
**- What I did**
Added the `addons.ElastiCubeDependencyFinder` class, the core of a new feature for the Sisense Connector CLI that is going to [allow users to easily find and display the specific fields and filters that depend on a given ElastiCube data source, table, and/or column](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/projects/1#card-68317635).

**- How I did it**
Added the `addons.ElastiCubeDependencyFinder` class and its unit tests as well.

**- How to verify it**
Run the unit tests.

**- Description for the changelog**
Added the `addons.ElastiCubeDependencyFinder` class.

PS 1: This PR is part of the effort to deliver #70.
PS 2: The CLI changes and related docs are already done but will be tackled in a separate PR to make the code review easier.
