### PR TITLE
Added encoding = 'utf-8' while opening the Readme file

### DIFF
--- a/google-datacatalog-qlik-connector/setup.py
+++ b/google-datacatalog-qlik-connector/setup.py
@@ -18,7 +18,7 @@ import setuptools
 
 release_status = 'Development Status :: 4 - Beta'
 
-with open('README.md') as readme_file:
+with open('README.md', encoding = 'utf-8') as readme_file:
     readme = readme_file.read()
 
 setuptools.setup(


### PR DESCRIPTION
On Windows platform, it gives UnicodeDecodeError (as below) if we do not specify the encoding in Setup.py

UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 472: character maps to <undefined>

So, I added the encoding to make it work.
