### PR TITLE
Add the find-elasticube-deps CLI option

### DIFF
--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -130,7 +130,7 @@ export SISENSE2DC_DATACATALOG_LOCATION_ID=google_cloud_location_id
 - Virtualenv
 
 ```shell script
-google-datacatalog-sisense-connector \
+google-datacatalog-sisense-connector sync-catalog \
   --sisense-server $SISENSE2DC_SISENSE_SERVER \
   --sisense-username $SISENSE2DC_SISENSE_USERNAME \
   --sisense-password $SISENSE2DC_SISENSE_PASSWORD \
@@ -143,7 +143,7 @@ google-datacatalog-sisense-connector \
 ```shell script
 docker build --rm --tag sisense2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
-  sisense2datacatalog \
+  sisense2datacatalog sync-catalog \
   --sisense-server $SISENSE2DC_SISENSE_SERVER \
   --sisense-username $SISENSE2DC_SISENSE_USERNAME \
   --sisense-password $SISENSE2DC_SISENSE_PASSWORD \

--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -41,8 +41,12 @@ currently processes JAQL query metadata from:
     + [2.1.2. Download a JSON key and save it as](#212-download-a-json-key-and-save-it-as)
   * [2.2. Set environment variables](#22-set-environment-variables)
 - [3. Running the connector](#3-running-the-connector)
-  * [3.1. Python entry point](#31-python-entry-point)
-  * [3.2. Docker entry point](#32-docker-entry-point)
+  * [3.1. sync-catalog](#31-sync-catalog)
+    + [3.1.1. Python entry point](#311-python-entry-point)
+    + [3.1.2. Docker entry point](#312-docker-entry-point)
+  * [3.2. find-elasticube-deps](#32-find-elasticube-deps)
+    + [3.2.1. Python entry point](#321-python-entry-point)
+    + [3.2.2. Docker entry point](#322-docker-entry-point)
 - [4. Developer environment](#4-developer-environment)
   * [4.1. Install and run the YAPF formatter](#41-install-and-run-the-yapf-formatter)
   * [4.2. Install and run the Flake8 linter](#42-install-and-run-the-flake8-linter)
@@ -123,9 +127,13 @@ export SISENSE2DC_DATACATALOG_LOCATION_ID=google_cloud_location_id
 
 ## 3. Running the connector
 
+### 3.1. sync-catalog
+
+Synchronizes Google Data Catalog with a given Sisense server.
+
 - The `--datacatalog-location-id` argument is optional and defaults to `us`.
 
-### 3.1. Python entry point
+#### 3.1.1. Python entry point
 
 - Virtualenv
 
@@ -138,7 +146,7 @@ google-datacatalog-sisense-connector sync-catalog \
   [--datacatalog-location-id $SISENSE2DC_DATACATALOG_LOCATION_ID]
 ```
 
-### 3.2. Docker entry point
+#### 3.1.2. Docker entry point
 
 ```shell script
 docker build --rm --tag sisense2datacatalog .
@@ -149,6 +157,35 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   --sisense-password $SISENSE2DC_SISENSE_PASSWORD \
   --datacatalog-project-id $SISENSE2DC_DATACATALOG_PROJECT_ID \
   [--datacatalog-location-id $SISENSE2DC_DATACATALOG_LOCATION_ID]
+```
+
+### 3.2. find-elasticube-deps
+
+Finds ElastiCube dependencies through catalog search and prints them in the
+console.
+
+#### 3.2.1. Python entry point
+
+- Virtualenv
+
+```shell script
+google-datacatalog-sisense-connector find-elasticube-deps \
+  --datasource <datasource> \
+  --table <table> \
+  --column <column> \
+  --datacatalog-project-id $SISENSE2DC_DATACATALOG_PROJECT_ID
+```
+
+#### 3.2.2. Docker entry point
+
+```shell script
+docker build --rm --tag sisense2datacatalog .
+docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
+  sisense2datacatalog find-elasticube-deps \
+  --datasource <datasource> \
+  --table <table> \
+  --column <column> \
+  --datacatalog-project-id $SISENSE2DC_DATACATALOG_PROJECT_ID
 ```
 
 ## 4. Developer environment

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/__init__.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/__init__.py
@@ -15,5 +15,6 @@
 # limitations under the License.
 
 from .elasticube_dependency_finder import ElastiCubeDependencyFinder
+from .elasticube_dependency_printer import ElastiCubeDependencyPrinter
 
-__all__ = ('ElastiCubeDependencyFinder',)
+__all__ = ('ElastiCubeDependencyFinder', 'ElastiCubeDependencyPrinter')

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List, Optional, Tuple
+
+from google.cloud.datacatalog import Entry, Tag
+
+from google.datacatalog_connectors.sisense.addons import \
+    elasticube_dependency_finder as finder
+
+
+class ElastiCubeDependencyPrinter:
+
+    def print_dependency_finder_results(
+            self, results: Dict[str, Tuple[Entry, List[Tag]]]) -> None:
+
+        if not results:
+            return
+
+        print('\nResults:')
+
+        human_readable_index = 0
+        for entry_name, metadata in results.items():
+            entry = metadata[0]
+            tags = metadata[1]
+
+            dashboard_title = self.__get_asset_metadata_value(
+                tags, 'dashboard_title')
+            datasource = self.__get_asset_metadata_value(tags, 'datasource')
+            jaql_tags = finder.ElastiCubeDependencyFinder.filter_jaql_tags(
+                tags)
+
+            human_readable_index += 1
+            print(f'\n{human_readable_index}')
+            print(f'Entry       : {entry.name}')
+            print(f'Type        : {entry.user_specified_type}')
+            print(f'Title       : {entry.display_name}')
+            if dashboard_title:
+                print(f'Dashboard   : {dashboard_title}')
+            print(f'Data source : {datasource}')
+            print(f'URL         : {entry.linked_resource}\n')
+            if jaql_tags:
+                print('Matching fields and filters:')
+                for tag in jaql_tags:
+                    print()
+                    print(f'  Component : {tag.column}')
+                    print(f'  Table     : {tag.fields["table"].string_value}')
+                    print(f'  Column    : {tag.fields["column"].string_value}')
+            print('--------------------------------------------------')
+        print()
+
+    @classmethod
+    def __get_asset_metadata_value(cls, tags: List[Tag],
+                                   field_name: str) -> Optional[str]:
+
+        asset_metadata_tag = finder.ElastiCubeDependencyFinder\
+            .filter_asset_metadata_tag(tags)
+
+        if field_name in asset_metadata_tag.fields:
+            return asset_metadata_tag.fields[field_name].string_value

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer.py
@@ -18,14 +18,14 @@ from typing import Dict, List, Optional, Tuple
 
 from google.cloud.datacatalog import Entry, Tag
 
-from google.datacatalog_connectors.sisense.addons import \
-    elasticube_dependency_finder as finder
+from google.datacatalog_connectors.sisense import addons
 
 
 class ElastiCubeDependencyPrinter:
 
+    @classmethod
     def print_dependency_finder_results(
-            self, results: Dict[str, Tuple[Entry, List[Tag]]]) -> None:
+            cls, results: Dict[str, Tuple[Entry, List[Tag]]]) -> None:
 
         if not results:
             return
@@ -37,10 +37,10 @@ class ElastiCubeDependencyPrinter:
             entry = metadata[0]
             tags = metadata[1]
 
-            dashboard_title = self.__get_asset_metadata_value(
+            dashboard_title = cls.__get_asset_metadata_value(
                 tags, 'dashboard_title')
-            datasource = self.__get_asset_metadata_value(tags, 'datasource')
-            jaql_tags = finder.ElastiCubeDependencyFinder.filter_jaql_tags(
+            datasource = cls.__get_asset_metadata_value(tags, 'datasource')
+            jaql_tags = addons.ElastiCubeDependencyFinder.filter_jaql_tags(
                 tags)
 
             human_readable_index += 1
@@ -50,7 +50,7 @@ class ElastiCubeDependencyPrinter:
             print(f'Title       : {entry.display_name}')
             if dashboard_title:
                 print(f'Dashboard   : {dashboard_title}')
-            print(f'Data source : {datasource}')
+            print(f'Data source : {datasource if datasource else ""}')
             print(f'URL         : {entry.linked_resource}\n')
             if jaql_tags:
                 print('Matching fields and filters:')
@@ -66,7 +66,7 @@ class ElastiCubeDependencyPrinter:
     def __get_asset_metadata_value(cls, tags: List[Tag],
                                    field_name: str) -> Optional[str]:
 
-        asset_metadata_tag = finder.ElastiCubeDependencyFinder\
+        asset_metadata_tag = addons.ElastiCubeDependencyFinder\
             .filter_asset_metadata_tag(tags)
 
         if field_name in asset_metadata_tag.fields:

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sisense2datacatalog_cli.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sisense2datacatalog_cli.py
@@ -121,8 +121,8 @@ class _FindElastiCubeDepsCliHelper:
                 args.datacatalog_project_id).find(args.datasource, args.table,
                                                   args.column)
 
-            addons.ElastiCubeDependencyPrinter()\
-                .print_dependency_finder_results(dependencies)
+            addons.ElastiCubeDependencyPrinter.print_dependency_finder_results(
+                dependencies)
         except Exception as e:
             raise SystemExit(e)
 

--- a/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sisense2datacatalog_cli.py
+++ b/google-datacatalog-sisense-connector/src/google/datacatalog_connectors/sisense/sisense2datacatalog_cli.py
@@ -18,11 +18,10 @@ import argparse
 import logging
 import sys
 
-from google.datacatalog_connectors.sisense import sync
+from google.datacatalog_connectors.sisense import addons, sync
 
 
 class Sisense2DataCatalogCli:
-    __DEFAULT_DATACATALOG_LOCATION_ID = 'us'
 
     @classmethod
     def run(cls, argv):
@@ -41,36 +40,91 @@ class Sisense2DataCatalogCli:
             description=__doc__,
             formatter_class=argparse.RawDescriptionHelpFormatter)
 
-        parser.add_argument('--sisense-server',
-                            help='Sisense Server address',
-                            required=True)
-        parser.add_argument('--sisense-username',
-                            help='Sisense username',
-                            required=True)
-        parser.add_argument('--sisense-password',
-                            help='Sisense password',
-                            required=True)
-        parser.add_argument('--datacatalog-project-id',
-                            help='Google Cloud Project ID',
-                            required=True)
-        parser.add_argument('--datacatalog-location-id',
-                            help='Location ID to be used Google Data Catalog'
-                            'to store the metadata',
-                            default=cls.__DEFAULT_DATACATALOG_LOCATION_ID)
-
-        parser.set_defaults(func=cls.__run_synchronizer)
+        subparsers = parser.add_subparsers()
+        _SyncCatalogCliHelper().add_parser(subparsers)
+        _FindElastiCubeDepsCliHelper().add_parser(subparsers)
 
         return parser.parse_args(argv)
 
+
+class _SyncCatalogCliHelper:
+    __DEFAULT_DATACATALOG_LOCATION_ID = 'us'
+
     @classmethod
-    def __run_synchronizer(cls, args):
-        sync.MetadataSynchronizer(
+    def add_parser(cls, subparsers):
+        parser = subparsers.add_parser(
+            'sync-catalog',
+            help='Synchronize Data Catalog with a Sisense server')
+
+        parser.add_argument('--sisense-server',
+                            help='Sisense Server address',
+                            required=True)
+
+        parser.add_argument('--sisense-username',
+                            help='Sisense username',
+                            required=True)
+
+        parser.add_argument('--sisense-password',
+                            help='Sisense password',
+                            required=True)
+
+        parser.add_argument('--datacatalog-project-id',
+                            help='ID of the Google Cloud Project where the'
+                            ' Data Catalog entries, tag templates, and tags'
+                            ' created by the connector are stored',
+                            required=True)
+
+        parser.add_argument('--datacatalog-location-id',
+                            help='ID of the Location to be used by Google Data'
+                            ' Catalog to store the metadata',
+                            default=cls.__DEFAULT_DATACATALOG_LOCATION_ID)
+
+        parser.set_defaults(func=cls.__sync_catalog)
+
+    @classmethod
+    def __sync_catalog(cls, args):
+        synchronizer = sync.MetadataSynchronizer(
             sisense_server_address=args.sisense_server,
             sisense_username=args.sisense_username,
             sisense_password=args.sisense_password,
             datacatalog_project_id=args.datacatalog_project_id,
-            datacatalog_location_id=cls.__DEFAULT_DATACATALOG_LOCATION_ID).run(
-            )
+            datacatalog_location_id=cls.__DEFAULT_DATACATALOG_LOCATION_ID)
+        synchronizer.run()
+
+
+class _FindElastiCubeDepsCliHelper:
+
+    @classmethod
+    def add_parser(cls, subparsers):
+        parser = subparsers.add_parser(
+            'find-elasticube-deps',
+            help='Find ElastiCube dependencies through catalog search')
+
+        parser.add_argument('--datasource',
+                            help='An ElastiCube Data Source name')
+
+        parser.add_argument('--table', help='An ElastiCube Table name')
+
+        parser.add_argument('--column', help='An ElastiCube Column name')
+
+        parser.add_argument('--datacatalog-project-id',
+                            help='ID of the Google Cloud Project in which the'
+                            ' catalog search will be scoped',
+                            required=True)
+
+        parser.set_defaults(func=cls.__find_elasticube_deps)
+
+    @classmethod
+    def __find_elasticube_deps(cls, args):
+        try:
+            dependencies = addons.ElastiCubeDependencyFinder(
+                args.datacatalog_project_id).find(args.datasource, args.table,
+                                                  args.column)
+
+            addons.ElastiCubeDependencyPrinter()\
+                .print_dependency_finder_results(dependencies)
+        except Exception as e:
+            raise SystemExit(e)
 
 
 def main():

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/__init__.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_finder_test.py
@@ -16,12 +16,12 @@
 
 import unittest
 from unittest import mock
-from typing import Tuple
 
 from google.cloud import datacatalog
-from google.cloud.datacatalog import Entry, SearchCatalogResult, Tag
 
 from google.datacatalog_connectors.sisense import addons
+
+from . import elasticube_dependency_mocks as mocks
 
 
 class ElastiCubeDependencyFinderTest(unittest.TestCase):
@@ -48,15 +48,15 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         mock_make_query.return_value = fake_query
 
         self.__datacatalog_facade.search_catalog.return_value = [
-            self.__make_fake_search_result('table-entry')
+            mocks.make_fake_search_result('table-entry')
         ]
 
-        fake_entry = self.__make_fake_entry('table-entry')
+        fake_entry = mocks.make_fake_entry('table-entry')
         mock_get_entries.return_value = {
             'fake_entries/table-entry': fake_entry
         }
 
-        fake_tag = self.__make_fake_tag()
+        fake_tag = mocks.make_fake_tag()
         mock_list_tags.return_value = {'fake_entries/table-entry': [fake_tag]}
 
         mock_filter_relevant_tags.return_value = [fake_tag]
@@ -204,7 +204,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual('tag:column:"test-column"', query)
 
     def test_get_entries_should_return_dict(self):
-        fake_entry = self.__make_fake_entry('some-entry')
+        fake_entry = mocks.make_fake_entry('some-entry')
         self.__datacatalog_facade.get_entry.return_value = fake_entry
 
         entries = self.__finder._ElastiCubeDependencyFinder__get_entries(
@@ -217,7 +217,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
             'fake_entries/some-entry')
 
     def test_list_tags_should_return_dict(self):
-        fake_tag = self.__make_fake_tag()
+        fake_tag = mocks.make_fake_tag()
         self.__datacatalog_facade.list_tags.return_value = [fake_tag]
 
         tags = self.__finder._ElastiCubeDependencyFinder__list_tags(
@@ -237,9 +237,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
             self, mock_filter_asset_metadata_tag,
             mock_filter_table_column_matching_tags, mock_sort_tags_by_schema):
 
-        fake_entry = self.__make_fake_entry('some-entry')
-        fake_asset_metadata_tag = self.__make_fake_tag()
-        fake_table_matching_tag = self.__make_fake_tag()
+        fake_entry = mocks.make_fake_entry('some-entry')
+        fake_asset_metadata_tag = mocks.make_fake_tag()
+        fake_table_matching_tag = mocks.make_fake_tag()
 
         mock_filter_asset_metadata_tag.return_value = fake_asset_metadata_tag
         mock_filter_table_column_matching_tags.return_value = [
@@ -266,9 +266,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
     def test_filter_asset_metadata_tag_should_return_dashboard_metadata_tag(
             self):
 
-        fake_jaql_related_tag = self.__make_fake_tag(
+        fake_jaql_related_tag = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_jaql_metadata')
-        fake_dashboard_metadata_tag = self.__make_fake_tag(
+        fake_dashboard_metadata_tag = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_dashboard_metadata')
 
         tag = self.__finder.filter_asset_metadata_tag(
@@ -277,9 +277,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_dashboard_metadata_tag, tag)
 
     def test_filter_asset_metadata_tag_should_return_widget_metadata_tag(self):
-        fake_jaql_related_tag = self.__make_fake_tag(
+        fake_jaql_related_tag = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_jaql_metadata')
-        fake_widget_metadata_tag = self.__make_fake_tag(
+        fake_widget_metadata_tag = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_widget_metadata')
 
         tag = self.__finder.filter_asset_metadata_tag(
@@ -294,8 +294,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
             self, mock_filter_table_matching_tags,
             mock_filter_column_matching_tags):
 
-        fake_table_matching_tag = self.__make_fake_tag()
-        fake_non_matching_tag = self.__make_fake_tag()
+        fake_table_matching_tag = mocks.make_fake_tag()
+        fake_non_matching_tag = mocks.make_fake_tag()
 
         mock_filter_table_matching_tags.return_value = [
             fake_table_matching_tag
@@ -319,8 +319,8 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
     def test_filter_table_column_matching_tags_should_return_matching_column(
             self, mock_filter_column_matching_tags):
 
-        fake_non_matching_tag = self.__make_fake_tag()
-        fake_column_matching_tag = self.__make_fake_tag()
+        fake_non_matching_tag = mocks.make_fake_tag()
+        fake_column_matching_tag = mocks.make_fake_tag()
 
         mock_filter_column_matching_tags.return_value = [
             fake_column_matching_tag
@@ -344,9 +344,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
             self, mock_filter_table_matching_tags,
             mock_filter_column_matching_tags):
 
-        fake_table_only_matching_tag = self.__make_fake_tag()
-        fake_column_only_matching_tag = self.__make_fake_tag()
-        fake_table_column_matching_tag = self.__make_fake_tag()
+        fake_table_only_matching_tag = mocks.make_fake_tag()
+        fake_column_only_matching_tag = mocks.make_fake_tag()
+        fake_table_column_matching_tag = mocks.make_fake_tag()
 
         mock_filter_table_matching_tags.return_value = [
             fake_table_only_matching_tag, fake_table_column_matching_tag
@@ -373,11 +373,11 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
 
     def test_filter_jaql_tags_should_return_only_jaql_tags(self):
 
-        fake_jaql_related_tag_1 = self.__make_fake_tag(
+        fake_jaql_related_tag_1 = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_jaql_metadata')
-        fake_widget_metadata_tag = self.__make_fake_tag(
+        fake_widget_metadata_tag = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_widget_metadata')
-        fake_jaql_related_tag_2 = self.__make_fake_tag(
+        fake_jaql_related_tag_2 = mocks.make_fake_tag(
             template='test/tagTemplates/sisense_jaql_metadata')
 
         tags = self.__finder.filter_jaql_tags([
@@ -390,7 +390,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_jaql_related_tag_2, tags[1])
 
     def test_filter_table_matching_tags_should_none_if_no_table_name(self):
-        fake_table_related_tag = self.__make_fake_tag(
+        fake_table_related_tag = mocks.make_fake_tag(
             string_fields=(('table', 'test-table'),))
 
         tags = self.__finder \
@@ -400,9 +400,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(0, len(tags))
 
     def test_filter_table_matching_tags_should_return_only_matching_tags(self):
-        fake_non_matching_tag = self.__make_fake_tag(
+        fake_non_matching_tag = mocks.make_fake_tag(
             string_fields=(('column', 'test-column'),))
-        fake_table_matching_tag = self.__make_fake_tag(
+        fake_table_matching_tag = mocks.make_fake_tag(
             string_fields=(('table', 'test-table'),))
 
         tags = self.__finder \
@@ -414,7 +414,7 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_table_matching_tag, tags[0])
 
     def test_filter_column_matching_tags_should_none_if_no_column_name(self):
-        fake_column_related_tag = self.__make_fake_tag(
+        fake_column_related_tag = mocks.make_fake_tag(
             string_fields=(('column', 'test-column'),))
 
         tags = self.__finder \
@@ -426,9 +426,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
     def test_filter_column_matching_tags_should_return_only_matching_tags(
             self):
 
-        fake_non_matching_tag = self.__make_fake_tag(
+        fake_non_matching_tag = mocks.make_fake_tag(
             string_fields=(('table', 'test-table'),))
-        fake_column_matching_tag = self.__make_fake_tag(
+        fake_column_matching_tag = mocks.make_fake_tag(
             string_fields=(('column', 'test-column'),))
 
         tags = self.__finder \
@@ -463,9 +463,9 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         schema = datacatalog.Schema()
         schema.columns.append(fields_column)
 
-        fake_column_level_tag_1 = self.__make_fake_tag(column='fields.field1')
-        fake_column_level_tag_2 = self.__make_fake_tag(column='fields.field2')
-        fake_column_level_tag_3 = self.__make_fake_tag(
+        fake_column_level_tag_1 = mocks.make_fake_tag(column='fields.field1')
+        fake_column_level_tag_2 = mocks.make_fake_tag(column='fields.field2')
+        fake_column_level_tag_3 = mocks.make_fake_tag(
             column='fields.field2.subfields.subfield1')
 
         tags = self.__finder \
@@ -481,36 +481,3 @@ class ElastiCubeDependencyFinderTest(unittest.TestCase):
         self.assertEqual(fake_column_level_tag_1, tags[0])
         self.assertEqual(fake_column_level_tag_2, tags[1])
         self.assertEqual(fake_column_level_tag_3, tags[2])
-
-    @classmethod
-    def __make_fake_search_result(cls, entry_id: str) -> SearchCatalogResult:
-        result = datacatalog.SearchCatalogResult()
-        result.relative_resource_name = f'fake_entries/{entry_id}'
-        return result
-
-    @classmethod
-    def __make_fake_entry(cls, entry_id: str) -> Entry:
-        entry = datacatalog.Entry()
-        entry.name = f'fake_entries/{entry_id}'
-        entry.schema = datacatalog.Schema()
-        return entry
-
-    @classmethod
-    def __make_fake_tag(cls,
-                        template: str = 'template',
-                        column: str = None,
-                        string_fields: Tuple[Tuple[str, str]] = None) -> Tag:
-
-        tag = datacatalog.Tag()
-        tag.template = template
-
-        if column:
-            tag.column = column
-
-        if string_fields:
-            for string_field in string_fields:
-                tag_field = datacatalog.TagField()
-                tag_field.string_value = string_field[1]
-                tag.fields[string_field[0]] = tag_field
-
-        return tag

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_mocks.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_mocks.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional, Tuple
+
+from google.cloud import datacatalog
+from google.cloud.datacatalog import Entry, SearchCatalogResult, Tag
+
+
+def make_fake_search_result(entry_id: str) -> SearchCatalogResult:
+    result = datacatalog.SearchCatalogResult()
+    result.relative_resource_name = f'fake_entries/{entry_id}'
+    return result
+
+
+def make_fake_entry(entry_id: str) -> Entry:
+    entry = datacatalog.Entry()
+    entry.name = f'fake_entries/{entry_id}'
+    entry.schema = datacatalog.Schema()
+    return entry
+
+
+def make_fake_tag(template: Optional[str] = 'template',
+                  column: Optional[str] = None,
+                  string_fields: List[Tuple[str, str]] = None) -> Tag:
+
+    tag = datacatalog.Tag()
+    tag.template = template
+
+    if column:
+        tag.column = column
+
+    if string_fields:
+        for string_field in string_fields:
+            tag_field = datacatalog.TagField()
+            tag_field.string_value = string_field[1]
+            tag.fields[string_field[0]] = tag_field
+
+    return tag

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/addons/elasticube_dependency_printer_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.cloud import datacatalog
+
+from google.datacatalog_connectors.sisense import addons
+
+from . import elasticube_dependency_mocks as mocks
+
+
+class ElastiCubeDependencyPrinterTest(unittest.TestCase):
+    __ADDONS_PACKAGE = 'google.datacatalog_connectors.sisense.addons'
+    __PRINTER_MODULE = f'{__ADDONS_PACKAGE}.elasticube_dependency_printer'
+    __PRINTER_CLASS = f'{__PRINTER_MODULE}.ElastiCubeDependencyPrinter'
+    __PRIVATE_METHOD_PREFIX = f'{__PRINTER_CLASS}._ElastiCubeDependencyPrinter'
+
+    @mock.patch(f'{__PRINTER_MODULE}.addons'
+                f'.ElastiCubeDependencyFinder.filter_jaql_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_asset_metadata_value')
+    def test_print_dependency_finder_results_should_skip_if_no_results(
+            self, mock_get_asset_metadata_value, mock_filter_jaql_tags):
+
+        addons.ElastiCubeDependencyPrinter.print_dependency_finder_results({})
+
+        mock_get_asset_metadata_value.assert_not_called()
+        mock_filter_jaql_tags.assert_not_called()
+
+    @mock.patch(f'{__PRINTER_MODULE}.addons.ElastiCubeDependencyFinder'
+                f'.filter_jaql_tags', lambda *args: [])
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_asset_metadata_value')
+    def test_print_dependency_finder_results_should_get_asset_metadata_values(
+            self, mock_get_asset_metadata_value):
+
+        fake_find_results = {'entries/test-entry': (datacatalog.Entry(), [])}
+
+        addons.ElastiCubeDependencyPrinter.print_dependency_finder_results(
+            fake_find_results)
+
+        mock_get_asset_metadata_value.assert_has_calls(
+            [mock.call([], 'dashboard_title'),
+             mock.call([], 'datasource')])
+
+    @mock.patch(f'{__PRINTER_MODULE}.addons'
+                f'.ElastiCubeDependencyFinder.filter_jaql_tags')
+    @mock.patch(f'{__PRIVATE_METHOD_PREFIX}__get_asset_metadata_value',
+                lambda *args: None)
+    def test_print_dependency_finder_results_should_filter_jaql_tags(
+            self, mock_filter_jaql_tags):
+
+        fake_tag = mocks.make_fake_tag(
+            string_fields=[('table', 'test-table'), ('column', 'test-column')])
+
+        # Just to improve code coverage. The Below return value does not impact
+        # test results but causes the script to print Tag's data.
+        mock_filter_jaql_tags.return_value = [fake_tag]
+
+        fake_find_results = {
+            'entries/test-entry': (datacatalog.Entry(), [fake_tag])
+        }
+
+        addons.ElastiCubeDependencyPrinter.print_dependency_finder_results(
+            fake_find_results)
+
+        mock_filter_jaql_tags.assert_called_once_with([fake_tag])
+
+    @mock.patch(f'{__PRINTER_MODULE}.addons'
+                f'.ElastiCubeDependencyFinder.filter_asset_metadata_tag')
+    def test_get_asset_metadata_value_should_return_value_if_available(
+            self, mock_filter_asset_metadata_tag):
+
+        fake_tag = mocks.make_fake_tag(string_fields=[('datasource',
+                                                       'test-datasource')])
+
+        mock_filter_asset_metadata_tag.return_value = fake_tag
+
+        value = addons.ElastiCubeDependencyPrinter\
+            ._ElastiCubeDependencyPrinter__get_asset_metadata_value(
+                [fake_tag], 'datasource')
+
+        self.assertEqual('test-datasource', value)
+
+        mock_filter_asset_metadata_tag.assert_called_once_with([fake_tag])
+
+    @mock.patch(f'{__PRINTER_MODULE}.addons'
+                f'.ElastiCubeDependencyFinder.filter_asset_metadata_tag')
+    def test_get_asset_metadata_value_should_return_none_if_not_available(
+            self, mock_filter_asset_metadata_tag):
+
+        fake_tag = mocks.make_fake_tag(string_fields=[('field', 'test-field')])
+
+        mock_filter_asset_metadata_tag.return_value = fake_tag
+
+        value = addons.ElastiCubeDependencyPrinter\
+            ._ElastiCubeDependencyPrinter__get_asset_metadata_value(
+                [fake_tag], 'datasource')
+
+        self.assertIsNone(value)
+
+        mock_filter_asset_metadata_tag.assert_called_once_with([fake_tag])

--- a/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sisense2datacatalog_cli_test.py
+++ b/google-datacatalog-sisense-connector/tests/google/datacatalog_connectors/sisense/sisense2datacatalog_cli_test.py
@@ -59,8 +59,8 @@ class Sisense2DataCatalogCliTest(unittest.TestCase):
                 'test-password'
             ])
 
-    @mock.patch(
-        'google.datacatalog_connectors.sisense.sync.MetadataSynchronizer')
+    @mock.patch('google.datacatalog_connectors.sisense.sisense2datacatalog_cli'
+                '.sync.MetadataSynchronizer')
     def test_sync_catalog_should_use_synchronizer(self,
                                                   mock_metadata_synchonizer):
 
@@ -88,10 +88,10 @@ class Sisense2DataCatalogCliTest(unittest.TestCase):
                 '--table', 'test-table', '--column', 'test-column'
             ])
 
-    @mock.patch('google.datacatalog_connectors.sisense.addons'
-                '.ElastiCubeDependencyPrinter')
-    @mock.patch('google.datacatalog_connectors.sisense.addons'
-                '.ElastiCubeDependencyFinder')
+    @mock.patch('google.datacatalog_connectors.sisense.sisense2datacatalog_cli'
+                '.addons.ElastiCubeDependencyPrinter')
+    @mock.patch('google.datacatalog_connectors.sisense.sisense2datacatalog_cli'
+                '.addons.ElastiCubeDependencyFinder')
     def test_find_elasticube_deps_should_find_and_print_dependencies(
             self, mock_deps_finder, mock_deps_printer):
 
@@ -103,15 +103,14 @@ class Sisense2DataCatalogCliTest(unittest.TestCase):
 
         mock_deps_finder.assert_called_once_with('dc-project-id')
 
-        printer = mock_deps_finder.return_value
-        printer.find.assert_called_once_with('test-datasource', 'test-table',
-                                             'test-column')
+        finder = mock_deps_finder.return_value
+        finder.find.assert_called_once_with('test-datasource', 'test-table',
+                                            'test-column')
 
-        printer = mock_deps_printer.return_value
-        printer.print_dependency_finder_results.assert_called_once()
+        mock_deps_printer.print_dependency_finder_results.assert_called_once()
 
-    @mock.patch('google.datacatalog_connectors.sisense.addons'
-                '.ElastiCubeDependencyFinder')
+    @mock.patch('google.datacatalog_connectors.sisense.sisense2datacatalog_cli'
+                '.addons.ElastiCubeDependencyFinder')
     def test_find_elasticube_deps_should_exit_on_exception(
             self, mock_deps_finder):
 


### PR DESCRIPTION
**- What I did**
Enhanced Sisense2DataCatalog's CLI by adding the `find-elasticube-deps` option. The original catalog synchronization CLI tool is now under the `sync-catalog` option.

**- How I did it**
1. Refactored and improved `sisense.Sisense2DataCatalogCli` arg parsers. Two helper classes were created, `_SyncCatalogCliHelper` and `_FindElastiCubeDepsCliHelper`, each one setting up a specific CLI tool.
2. Added `addons.ElastiCubeDependencyPrinter` in order to print dependency finding results in a user-friendly fashion.
3. Added unit tests that fully cover the above code changes.
4. Update `README.md` by adding instructions on how to use the CLI.

**- How to verify it**
Run the unit tests and, if possible, the connector in an integrated environment.
For the new `find-elasticube-deps` option, the output should be similar to:

```txt
INFO:root:
INFO:root:===> Searching Data Catalog...
INFO:root:Query: system=Sisense (type=Dashboard OR type=Widget)  tag:table:"admissions" tag:column:"Admission_Time"
INFO:root:==== DONE ========================================
INFO:root:
INFO:root:Catalog search returned 10 results
INFO:root:
INFO:root:===> Getting entries...
INFO:root:==== DONE ========================================
INFO:root:
INFO:root:===> Listing tags...
INFO:root:==== DONE ========================================
INFO:root:
INFO:root:===> Assembling results...
INFO:root:==== DONE ========================================

Results:

1
Entry       : projects/__REDACTED__/locations/us/entryGroups/sisense/entries/sss__REDACTED__
Type        : Widget
Title       : TOP 10 DIAGNOSIS
Dashboard   : Sample - Medical
Data source : Sample Healthcare
URL         : https://__REDACTED__.sisense.com/app/main#/dashboards/__REDACTED__/widgets/__REDACTED__

Matching fields and filters:

  Component : fields.avg days admitted.formula.days in admission  time
  Table     : Admissions
  Column    : Admission_Time (Calendar)
--------------------------------------------------
...
```

**- Description for the changelog**
Enhanced Sisense2DataCatalog's CLI by adding the `find-elasticube-deps` option.

This PR is part of the effort to deliver #70.