### PR TITLE
Reorganize badges in the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BI data sources.
 **Disclaimer: This is not an officially supported Google product.**
 
 [![License](https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE)
-[![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)
+![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)
 [![Issues](https://img.shields.io/github/issues/googlecloudplatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues)
 
 ## **Breaking Changes in v0.5.0**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ BI data sources.
 
 **Disclaimer: This is not an officially supported Google product.**
 
-![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)
+[![License](https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE)
+[![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)
+[![Issues](https://img.shields.io/github/issues/googlecloudplatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues)
 
 ## **Breaking Changes in v0.5.0**
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BI data sources.
 **Disclaimer: This is not an officially supported Google product.**
 
 [![License](https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE)
-![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master)
+[![Python package](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/actions/workflows/pythonpackage.yml/badge.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/actions/workflows/pythonpackage.yml)
 [![Issues](https://img.shields.io/github/issues/googlecloudplatform/datacatalog-connectors-bi.svg)](https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues)
 
 ## **Breaking Changes in v0.5.0**

--- a/google-datacatalog-looker-connector/README.md
+++ b/google-datacatalog-looker-connector/README.md
@@ -216,7 +216,7 @@ The connector may fail during the scrape stage if the Looker APIs do not return
 metadata in the expected format. The code base uses the `init31` looker_sdk client.
 As a reference, the below versions were already validated:
 
-| VERSION             | RESULT  |
+| VERSION             | PASSED? |
 | ------------------- | :-----: |
 | [Looker API 3.1][7] | &check; |
 

--- a/google-datacatalog-looker-connector/README.md
+++ b/google-datacatalog-looker-connector/README.md
@@ -2,13 +2,14 @@
 
 Package for ingesting Looker metadata into Google Cloud Data Catalog, currently
 supporting below asset types:
+
 - Folder
 - Look
 - Dashboard
 - Dashboard Element (aka Tile)
 - Query
 
-[![Python package][4]][4] [![PyPi][5]][6] [![License][7]][7] [![Issues][8]][9]
+[![License][1]][2] [![PyPi][3]][4]
 
 **Disclaimer: This is not an officially supported Google product.**
 
@@ -28,7 +29,7 @@ supporting below asset types:
   * [1.2. Windows](#12-windows)
   * [1.3. Install from source](#13-install-from-source)
     + [1.3.1. Get the code](#131-get-the-code)
-    + [1.3.2. Create and activate a *virtualenv*](#132-create-and-activate-a-virtualenv)
+    + [1.3.2. Create and activate a _virtualenv_](#132-create-and-activate-a-virtualenv)
     + [1.3.3. Install the library](#133-install-the-library)
 - [2. Environment setup](#2-environment-setup)
   * [2.1. Auth credentials](#21-auth-credentials)
@@ -51,22 +52,21 @@ supporting below asset types:
 
 <!-- tocstop -->
 
------
+---
 
 ## 1. Installation
 
-Install this library in a [virtualenv][3] using pip. [virtualenv][3] is a tool
+Install this library in a [virtualenv][5] using pip. [virtualenv][5] is a tool
 to create isolated Python environments. The basic problem it addresses is one
 of dependencies and versions, and indirectly permissions.
 
-With [virtualenv][3], it's possible to install this library without needing
+With [virtualenv][5], it's possible to install this library without needing
 system install permissions, and without clashing with the installed system
 dependencies. Make sure you use Python `3.7`.
 
-
 ### 1.1. Mac/Linux
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.7 <your-env>
 source <your-env>/bin/activate
@@ -75,7 +75,7 @@ source <your-env>/bin/activate
 
 ### 1.2. Windows
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.7 <your-env>
 <your-env>\Scripts\activate
@@ -86,14 +86,14 @@ virtualenv --python python3.7 <your-env>
 
 #### 1.3.1. Get the code
 
-````shell script
+```sh
 git clone https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/
 cd datacatalog-connectors-bi/google-datacatalog-looker-connector
-````
+```
 
-#### 1.3.2. Create and activate a *virtualenv*
+#### 1.3.2. Create and activate a _virtualenv_
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.7 <your-env>
 source <your-env>/bin/activate
@@ -101,7 +101,7 @@ source <your-env>/bin/activate
 
 #### 1.3.3. Install the library
 
-```shell script
+```sh
 pip install .
 ```
 
@@ -114,6 +114,7 @@ pip install .
 - Data Catalog Admin
 
 #### 2.1.2. Download a JSON key and save it as
+
 - `<YOUR-CREDENTIALS_FILES_FOLDER>/looker2dc-datacatalog-credentials.json`
 
 > Please notice this folder and file will be required in next steps.
@@ -129,14 +130,14 @@ https://<YOUR-LOOKER-ENDPOINT>/admin/users/api3_key/<YOUR-USER-ID>
 
 #### 2.1.4. Create a Looker configuration file
 
-File content is described in [Looker SDK documentation][1]. Save the file as
+File content is described in [Looker SDK documentation][6]. Save the file as
 `<YOUR-CREDENTIALS_FILES_FOLDER>/looker2dc-looker-credentials.ini`
 
 > Please notice this folder and file will be required in next steps.
 
 ### 2.2. Set environment variables
 
-```shell script
+```sh
 export GOOGLE_APPLICATION_CREDENTIALS=datacatalog_credentials_file
 ```
 
@@ -150,7 +151,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=datacatalog_credentials_file
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-looker-connector \
   --datacatalog-project-id <YOUR-DATACATALOG-PROJECT-ID> \
   --looker-credentials-file looker_credentials_ini_file
@@ -161,10 +162,10 @@ google-datacatalog-looker-connector \
 
 ### 3.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag looker2datacatalog .
 docker run --rm --tty -v <YOUR-CREDENTIALS_FILES_FOLDER>:/data \
-  looker2datacatalog \ 
+  looker2datacatalog \
   --datacatalog-project-id <YOUR-DATACATALOG-PROJECT-ID> \
   --looker-credentials-file /data/looker2dc-looker-credentials.ini
 ```
@@ -173,7 +174,7 @@ docker run --rm --tty -v <YOUR-CREDENTIALS_FILES_FOLDER>:/data \
 
 ### 4.1. Install and run Yapf formatter
 
-```shell script
+```sh
 pip install --upgrade yapf
 
 # Auto update files
@@ -191,14 +192,14 @@ mv pre-commit.sh .git/hooks/pre-commit
 
 ### 4.2. Install and run Flake8 linter
 
-```shell script
+```sh
 pip install --upgrade flake8
 flake8 src tests
 ```
 
 ### 4.3. Run Tests
 
-```shell script
+```sh
 python setup.py test
 ```
 
@@ -212,37 +213,34 @@ documentation](docs/developer-resources).
 ### 5.1. Looker APIs compatibility
 
 The connector may fail during the scrape stage if the Looker APIs do not return
-metadata in the expected format. The code base uses the `init31` looker_sdk client.  
+metadata in the expected format. The code base uses the `init31` looker_sdk client.
 As a reference, the below versions were already validated:
 
-| VERSION                 | RESULT  |
-| ----------------------- | :-----: |
-| [Looker API 3.1][10]    | SUCCESS |
-
+| VERSION             | RESULT  |
+| ------------------- | :-----: |
+| [Looker API 3.1][7] | &check; |
 
 ### 5.2. Data Catalog quota
 
 In the case a connector execution hits Data Catalog quota limit, an error will
 be raised and logged with the following detailment, depending on the performed
-operation READ/WRITE/SEARCH: 
+operation READ/WRITE/SEARCH:
 
-```
+```text
 status = StatusCode.RESOURCE_EXHAUSTED
-details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'."
-debug_error_string = 
-"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
+details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'."
+debug_error_string =
+"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'.","grpc_status":8}"
 ```
 
 For more information on Data Catalog quota, please refer to: [Data Catalog
-quota docs][2].
+quota docs][8].
 
-[1]: https://github.com/looker-open-source/sdk-codegen/blob/master/looker-sample.ini
-[2]: https://cloud.google.com/data-catalog/docs/resources/quotas
-[3]: https://virtualenv.pypa.io/en/latest/
-[4]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master
-[5]: https://img.shields.io/pypi/v/google-datacatalog-looker-connector.svg
-[6]: https://pypi.org/project/google-datacatalog-looker-connector/
-[7]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
-[8]: https://img.shields.io/github/issues/GoogleCloudPlatform/datacatalog-connectors-bi.svg
-[9]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues
-[10]: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
+[1]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
+[2]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE
+[3]: https://img.shields.io/pypi/v/google-datacatalog-looker-connector.svg
+[4]: https://pypi.org/project/google-datacatalog-looker-connector/
+[5]: https://virtualenv.pypa.io/en/latest/
+[6]: https://github.com/looker-open-source/sdk-codegen/blob/master/looker-sample.ini
+[7]: https://docs.looker.com/reference/api-and-integration/api-reference/v3.1
+[8]: https://cloud.google.com/data-catalog/docs/resources/quotas

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -239,7 +239,7 @@ In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed
 operation (READ/WRITE/SEARCH):
 
-```
+```text
 status = StatusCode.RESOURCE_EXHAUSTED
 details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'."
 debug_error_string =

--- a/google-datacatalog-qlik-connector/README.md
+++ b/google-datacatalog-qlik-connector/README.md
@@ -2,13 +2,16 @@
 
 Package for ingesting Qlik Sense metadata into Google Cloud Data Catalog,
 currently supporting below asset types:
+
 - Custom Property Definition
 - Stream
 - App (only the published ones)
-- Master Items: Dimension  
+- Master Items: Dimension
 - Master Items: Measure
 - Master Items: Visualization
 - Sheet (only the published ones)
+
+[![License][1]][2] [![PyPi][3]][4]
 
 **Disclaimer: This is not an officially supported Google product.**
 
@@ -28,7 +31,7 @@ currently supporting below asset types:
   * [1.2. Windows](#12-windows)
   * [1.3. Install from source](#13-install-from-source)
     + [1.3.1. Get the code](#131-get-the-code)
-    + [1.3.2. Create and activate a *virtualenv*](#132-create-and-activate-a-virtualenv)
+    + [1.3.2. Create and activate a _virtualenv_](#132-create-and-activate-a-virtualenv)
     + [1.3.3. Install the library](#133-install-the-library)
 - [2. Environment setup](#2-environment-setup)
   * [2.1. Auth credentials](#21-auth-credentials)
@@ -53,18 +56,17 @@ currently supporting below asset types:
 
 ## 1. Installation
 
-Install this library in a [virtualenv][1] using pip. [virtualenv][1] is a tool
+Install this library in a [virtualenv][5] using pip. [virtualenv][5] is a tool
 to create isolated Python environments. The basic problem it addresses is one
 of dependencies and versions, and indirectly permissions.
 
-With [virtualenv][1], it's possible to install this library without needing
+With [virtualenv][5], it's possible to install this library without needing
 system install permissions, and without clashing with the installed system
 dependencies. Make sure you use Python 3.6+.
 
-
 ### 1.1. Mac/Linux
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
@@ -73,7 +75,7 @@ source <your-env>/bin/activate
 
 ### 1.2. Windows
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 <your-env>\Scripts\activate
@@ -84,14 +86,14 @@ virtualenv --python python3.6 <your-env>
 
 #### 1.3.1. Get the code
 
-````shell script
+```sh
 git clone https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/
 cd datacatalog-connectors-bi/google-datacatalog-qlik-connector
-````
+```
 
-#### 1.3.2. Create and activate a *virtualenv*
+#### 1.3.2. Create and activate a _virtualenv_
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
@@ -99,7 +101,7 @@ source <your-env>/bin/activate
 
 #### 1.3.3. Install the library
 
-```shell script
+```sh
 pip install .
 ```
 
@@ -112,6 +114,7 @@ pip install .
 - Data Catalog Admin
 
 #### 2.1.2. Download a JSON key and save it as
+
 - `<YOUR-CREDENTIALS_FILES_FOLDER>/qlik2dc-datacatalog-credentials.json`
 
 > Please notice this folder and file will be required in next steps.
@@ -124,7 +127,7 @@ fulfilling the below environment variables, set `QLIK2DC_QLIK_AD_DOMAIN` with
 the Windows Active Directory domain your user belongs to and
 `QLIK2DC_QLIK_USERNAME` with the username (no backslash in both).
 
-```shell script
+```sh
 export GOOGLE_APPLICATION_CREDENTIALS=datacatalog_credentials_file
 
 export QLIK2DC_QLIK_SERVER=qlik_server
@@ -148,7 +151,7 @@ export QLIK2DC_DATACATALOG_LOCATION_ID=google_cloud_location_id
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-qlik-connector \
   --qlik-server $QLIK2DC_QLIK_SERVER \
   [--qlik-ad-domain $QLIK2DC_QLIK_AD_DOMAIN \]
@@ -160,7 +163,7 @@ google-datacatalog-qlik-connector \
 
 ### 3.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag qlik2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   qlik2datacatalog \
@@ -176,7 +179,7 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
 
 ### 4.1. Install and run the YAPF formatter
 
-```shell script
+```sh
 pip install --upgrade yapf
 
 # Auto update files
@@ -194,14 +197,14 @@ mv pre-commit.sh .git/hooks/pre-commit
 
 ### 4.2. Install and run the Flake8 linter
 
-```shell script
+```sh
 pip install --upgrade flake8
 flake8 src tests
 ```
 
 ### 4.3. Run Tests
 
-```shell script
+```sh
 python setup.py test
 ```
 
@@ -220,31 +223,35 @@ already validated:
 
 - Qlik Sense Repository Service API
 
-| VERSION                 | RESULT  |
+| VERSION                 | PASSED? |
 | ----------------------- | :-----: |
-| 34.16.0 (September2020) | SUCCESS |
+| 34.16.0 (September2020) | &check; |
 
 - Qlik Engine JSON API
 
-| VERSION                  | RESULT  |
+| VERSION                  | PASSED? |
 | ------------------------ | :-----: |
-| 12.763.4 (September2020) | SUCCESS |
+| 12.763.4 (September2020) | &check; |
 
 ### 5.2. Data Catalog quota
 
 In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed
-operation (READ/WRITE/SEARCH): 
+operation (READ/WRITE/SEARCH):
 
 ```
 status = StatusCode.RESOURCE_EXHAUSTED
-details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'."
-debug_error_string = 
-"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
+details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'."
+debug_error_string =
+"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'.","grpc_status":8}"
 ```
 
 For more information on Data Catalog quota, please refer to the [product
-documentation][2].
+documentation][6].
 
-[1]: https://virtualenv.pypa.io/en/latest/
-[2]: https://cloud.google.com/data-catalog/docs/resources/quotas
+[1]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
+[2]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE
+[3]: https://img.shields.io/pypi/v/google-datacatalog-qlik-connector.svg
+[4]: https://pypi.org/project/google-datacatalog-qlik-connector/
+[5]: https://virtualenv.pypa.io/en/latest/
+[6]: https://cloud.google.com/data-catalog/docs/resources/quotas

--- a/google-datacatalog-sisense-connector/README.md
+++ b/google-datacatalog-sisense-connector/README.md
@@ -2,6 +2,7 @@
 
 Package for ingesting [Sisense](https://www.sisense.com) metadata into Google
 Cloud Data Catalog, currently supporting the below assets:
+
 - Folder
 - Dashboard
 - Widget
@@ -10,14 +11,15 @@ This sample connector creates Data Catalog tags to enable a data lineage
 mechanism that allows users to search the catalog to find where/which
 ElastiCube Table fields are used in Widgets or Dashboards. To do so, it
 currently processes JAQL query metadata from:
+
 - Dashboard filters
 - Widgets fields and filters
 - Nested [formulas](https://sisense.dev/reference/jaql/#formulas)
 - Nested `filter.by` properties, used by [top/bottom filters](https://sisense.dev/reference/jaql/#top-bottom-filters)
 
-**Disclaimer: This is not an officially supported Google product.**
+[![License][1]][2] [![PyPi][3]][4]
 
-> This connector is a work in progress!
+**Disclaimer: This is not an officially supported Google product.**
 
 <!--
   ⚠️ DO NOT UPDATE THE TABLE OF CONTENTS MANUALLY ️️⚠️
@@ -35,7 +37,7 @@ currently processes JAQL query metadata from:
   * [1.2. Windows](#12-windows)
   * [1.3. Install from source](#13-install-from-source)
     + [1.3.1. Get the code](#131-get-the-code)
-    + [1.3.2. Create and activate a *virtualenv*](#132-create-and-activate-a-virtualenv)
+    + [1.3.2. Create and activate a _virtualenv_](#132-create-and-activate-a-virtualenv)
     + [1.3.3. Install the library](#133-install-the-library)
 - [2. Environment setup](#2-environment-setup)
   * [2.1. Auth credentials](#21-auth-credentials)
@@ -68,17 +70,17 @@ currently processes JAQL query metadata from:
 
 ## 1. Installation
 
-Install this library in a [virtualenv][1] using pip. [Virtualenv][1] is a tool
+Install this library in a [virtualenv][5] using pip. [Virtualenv][5] is a tool
 to create isolated Python environments. The basic problem it addresses is one
 of dependencies and versions, and indirectly permissions.
 
-With [virtualenv][1], it's possible to install this library without needing
+With [virtualenv][5], it's possible to install this library without needing
 system install permissions, and without clashing with the installed system
 dependencies. Make sure you use Python 3.6+.
 
 ### 1.1. Mac/Linux
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
@@ -87,7 +89,7 @@ source <your-env>/bin/activate
 
 ### 1.2. Windows
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 <your-env>\Scripts\activate
@@ -98,14 +100,14 @@ virtualenv --python python3.6 <your-env>
 
 #### 1.3.1. Get the code
 
-````shell script
+```sh
 git clone https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/
 cd datacatalog-connectors-bi/google-datacatalog-sisense-connector
-````
+```
 
-#### 1.3.2. Create and activate a *virtualenv*
+#### 1.3.2. Create and activate a _virtualenv_
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
@@ -113,7 +115,7 @@ source <your-env>/bin/activate
 
 #### 1.3.3. Install the library
 
-```shell script
+```sh
 pip install .
 ```
 
@@ -126,6 +128,7 @@ pip install .
 - Data Catalog Admin
 
 #### 2.1.2. Download a JSON key and save it as
+
 - `<YOUR-CREDENTIALS_FILES_FOLDER>/sisense2dc-datacatalog-credentials.json`
 
 > Please notice this folder and file will be required in next steps.
@@ -134,7 +137,7 @@ pip install .
 
 Replace below values according to your environment:
 
-```shell script
+```sh
 export GOOGLE_APPLICATION_CREDENTIALS=datacatalog_credentials_file
 
 export SISENSE2DC_SISENSE_SERVER=sisense_server
@@ -160,7 +163,7 @@ Synchronizes Google Data Catalog with a given Sisense server.
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-sisense-connector sync-catalog \
   --sisense-server $SISENSE2DC_SISENSE_SERVER \
   --sisense-username $SISENSE2DC_SISENSE_USERNAME \
@@ -171,7 +174,7 @@ google-datacatalog-sisense-connector sync-catalog \
 
 #### 3.1.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag sisense2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   sisense2datacatalog sync-catalog \
@@ -191,7 +194,7 @@ console.
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-sisense-connector find-elasticube-deps \
   --datasource <datasource> \
   --table <table> \
@@ -201,7 +204,7 @@ google-datacatalog-sisense-connector find-elasticube-deps \
 
 #### 3.2.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag sisense2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   sisense2datacatalog find-elasticube-deps \
@@ -220,7 +223,7 @@ prints them in the console.
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-sisense-connector list-elasticube-deps \
   --asset-url <asset-url> \
   --datacatalog-project-id $SISENSE2DC_DATACATALOG_PROJECT_ID
@@ -228,7 +231,7 @@ google-datacatalog-sisense-connector list-elasticube-deps \
 
 #### 3.3.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag sisense2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   sisense2datacatalog list-elasticube-deps \
@@ -240,7 +243,7 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
 
 ### 4.1. Install and run the YAPF formatter
 
-```shell script
+```sh
 pip install --upgrade yapf
 
 # Auto update files
@@ -258,14 +261,14 @@ mv pre-commit.sh .git/hooks/pre-commit
 
 ### 4.2. Install and run the Flake8 linter
 
-```shell script
+```sh
 pip install --upgrade flake8
 flake8 src tests
 ```
 
 ### 4.3. Run Tests
 
-```shell script
+```sh
 python setup.py test
 ```
 
@@ -302,25 +305,29 @@ already validated:
 
 - Sisense REST API v1.0
 
-| VERSION       | RESULT  |
+| VERSION       | PASSED? |
 | ------------- | :-----: |
-| Windows 8.2.5 | SUCCESS |
+| Windows 8.2.5 | &check; |
 
 ### 6.2. Data Catalog quota
 
 In case a connector execution hits Data Catalog quota limit, an error will be
 raised and logged with the following details, depending on the performed
-operation (READ/WRITE/SEARCH): 
+operation (READ/WRITE/SEARCH):
 
-```
+```text
 status = StatusCode.RESOURCE_EXHAUSTED
-details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'."
-debug_error_string = 
-"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
+details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'."
+debug_error_string =
+"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'.","grpc_status":8}"
 ```
 
 For more information on Data Catalog quota, please refer to the [product
-documentation][2].
+documentation][6].
 
-[1]: https://virtualenv.pypa.io/en/latest/
-[2]: https://cloud.google.com/data-catalog/docs/resources/quotas
+[1]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
+[2]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE
+[3]: https://img.shields.io/pypi/v/google-datacatalog-sisense-connector.svg
+[4]: https://pypi.org/project/google-datacatalog-sisense-connector/
+[5]: https://virtualenv.pypa.io/en/latest/
+[6]: https://cloud.google.com/data-catalog/docs/resources/quotas

--- a/google-datacatalog-tableau-connector/README.md
+++ b/google-datacatalog-tableau-connector/README.md
@@ -2,11 +2,12 @@
 
 Package for ingesting Tableau metadata into Google Cloud Data Catalog,
 currently supporting below asset types:
+
 - Workbook
 - Sheet
 - Dashboard
 
-[![Python package][3]][3] [![PyPi][4]][5] [![License][6]][6] [![Issues][7]][8]
+[![License][1]][2] [![PyPi][3]][4]
 
 **Disclaimer: This is not an officially supported Google product.**
 
@@ -26,7 +27,7 @@ currently supporting below asset types:
   * [1.2. Windows](#12-windows)
   * [1.3. Install from source](#13-install-from-source)
     + [1.3.1. Get the code](#131-get-the-code)
-    + [1.3.2. Create and activate a *virtualenv*](#132-create-and-activate-a-virtualenv)
+    + [1.3.2. Create and activate a _virtualenv_](#132-create-and-activate-a-virtualenv)
     + [1.3.3. Install the library](#133-install-the-library)
 - [2. Environment setup](#2-environment-setup)
   * [2.1. Auth credentials](#21-auth-credentials)
@@ -46,22 +47,21 @@ currently supporting below asset types:
 
 <!-- tocstop -->
 
------
+---
 
 ## 1. Installation
 
-Install this library in a [virtualenv][2] using pip. [virtualenv][2] is a tool
+Install this library in a [virtualenv][5] using pip. [virtualenv][5] is a tool
 to create isolated Python environments. The basic problem it addresses is one
 of dependencies and versions, and indirectly permissions.
 
-With [virtualenv][2], it's possible to install this library without needing
+With [virtualenv][5], it's possible to install this library without needing
 system install permissions, and without clashing with the installed system
 dependencies. Make sure you use Python `3.6+`.
 
-
 ### 1.1. Mac/Linux
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
@@ -70,7 +70,7 @@ source <your-env>/bin/activate
 
 ### 1.2. Windows
 
-```shell script
+```sh
 pip3 install virtualenv
 virtualenv --python python3.6 <your-env>
 <your-env>\Scripts\activate
@@ -81,22 +81,22 @@ virtualenv --python python3.6 <your-env>
 
 #### 1.3.1. Get the code
 
-````shell script
+```sh
 git clone https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/
 cd datacatalog-connectors-bi/google-datacatalog-tableau-connector
-````
+```
 
-#### 1.3.2. Create and activate a *virtualenv*
+#### 1.3.2. Create and activate a _virtualenv_
 
-```shell script
+```sh
 pip3 install virtualenv
-virtualenv --python python3.6 <your-env> 
+virtualenv --python python3.6 <your-env>
 source <your-env>/bin/activate
 ```
 
 #### 1.3.3. Install the library
 
-```shell script
+```sh
 pip install .
 ```
 
@@ -109,6 +109,7 @@ pip install .
 - Data Catalog Admin
 
 #### 2.1.2. Download a JSON key and save it as
+
 - `<YOUR-CREDENTIALS_FILES_FOLDER>/tableau2dc-datacatalog-credentials.json`
 
 > Please notice this folder and file will be required in next steps.
@@ -117,7 +118,7 @@ pip install .
 
 Replace below values according to your environment:
 
-```shell script
+```sh
 export GOOGLE_APPLICATION_CREDENTIALS=data_catalog_credentials_file
 
 export TABLEAU2DC_TABLEAU_SERVER=tableau_server
@@ -138,7 +139,7 @@ export TABLEAU2DC_DATACATALOG_PROJECT_ID=google_cloud_project_id
 
 - Virtualenv
 
-```shell script
+```sh
 google-datacatalog-tableau-connector \
   --tableau-server $TABLEAU2DC_TABLEAU_SERVER \
   --tableau-api-version $TABLEAU2DC_TABLEAU_API_VERSION \
@@ -150,11 +151,11 @@ google-datacatalog-tableau-connector \
 
 ### 3.2. Docker entry point
 
-```shell script
+```sh
 docker build --rm --tag tableau2datacatalog .
 docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   tableau2datacatalog \
-  --tableau-server $TABLEAU2DC_TABLEAU_SERVER \ 
+  --tableau-server $TABLEAU2DC_TABLEAU_SERVER \
   --tableau-api-version $TABLEAU2DC_TABLEAU_API_VERSION \
   --tableau-username $TABLEAU2DC_TABLEAU_USERNAME \
   --tableau-password $TABLEAU2DC_TABLEAU_PASSWORD \
@@ -162,7 +163,7 @@ docker run --rm --tty -v YOUR-CREDENTIALS_FILES_FOLDER:/data \
   --datacatalog-project-id $TABLEAU2DC_DATACATALOG_PROJECT_ID
 ```
 
-## 4. Tableau resources for development and demonstration purposes 
+## 4. Tableau resources for development and demonstration purposes
 
 Please refer to the [Developer Resources / Tableau
 documentation](docs/developer-resources/tableau.md).
@@ -171,7 +172,7 @@ documentation](docs/developer-resources/tableau.md).
 
 ### 5.1. Install and run Yapf formatter
 
-```shell script
+```sh
 pip install --upgrade yapf
 
 # Auto update files
@@ -189,14 +190,14 @@ mv pre-commit.sh .git/hooks/pre-commit
 
 ### 6.2. Install and run Flake8 linter
 
-```shell script
+```sh
 pip install --upgrade flake8
 flake8 src tests
 ```
 
 ### 6.3. Run Tests
 
-```shell script
+```sh
 python setup.py test
 ```
 
@@ -209,23 +210,21 @@ documentation](docs/developer-resources).
 
 In the case a connector execution hits Data Catalog quota limit, an error will
 be raised and logged with the following detailment, depending on the performed
-operation READ/WRITE/SEARCH: 
+operation READ/WRITE/SEARCH:
 
 ```
 status = StatusCode.RESOURCE_EXHAUSTED
-details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'."
-debug_error_string = 
-"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:1111111111111'.","grpc_status":8}"
+details = "Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'."
+debug_error_string =
+"{"created":"@1587396969.506556000", "description":"Error received from peer ipv4:172.217.29.42:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"Quota exceeded for quota metric 'Read requests' and limit 'Read requests per minute' of service 'datacatalog.googleapis.com' for consumer 'project_number:___REDACTED___'.","grpc_status":8}"
 ```
 
 For more information on Data Catalog quota, please refer to: [Data Catalog
-quota docs][1]
+quota docs][6]
 
-[1]: https://cloud.google.com/data-catalog/docs/resources/quotas
-[2]: https://virtualenv.pypa.io/en/latest/
-[3]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/workflows/Python%20package/badge.svg?branch=master
-[4]: https://img.shields.io/pypi/v/google-datacatalog-tableau-connector.svg
-[5]: https://pypi.org/project/google-datacatalog-tableau-connector/
-[6]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
-[7]: https://img.shields.io/github/issues/GoogleCloudPlatform/datacatalog-connectors-bi.svg
-[8]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/issues
+[1]: https://img.shields.io/github/license/GoogleCloudPlatform/datacatalog-connectors-bi.svg
+[2]: https://github.com/GoogleCloudPlatform/datacatalog-connectors-bi/blob/master/LICENSE
+[3]: https://img.shields.io/pypi/v/google-datacatalog-tableau-connector.svg
+[4]: https://pypi.org/project/google-datacatalog-tableau-connector/
+[5]: https://virtualenv.pypa.io/en/latest/
+[6]: https://cloud.google.com/data-catalog/docs/resources/quotas

--- a/google-datacatalog-tableau-connector/README_HOOK.md
+++ b/google-datacatalog-tableau-connector/README_HOOK.md
@@ -6,7 +6,7 @@ Handler for Tableau web hook events.
 
 ### 1.1. Set environment variables
 
-```bash
+```sh
 export TABLEAU2DC_TABLEAU_SERVER=tableau_server
 export TABLEAU2DC_TABLEAU_API_VERSION=tableau_api_version
 export TABLEAU2DC_TABLEAU_USERNAME=tableau_username
@@ -20,6 +20,6 @@ export TABLEAU2DC_API_KEY=your-made-up-api-key
 
 ### 1.2. Run deploy
 
-```bash
+```sh
 ./deploy.sh
 ```


### PR DESCRIPTION
**- What I did**
Reorganized the badges in the main README files. The changes consist of:
1. The `license` badge is displayed in the repo and all connectors' main README files because it is general info.
2. The `Python package` badge is displayed only in the repo's main README because the CI workflow tests all connectors at once.
3. The `issues` badge is displayed only in the repo's main README because the link and counter refer to the repo and not to any specific connector.
4. The `pypi` badge is displayed in all connectors' main README files because it allows us to distinguish the link and version of each connector.

**- How to verify it**
Browse the README files in the base branch.

**- Description for the changelog**
Reorganized the badges in the README files.
