### PR TITLE
Set up Python 3.6 compatible 'tomli' versions

### DIFF
--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -44,7 +44,10 @@ setuptools.setup(
         'websockets ~= 8.1',
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov',),
+    tests_require=(
+        'pytest-cov',
+        'tomli ~= 1.2.2',
+    ),
     classifiers=[
         release_status,
         'Natural Language :: English',

--- a/google-datacatalog-sisense-connector/setup.py
+++ b/google-datacatalog-sisense-connector/setup.py
@@ -42,7 +42,10 @@ setuptools.setup(
         'tabulate ~= 0.8.9',
     ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov',),
+    tests_require=(
+        'pytest-cov',
+        'tomli ~= 1.2.2',
+    ),
     classifiers=[
         release_status,
         'Natural Language :: English',

--- a/google-datacatalog-tableau-connector/setup.py
+++ b/google-datacatalog-tableau-connector/setup.py
@@ -37,10 +37,15 @@ setuptools.setup(
         ],
     },
     include_package_data=True,
-    install_requires=('requests',
-                      'google-datacatalog-connectors-commons >= 0.6.0'),
+    install_requires=(
+        'google-datacatalog-connectors-commons ~= 0.6.0',
+        'requests',
+    ),
     setup_requires=('pytest-runner',),
-    tests_require=('pytest-cov',),
+    tests_require=(
+        'pytest-cov',
+        'tomli ~= 1.2.2',
+    ),
     classifiers=[
         release_status,
         'Natural Language :: English',


### PR DESCRIPTION
**- What I did**
Set up a Python 3.6 compatible version range for the `tomli` library, required by `pytest`.

**- How I did it**
Added `'tomli ~= 1.2.2'` to `setup.py`'s `tests_require` section. Only the Looker connector is not compatible with Python 3.6.

**- How to verify it**
Run the Qlik, Sisense, and Tableau unit tests using Python 3.6.

**- Description for the changelog**
Set up a Python 3.6 compatible version range for the `tomli` library, required by `pytest`.
